### PR TITLE
[ValidatorSet] Expose/Unexpose config methods

### DIFF
--- a/contracts/interfaces/IRoninValidatorSet.sol
+++ b/contracts/interfaces/IRoninValidatorSet.sol
@@ -282,4 +282,15 @@ interface IRoninValidatorSet is ICandidateManager {
    *
    */
   function setMaxValidatorNumber(uint256 _maxValidatorNumber) external;
+
+  /**
+   * @dev Updates the number of reserved slots for prioritized validators
+   *
+   * Requirements:
+   * - The method caller is admin
+   *
+   * Emits the event `MaxPrioritizedValidatorNumberUpdated`
+   *
+   */
+  function setMaxPrioritizedValidatorNumber(uint256 _maxPrioritizedValidatorNumber) external;
 }

--- a/contracts/mocks/MockValidatorSet.sol
+++ b/contracts/mocks/MockValidatorSet.sol
@@ -66,6 +66,8 @@ contract MockValidatorSet is IRoninValidatorSet, CandidateManager {
 
   function setMaxValidatorNumber(uint256 _maxValidatorNumber) external override {}
 
+  function setMaxPrioritizedValidatorNumber(uint256 _maxPrioritizedValidatorNumber) external override {}
+
   function maxValidatorNumber() external view override returns (uint256 _maximumValidatorNumber) {}
 
   function maxPrioritizedValidatorNumber()

--- a/contracts/ronin/validator/RoninValidatorSet.sol
+++ b/contracts/ronin/validator/RoninValidatorSet.sol
@@ -126,7 +126,7 @@ contract RoninValidatorSet is
     _setRoninTrustedOrganizationContract(__roninTrustedOrganizationContract);
     _setMaxValidatorNumber(__maxValidatorNumber);
     _setMaxValidatorCandidate(__maxValidatorCandidate);
-    _setPrioritizedValidatorNumber(__maxPrioritizedValidatorNumber);
+    _setMaxPrioritizedValidatorNumber(__maxPrioritizedValidatorNumber);
     _setNumberOfBlocksInEpoch(__numberOfBlocksInEpoch);
   }
 
@@ -507,6 +507,13 @@ contract RoninValidatorSet is
     _setMaxValidatorNumber(_max);
   }
 
+  /**
+   * @inheritdoc IRoninValidatorSet
+   */
+  function setMaxPrioritizedValidatorNumber(uint256 _number) external override onlyAdmin {
+    _setMaxPrioritizedValidatorNumber(_number);
+  }
+
   ///////////////////////////////////////////////////////////////////////////////////////
   //                     PRIVATE HELPER FUNCTIONS OF WRAPPING UP EPOCH                 //
   ///////////////////////////////////////////////////////////////////////////////////////
@@ -814,10 +821,7 @@ contract RoninValidatorSet is
   }
 
   /**
-   * @dev Updates the max validator number
-   *
-   * Emits the event `MaxValidatorNumberUpdated`
-   *
+   * @dev See {IRoninValidatorSet-setMaxValidatorNumber}
    */
   function _setMaxValidatorNumber(uint256 _number) internal {
     _maxValidatorNumber = _number;
@@ -825,9 +829,9 @@ contract RoninValidatorSet is
   }
 
   /**
-   * @dev Updates the number of reserved slots for prioritized validators
+   * @dev See {IRoninValidatorSet-setMaxPrioritizedValidatorNumber}
    */
-  function _setPrioritizedValidatorNumber(uint256 _number) internal {
+  function _setMaxPrioritizedValidatorNumber(uint256 _number) internal {
     require(
       _number <= _maxValidatorNumber,
       "RoninValidatorSet: cannot set number of prioritized greater than number of max validators"
@@ -849,7 +853,7 @@ contract RoninValidatorSet is
   }
 
   /**
-   * @dev Returns whether the last period is ending when compared with the new period.
+   * @dev See {IRoninValidatorSet-isPeriodEnding}
    */
   function _isPeriodEnding(uint256 _newPeriod) public view virtual returns (bool) {
     return _newPeriod > _lastUpdatedPeriod;


### PR DESCRIPTION
### Description
1. Exposing methods as [comment](https://github.com/axieinfinity/ronin-dpos-contracts/issues/50#issue-1435586725) in #50.
2. Unexposing `setNumberOfBlocksInEpoch` method

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
