### PR TITLE
[RoninValidatorSet] Add started at block

### DIFF
--- a/contracts/interfaces/IRoninValidatorSet.sol
+++ b/contracts/interfaces/IRoninValidatorSet.sol
@@ -75,6 +75,7 @@ interface IRoninValidatorSet is ICandidateManager {
    *
    * Requirements:
    * - The method caller is coinbase.
+   * - The method must be called after the started block `startedAtBlock()`.
    *
    * Emits the event `MiningRewardDeprecated` if the coinbase is slashed or no longer be a block producer.
    * Emits the event `BlockRewardSubmitted` for the valid call.
@@ -89,6 +90,7 @@ interface IRoninValidatorSet is ICandidateManager {
    * - The method must be called when the current epoch is ending.
    * - The epoch is not wrapped yet.
    * - The method caller is coinbase.
+   * - The method must be called after the started block `startedAtBlock()`.
    *
    * Emits the event `MiningRewardDistributed` when some validator has reward distributed.
    * Emits the event `StakingRewardDistributed` when some staking pool has reward distributed.
@@ -145,6 +147,11 @@ interface IRoninValidatorSet is ICandidateManager {
   ///////////////////////////////////////////////////////////////////////////////////////
   //                             FUNCTIONS FOR NORMAL USER                             //
   ///////////////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev Returns the block that the contract allows incoming mutable calls.
+   */
+  function startedAtBlock() external view returns (uint256);
 
   /**
    * @dev Returns the maximum number of validators in the epoch

--- a/contracts/mocks/MockValidatorSet.sol
+++ b/contracts/mocks/MockValidatorSet.sol
@@ -127,4 +127,6 @@ contract MockValidatorSet is IRoninValidatorSet, CandidateManager {
   function currentPeriod() public view override(CandidateManager, ICandidateManager) returns (uint256) {
     return block.timestamp / 86400;
   }
+
+  function startedAtBlock() external view override returns (uint256) {}
 }

--- a/src/deploy/proxy/ronin-validator-proxy.ts
+++ b/src/deploy/proxy/ronin-validator-proxy.ts
@@ -25,6 +25,7 @@ const deploy = async ({ getNamedAccounts, deployments }: HardhatRuntimeEnvironme
     roninValidatorSetConf[network.name]!.maxValidatorCandidate,
     roninValidatorSetConf[network.name]!.maxPrioritizedValidatorNumber,
     roninValidatorSetConf[network.name]!.numberOfBlocksInEpoch,
+    generalRoninConf[network.name]!.startedAtBlock,
   ]);
 
   const deployment = await deploy('RoninValidatorSetProxy', {


### PR DESCRIPTION
### Description
- Adds started at block in `RoninValidatorSet`
- Not allow the methods `wrapUpEpoch` and `submitBlockReward` to be called before the started block.

### Devnet config
- Started at block: 0

### Checklist
- [x] I have clearly commented on all the main functions followed the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
