### PR TITLE
[ValidatortSet] Support withdrawing jailed reward

### DIFF
--- a/contracts/interfaces/validator/info-fragments/ICommonInfo.sol
+++ b/contracts/interfaces/validator/info-fragments/ICommonInfo.sol
@@ -6,4 +6,7 @@ import "./IJailingInfo.sol";
 import "./ITimingInfo.sol";
 import "./IValidatorInfo.sol";
 
-interface ICommonInfo is ITimingInfo, IJailingInfo, IValidatorInfo {}
+interface ICommonInfo is ITimingInfo, IJailingInfo, IValidatorInfo {
+  /// @dev Emitted when the deprecated reward is withdrawn.
+  event DeprecatedRewardWithdrawn(address indexed recipientAddr, uint256 amount);
+}

--- a/contracts/interfaces/validator/info-fragments/ICommonInfo.sol
+++ b/contracts/interfaces/validator/info-fragments/ICommonInfo.sol
@@ -9,4 +9,9 @@ import "./IValidatorInfo.sol";
 interface ICommonInfo is ITimingInfo, IJailingInfo, IValidatorInfo {
   /// @dev Emitted when the deprecated reward is withdrawn.
   event DeprecatedRewardWithdrawn(address indexed recipientAddr, uint256 amount);
+
+  /**
+   * @dev Returns the total deprecated reward, which includes reward that is not sent for slashed validators and unsastified bridge operators
+   */
+  function totalDeprecatedReward() external view returns (uint256);
 }

--- a/contracts/mocks/validator/MockValidatorSet.sol
+++ b/contracts/mocks/validator/MockValidatorSet.sol
@@ -134,4 +134,6 @@ contract MockValidatorSet is IRoninValidatorSet, CandidateManager {
       uint256 epochLeft_
     )
   {}
+
+  function totalDeprecatedReward() external view override returns (uint256) {}
 }

--- a/contracts/ronin/validator/CoinbaseExecution.sol
+++ b/contracts/ronin/validator/CoinbaseExecution.sol
@@ -197,9 +197,10 @@ abstract contract CoinbaseExecution is
   }
 
   /**
-   * @dev This loop over the all current validators to:
+   * @dev This loops over all current validators to:
    * - Update delegating reward for and calculate total delegating rewards to be sent to the staking contract,
-   * - Distribute the reward of block producers and bridge operators to their treasury addresses.
+   * - Distribute the reward of block producers and bridge operators to their treasury addresses,
+   * - Update the total deprecated reward if the two previous conditions do not sastify.
    *
    * Note: This method should be called once in the end of each period.
    *
@@ -217,12 +218,16 @@ abstract contract CoinbaseExecution is
 
       if (!_bridgeRewardDeprecated(_consensusAddr, _lastPeriod)) {
         _distributeBridgeOperatingReward(_consensusAddr, _candidateInfo[_consensusAddr].bridgeOperatorAddr, _treasury);
+      } else {
+        _totalDeprecatedReward += _bridgeOperatingReward[_consensusAddr];
       }
 
       if (!_jailed(_consensusAddr) && !_miningRewardDeprecated(_consensusAddr, _lastPeriod)) {
         _totalDelegatingReward += _delegatingReward[_consensusAddr];
         _delegatingRewards[_i] = _delegatingReward[_consensusAddr];
         _distributeMiningReward(_consensusAddr, _treasury);
+      } else {
+        _totalDeprecatedReward += _miningReward[_consensusAddr] + _delegatingReward[_consensusAddr];
       }
 
       delete _delegatingReward[_consensusAddr];

--- a/contracts/ronin/validator/RoninValidatorSet.sol
+++ b/contracts/ronin/validator/RoninValidatorSet.sol
@@ -47,6 +47,21 @@ contract RoninValidatorSet is Initializable, CoinbaseExecution, SlashingExecutio
     _numberOfBlocksInEpoch = __numberOfBlocksInEpoch;
   }
 
+  function withdrawDeprecatedReward() external onlyAdmin {
+    uint256 _withdrawAmount = _totalBridgeReward;
+    address _withdrawTarget = stakingVestingContract();
+
+    _totalBridgeReward = 0;
+
+    (bool _success, ) = _withdrawTarget.call{ value: _withdrawAmount }(
+      abi.encodeWithSelector(IStakingVesting.receiveRON.selector)
+    );
+
+    require(_success, "RoninValidatorSet: cannot withdraw deprecated reward to staking vesting contract");
+
+    emit DeprecatedRewardWithdrawn(_withdrawTarget, _withdrawAmount);
+  }
+
   /**
    * @dev Only receives RON from staking vesting contract.
    */

--- a/contracts/ronin/validator/RoninValidatorSet.sol
+++ b/contracts/ronin/validator/RoninValidatorSet.sol
@@ -47,17 +47,24 @@ contract RoninValidatorSet is Initializable, CoinbaseExecution, SlashingExecutio
     _numberOfBlocksInEpoch = __numberOfBlocksInEpoch;
   }
 
+  /**
+   * @dev Withdraw the deprecated rewards e.g. the rewards that get deprecated when validator is slashed, maintained.
+   * The withdraw target is the staking vesting contract.
+   *
+   * Requirement:
+   * - The method caller must be the admin
+   */
   function withdrawDeprecatedReward() external onlyAdmin {
-    uint256 _withdrawAmount = _totalBridgeReward;
+    uint256 _withdrawAmount = _totalDeprecatedReward;
     address _withdrawTarget = stakingVestingContract();
 
-    _totalBridgeReward = 0;
+    _totalDeprecatedReward = 0;
 
     (bool _success, ) = _withdrawTarget.call{ value: _withdrawAmount }(
       abi.encodeWithSelector(IStakingVesting.receiveRON.selector)
     );
 
-    require(_success, "RoninValidatorSet: cannot withdraw deprecated reward to staking vesting contract");
+    require(_success, "RoninValidatorSet: cannot transfer deprecated reward to staking vesting contract");
 
     emit DeprecatedRewardWithdrawn(_withdrawTarget, _withdrawAmount);
   }

--- a/contracts/ronin/validator/SlashingExecution.sol
+++ b/contracts/ronin/validator/SlashingExecution.sol
@@ -23,6 +23,9 @@ abstract contract SlashingExecution is
   ) external override onlySlashIndicatorContract {
     uint256 _period = currentPeriod();
     _miningRewardDeprecatedAtPeriod[_validatorAddr][_period] = true;
+
+    _totalDeprecatedReward += _miningReward[_validatorAddr] + _delegatingReward[_validatorAddr];
+
     delete _miningReward[_validatorAddr];
     delete _delegatingReward[_validatorAddr];
 

--- a/contracts/ronin/validator/storage-fragments/CommonStorage.sol
+++ b/contracts/ronin/validator/storage-fragments/CommonStorage.sol
@@ -28,6 +28,13 @@ abstract contract CommonStorage is ICommonInfo, TimingStorage, JailingStorage, V
   uint256[49] private ______gap;
 
   /**
+   * @inheritdoc ICommonInfo
+   */
+  function totalDeprecatedReward() external view override returns (uint256) {
+    return _totalDeprecatedReward;
+  }
+
+  /**
    * @inheritdoc ITimingInfo
    */
   function epochOf(uint256 _block)

--- a/contracts/ronin/validator/storage-fragments/CommonStorage.sol
+++ b/contracts/ronin/validator/storage-fragments/CommonStorage.sol
@@ -18,11 +18,14 @@ abstract contract CommonStorage is ICommonInfo, TimingStorage, JailingStorage, V
   /// @dev Mapping from consensus address => pending reward for being bridge operator
   mapping(address => uint256) internal _bridgeOperatingReward;
 
+  /// @dev The deprecated reward that has not been withdrawn by admin
+  uint256 internal _totalDeprecatedReward;
+
   /**
    * @dev This empty reserved space is put in place to allow future versions to add new
    * variables without shifting down storage in the inheritance chain.
    */
-  uint256[50] private ______gap;
+  uint256[49] private ______gap;
 
   /**
    * @inheritdoc ITimingInfo

--- a/test/helpers/ronin-validator-set.ts
+++ b/test/helpers/ronin-validator-set.ts
@@ -187,4 +187,21 @@ export const expects = {
       1
     );
   },
+
+  emitDeprecatedRewardWithdrawnEvent: async function (
+    tx: ContractTransaction,
+    expectingWithdrawnTarget: string,
+    expectingWithdrawnAmount: BigNumberish
+  ) {
+    await expectEvent(
+      contractInterface,
+      'DeprecatedRewardWithdrawn',
+      tx,
+      (event) => {
+        expect(event.args[0], 'invalid withdraw target').eq(expectingWithdrawnTarget);
+        expect(event.args[1], 'invalid withdraw amount').eql(expectingWithdrawnAmount);
+      },
+      1
+    );
+  },
 };


### PR DESCRIPTION
### Description

- Fix #78 
- Allow admin to withdraw deprecated reward from ValidatorSet contract to StakingVesting contract.

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
