### PR TITLE
[Slash] Add governanceAdmin in initializing contract

### DIFF
--- a/contracts/interfaces/ISlashIndicator.sol
+++ b/contracts/interfaces/ISlashIndicator.sol
@@ -17,6 +17,8 @@ interface ISlashIndicator {
   event SlashDoubleSignAmountUpdated(uint256 slashDoubleSignAmount);
   /// @dev Emiited when the duration of jailing felony updated
   event FelonyJailDurationUpdated(uint256 felonyJailDuration);
+  /// @dev Emitted when the address of governance admin is updated.
+  event GovernanceAdminUpdated(address);
 
   enum SlashType {
     UNKNOWN,
@@ -105,6 +107,17 @@ interface ISlashIndicator {
    *
    */
   function setFelonyJailDuration(uint256 _felonyJailDuration) external;
+
+  /**
+   * @dev Updates the governance admin
+   *
+   * Requirements:
+   * - The method caller is the governance admin
+   *
+   * Emits the event `GovernanceAdminUpdated`
+   *
+   */
+  function setGovernanceAdmin(address _governanceAdmin) external;
 
   /**
    * @dev Gets slash indicator of a validator

--- a/contracts/mocks/MockSlashIndicator.sol
+++ b/contracts/mocks/MockSlashIndicator.sol
@@ -52,6 +52,8 @@ contract MockSlashIndicator is ISlashIndicator {
 
   function governanceAdmin() external view override returns (address) {}
 
+  function setGovernanceAdmin(address __newAddr) external override {}
+
   function setSlashFelonyAmount(uint256 _slashFelonyAmount) external override {}
 
   function setSlashDoubleSignAmount(uint256 _slashDoubleSignAmount) external override {}

--- a/contracts/slashing/SlashIndicator.sol
+++ b/contracts/slashing/SlashIndicator.sol
@@ -61,15 +61,16 @@ contract SlashIndicator is ISlashIndicator, Initializable {
    * @dev Initializes the contract storage.
    */
   function initialize(
+    address __governanceAdmin,
+    IRoninValidatorSet _validatorSetContract,
     uint256 _misdemeanorThreshold,
     uint256 _felonyThreshold,
-    IRoninValidatorSet _validatorSetContract,
     uint256 _slashFelonyAmount,
     uint256 _slashDoubleSignAmount,
     uint256 _felonyJailBlocks
   ) external initializer {
     validatorContract = _validatorSetContract;
-
+    _setGovernanceAdmin(__governanceAdmin);
     _setSlashThresholds(_felonyThreshold, _misdemeanorThreshold);
     _setSlashFelonyAmount(_slashFelonyAmount);
     _setSlashDoubleSignAmount(_slashDoubleSignAmount);
@@ -141,6 +142,13 @@ contract SlashIndicator is ISlashIndicator, Initializable {
   /**
    * @inheritdoc ISlashIndicator
    */
+  function setGovernanceAdmin(address __governanceAdmin) external override onlyGovernanceAdmin {
+    _setGovernanceAdmin(__governanceAdmin);
+  }
+
+  /**
+   * @inheritdoc ISlashIndicator
+   */
   function setSlashThresholds(uint256 _felonyThreshold, uint256 _misdemeanorThreshold)
     external
     override
@@ -198,6 +206,20 @@ contract SlashIndicator is ISlashIndicator, Initializable {
   ///////////////////////////////////////////////////////////////////////////////////////
   //                                 HELPER FUNCTIONS                                  //
   ///////////////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev Updates the address of governance admin
+   */
+  function _setGovernanceAdmin(address __governanceAdmin) internal {
+    if (__governanceAdmin == _governanceAdmin) {
+      return;
+    }
+
+    require(__governanceAdmin != address(0), "SlashIndicator: Cannot set admin to zero address");
+
+    _governanceAdmin == __governanceAdmin;
+    emit GovernanceAdminUpdated(__governanceAdmin);
+  }
 
   /**
    * @dev Sets the slash thresholds

--- a/src/deploy/proxy/slash-indicator-proxy.ts
+++ b/src/deploy/proxy/slash-indicator-proxy.ts
@@ -11,9 +11,10 @@ const deploy = async ({ getNamedAccounts, deployments }: HardhatRuntimeEnvironme
   const logicContract = await deployments.get('SlashIndicatorLogic');
 
   const data = new SlashIndicator__factory().interface.encodeFunctionData('initialize', [
+    initAddress[network.name]!.governanceAdmin,
+    initAddress[network.name]!.validatorContract,
     slashIndicatorConf[network.name]!.misdemeanorThreshold,
     slashIndicatorConf[network.name]!.felonyThreshold,
-    initAddress[network.name]!.validatorContract,
     slashIndicatorConf[network.name]!.slashFelonyAmount,
     slashIndicatorConf[network.name]!.slashDoubleSignAmount,
     slashIndicatorConf[network.name]!.felonyJailBlocks,

--- a/test/integration/ActionSlashValidators.test.ts
+++ b/test/integration/ActionSlashValidators.test.ts
@@ -76,9 +76,10 @@ describe('[Integration] Slash validators', () => {
       slashLogicContract.address,
       proxyAdmin.address,
       slashLogicContract.interface.encodeFunctionData('initialize', [
+        governanceAdmin.address,
+        roninValidatorSetAddr,
         slashIndicatorConf[network.name]!.misdemeanorThreshold,
         slashIndicatorConf[network.name]!.felonyThreshold,
-        roninValidatorSetAddr,
         slashIndicatorConf[network.name]!.slashFelonyAmount,
         slashIndicatorConf[network.name]!.slashDoubleSignAmount,
         slashIndicatorConf[network.name]!.felonyJailBlocks,

--- a/test/integration/ActionSubmitReward.test.ts
+++ b/test/integration/ActionSubmitReward.test.ts
@@ -75,9 +75,10 @@ describe('[Integration] Submit Block Reward', () => {
       slashLogicContract.address,
       proxyAdmin.address,
       slashLogicContract.interface.encodeFunctionData('initialize', [
+        governanceAdmin.address,
+        roninValidatorSetAddr,
         slashIndicatorConf[network.name]!.misdemeanorThreshold,
         slashIndicatorConf[network.name]!.felonyThreshold,
-        roninValidatorSetAddr,
         slashIndicatorConf[network.name]!.slashFelonyAmount,
         slashIndicatorConf[network.name]!.slashDoubleSignAmount,
         slashIndicatorConf[network.name]!.felonyJailBlocks,

--- a/test/integration/ActionWrapUpEpoch.test.ts
+++ b/test/integration/ActionWrapUpEpoch.test.ts
@@ -76,9 +76,10 @@ describe('[Integration] Wrap up epoch', () => {
       slashLogicContract.address,
       proxyAdmin.address,
       slashLogicContract.interface.encodeFunctionData('initialize', [
+        governanceAdmin.address,
+        roninValidatorSetAddr,
         slashIndicatorConf[network.name]!.misdemeanorThreshold,
         slashIndicatorConf[network.name]!.felonyThreshold,
-        roninValidatorSetAddr,
         slashIndicatorConf[network.name]!.slashFelonyAmount,
         slashIndicatorConf[network.name]!.slashDoubleSignAmount,
         slashIndicatorConf[network.name]!.felonyJailBlocks,

--- a/test/slash/SlashIndicator.test.ts
+++ b/test/slash/SlashIndicator.test.ts
@@ -12,7 +12,7 @@ import {
 import { Address } from 'hardhat-deploy/dist/types';
 import { SlashType } from './slashType';
 import { Network, slashIndicatorConf } from '../../src/config';
-import { BigNumber } from 'ethers';
+import { BigNumber, Signer } from 'ethers';
 import { expects as SlashExpects } from '../helpers/slash-indicator';
 
 let slashContract: SlashIndicator;
@@ -21,6 +21,7 @@ let deployer: SignerWithAddress;
 let proxyAdmin: SignerWithAddress;
 let mockValidatorsContract: MockValidatorSetForSlash;
 let vagabond: SignerWithAddress;
+let governanceAdmin: SignerWithAddress;
 let coinbases: SignerWithAddress[];
 let defaultCoinbase: Address;
 let localIndicators: number[];
@@ -55,7 +56,7 @@ describe('Slash indicator test', () => {
   let misdemeanorThreshold: number;
 
   before(async () => {
-    [deployer, proxyAdmin, vagabond, ...coinbases] = await ethers.getSigners();
+    [deployer, proxyAdmin, vagabond, governanceAdmin, ...coinbases] = await ethers.getSigners();
     localIndicators = Array<number>(coinbases.length).fill(0);
     defaultCoinbase = await network.provider.send('eth_coinbase');
 
@@ -75,9 +76,10 @@ describe('Slash indicator test', () => {
       logicContract.address,
       proxyAdmin.address,
       logicContract.interface.encodeFunctionData('initialize', [
+        governanceAdmin.address,
+        mockValidatorsContract.address,
         slashIndicatorConf[network.name]!.misdemeanorThreshold,
         slashIndicatorConf[network.name]!.felonyThreshold,
-        mockValidatorsContract.address,
         slashIndicatorConf[network.name]!.slashFelonyAmount,
         slashIndicatorConf[network.name]!.slashDoubleSignAmount,
         slashIndicatorConf[network.name]!.felonyJailBlocks,


### PR DESCRIPTION
### Description
**Changes to Slashing contract**
- Add `governanceAdmin` in `initializing` function of contract
- Add setter/getter for `governanceAdmin`

### Checklist
- [x] I have clearly commented on all the main functions followed the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
