### PR TITLE
[RewardCalculation] Store period number instead of block number

### DIFF
--- a/contracts/interfaces/IRewardPool.sol
+++ b/contracts/interfaces/IRewardPool.sol
@@ -19,8 +19,8 @@ interface IRewardPool {
     uint256 debited;
     // The amount rewards that user have already earned.
     uint256 credited;
-    // Last block number that the info updated.
-    uint256 lastSyncedBlock;
+    // Last period number that the info updated.
+    uint256 lastSyncedPeriod;
   }
 
   struct SettledRewardFields {
@@ -36,8 +36,8 @@ interface IRewardPool {
   }
 
   struct SettledPool {
-    // Last block number that the info updated.
-    uint256 lastSyncedBlock;
+    // Last period number that the info updated.
+    uint256 lastSyncedPeriod;
     // Accumulated of the amount rewards per share (one unit staking).
     uint256 accumulatedRps;
   }


### PR DESCRIPTION
### Description
- Store period number instead of block number

### Checklist
- [x] I have clearly commented on all the main functions followed the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
