### PR TITLE
Fix typo in pull request template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,6 +1,6 @@
 ### Description
 
 ### Checklist
-- [ ] I have clearly commented on all the main functions followed the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
+- [ ] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
 - [ ] The box that allows repo maintainers to update this PR is checked
 - [ ] I tested locally to make sure this feature/fix works


### PR DESCRIPTION
### Description
Typo fix `followed` -> `following`.

### Checklist
- [x] I have clearly commented on all the main functions followed the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
