### PR TITLE
Update method `epochOf` & remove one-time-using function/event.

### DIFF
--- a/contracts/interfaces/IRoninValidatorSet.sol
+++ b/contracts/interfaces/IRoninValidatorSet.sol
@@ -15,8 +15,6 @@ interface IRoninValidatorSet is ICandidateManager {
   event MaxValidatorNumberUpdated(uint256);
   /// @dev Emitted when the number of reserved slots for prioritized validators is updated
   event MaxPrioritizedValidatorNumberUpdated(uint256);
-  /// @dev Emitted when the number of blocks in epoch is updated
-  event NumberOfBlocksInEpochUpdated(uint256);
   /// @dev Emitted when the validator set is updated
   event ValidatorSetUpdated(uint256 indexed period, address[] consensusAddrs);
   /// @dev Emitted when the bridge operator set is updated, to mirror the in-jail and maintaining status of the validator.

--- a/contracts/ronin/validator/RoninValidatorSet.sol
+++ b/contracts/ronin/validator/RoninValidatorSet.sol
@@ -130,7 +130,7 @@ contract RoninValidatorSet is
     _setMaxValidatorNumber(__maxValidatorNumber);
     _setMaxValidatorCandidate(__maxValidatorCandidate);
     _setMaxPrioritizedValidatorNumber(__maxPrioritizedValidatorNumber);
-    _setNumberOfBlocksInEpoch(__numberOfBlocksInEpoch);
+    _numberOfBlocksInEpoch = __numberOfBlocksInEpoch;
   }
 
   ///////////////////////////////////////////////////////////////////////////////////////
@@ -293,14 +293,14 @@ contract RoninValidatorSet is
       uint256 epochLeft_
     )
   {
-    uint256 __jailedUntil = _jailedUntil[_addr];
-    if (__jailedUntil < _blockNum) {
+    uint256 _jailedBlock = _jailedUntil[_addr];
+    if (_jailedBlock < _blockNum) {
       return (false, 0, 0);
     }
 
     isJailed_ = true;
-    blockLeft_ = __jailedUntil - _blockNum + 1;
-    epochLeft_ = epochOf(__jailedUntil) - epochOf(_blockNum) + 1;
+    blockLeft_ = _jailedBlock - _blockNum + 1;
+    epochLeft_ = epochOf(_jailedBlock) - epochOf(_blockNum) + 1;
   }
 
   /**
@@ -352,7 +352,7 @@ contract RoninValidatorSet is
    * @inheritdoc IRoninValidatorSet
    */
   function epochOf(uint256 _block) public view virtual override returns (uint256) {
-    return _block == 0 ? 0 : _block / _numberOfBlocksInEpoch + 1;
+    return _block / _numberOfBlocksInEpoch + 1;
   }
 
   /**
@@ -840,17 +840,6 @@ contract RoninValidatorSet is
 
     _maxPrioritizedValidatorNumber = _number;
     emit MaxPrioritizedValidatorNumberUpdated(_number);
-  }
-
-  /**
-   * @dev Updates the number of blocks in epoch
-   *
-   * Emits the event `NumberOfBlocksInEpochUpdated`
-   *
-   */
-  function _setNumberOfBlocksInEpoch(uint256 _number) internal {
-    _numberOfBlocksInEpoch = _number;
-    emit NumberOfBlocksInEpochUpdated(_number);
   }
 
   /**


### PR DESCRIPTION
### Description
- Fix #51: Update method `epochOf`
- Remove one-time-using function/event.
### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
