### PR TITLE
Revamp function names and normalize comments

### DIFF
--- a/contracts/extensions/GatewayV2.sol
+++ b/contracts/extensions/GatewayV2.sol
@@ -19,21 +19,21 @@ abstract contract GatewayV2 is HasProxyAdmin, Pausable, IQuorum {
   uint256[50] private ______gap;
 
   /**
-   * @dev See {IQuorum-getThreshold}.
+   * @inheritdoc IQuorum
    */
   function getThreshold() external view virtual returns (uint256, uint256) {
     return (_num, _denom);
   }
 
   /**
-   * @dev See {IQuorum-checkThreshold}.
+   * @inheritdoc IQuorum
    */
   function checkThreshold(uint256 _voteWeight) external view virtual returns (bool) {
     return _voteWeight * _denom >= _num * _getTotalWeight();
   }
 
   /**
-   * @dev See {IQuorum-setThreshold}.
+   * @inheritdoc IQuorum
    */
   function setThreshold(uint256 _numerator, uint256 _denominator)
     external
@@ -59,7 +59,7 @@ abstract contract GatewayV2 is HasProxyAdmin, Pausable, IQuorum {
   }
 
   /**
-   * @dev See {IQuorum-minimumVoteWeight}.
+   * @inheritdoc IQuorum
    */
   function minimumVoteWeight() public view virtual returns (uint256) {
     return _minimumVoteWeight(_getTotalWeight());

--- a/contracts/extensions/GovernanceAdmin.sol
+++ b/contracts/extensions/GovernanceAdmin.sol
@@ -91,7 +91,7 @@ contract GovernanceAdmin is CoreGovernance, HasRoninTrustedOrganizationContract,
   }
 
   /**
-   * @dev Override {CoreGovernance-_getMinimumVoteWeight}.
+   * @dev Override `CoreGovernance-_getMinimumVoteWeight`.
    */
   function _getMinimumVoteWeight() internal view virtual override returns (uint256) {
     (bool _success, bytes memory _returndata) = roninTrustedOrganizationContract().staticcall(
@@ -106,7 +106,7 @@ contract GovernanceAdmin is CoreGovernance, HasRoninTrustedOrganizationContract,
   }
 
   /**
-   * @dev Override {CoreGovernance-_getTotalWeights}.
+   * @dev Override `CoreGovernance-_getTotalWeights`.
    */
   function _getTotalWeights() internal view virtual override returns (uint256) {
     (bool _success, bytes memory _returndata) = roninTrustedOrganizationContract().staticcall(

--- a/contracts/extensions/WithdrawalLimitation.sol
+++ b/contracts/extensions/WithdrawalLimitation.sol
@@ -47,7 +47,7 @@ abstract contract WithdrawalLimitation is GatewayV2 {
   uint256[50] private ______gap;
 
   /**
-   * @dev Override {GatewayV2-setThreshold}.
+   * @dev Override `GatewayV2-setThreshold`.
    *
    * Requirements:
    * - The high-tier vote weight threshold must equal to or larger than the normal threshold.

--- a/contracts/interfaces/IBridgeTracking.sol
+++ b/contracts/interfaces/IBridgeTracking.sol
@@ -21,7 +21,7 @@ interface IBridgeTracking {
   /**
    * @dev Returns the total number of ballots of bridge operators at the specific period `_period`.
    */
-  function bulkTotalBallotsOf(uint256 _period, address[] calldata _bridgeOperators)
+  function getManyTotalBallots(uint256 _period, address[] calldata _bridgeOperators)
     external
     view
     returns (uint256[] memory);

--- a/contracts/interfaces/IMaintenance.sol
+++ b/contracts/interfaces/IMaintenance.sol
@@ -59,14 +59,9 @@ interface IMaintenance {
   function getSchedule(address _consensusAddr) external view returns (Schedule memory);
 
   /**
-   * @dev Returns the min duration for maintenance in block.
+   * @dev Returns the total of current schedules.
    */
-  function minMaintenanceDurationInBlock() external view returns (uint256);
-
-  /**
-   * @dev Returns the max duration for maintenance in block.
-   */
-  function maxMaintenanceDurationInBlock() external view returns (uint256);
+  function totalSchedules() external view returns (uint256 _count);
 
   /**
    * @dev Sets the duration restriction, start time restriction, and max allowed for maintenance.
@@ -88,6 +83,16 @@ interface IMaintenance {
   ) external;
 
   /**
+   * @dev Returns the min duration for maintenance in block.
+   */
+  function minMaintenanceDurationInBlock() external view returns (uint256);
+
+  /**
+   * @dev Returns the max duration for maintenance in block.
+   */
+  function maxMaintenanceDurationInBlock() external view returns (uint256);
+
+  /**
    * @dev The offset to the min block number that the schedule can start
    */
   function minOffsetToStartSchedule() external view returns (uint256);
@@ -101,11 +106,6 @@ interface IMaintenance {
    * @dev Returns the max number of scheduled maintenances.
    */
   function maxSchedules() external view returns (uint256);
-
-  /**
-   * @dev Returns the total of current schedules.
-   */
-  function totalSchedules() external view returns (uint256 _count);
 
   /**
    * @dev Schedules for maintenance from `_startedAtBlock` to `_startedAtBlock`.

--- a/contracts/interfaces/IMaintenance.sol
+++ b/contracts/interfaces/IMaintenance.sol
@@ -37,7 +37,7 @@ interface IMaintenance {
   /**
    * @dev Returns the bool array indicating the validators maintained at block number `_block` or not.
    */
-  function bulkMaintaining(address[] calldata _addrList, uint256 _block) external view returns (bool[] memory);
+  function getManyMaintained(address[] calldata _addrList, uint256 _block) external view returns (bool[] memory);
 
   /**
    * @dev Returns a bool array indicating the validator was maintaining in the inclusive range [`_fromBlock`, `_toBlock`] of blocks or not.

--- a/contracts/interfaces/IMaintenance.sol
+++ b/contracts/interfaces/IMaintenance.sol
@@ -40,9 +40,9 @@ interface IMaintenance {
   function getManyMaintained(address[] calldata _addrList, uint256 _block) external view returns (bool[] memory);
 
   /**
-   * @dev Returns a bool array indicating the validator was maintaining in the inclusive range [`_fromBlock`, `_toBlock`] of blocks or not.
+   * @dev Returns a bool array indicating the validators maintained in the inclusive range [`_fromBlock`, `_toBlock`] of blocks or not.
    */
-  function bulkMaintainingInBlockRange(
+  function getManyMaintainedInBlockRange(
     address[] calldata _addrList,
     uint256 _fromBlock,
     uint256 _toBlock

--- a/contracts/interfaces/IMaintenance.sol
+++ b/contracts/interfaces/IMaintenance.sol
@@ -21,21 +21,21 @@ interface IMaintenance {
   );
 
   /**
-   * @dev Returns whether the validator `_consensusAddr` is maintaining at the block number `_block`.
+   * @dev Returns whether the validator `_consensusAddr` maintained at the block number `_block`.
    */
-  function maintaining(address _consensusAddr, uint256 _block) external view returns (bool);
+  function maintained(address _consensusAddr, uint256 _block) external view returns (bool);
 
   /**
-   * @dev Returns whether the validator `_consensusAddr` was maintaining in the inclusive range [`_fromBlock`, `_toBlock`] of blocks.
+   * @dev Returns whether the validator `_consensusAddr` maintained in the inclusive range [`_fromBlock`, `_toBlock`] of blocks.
    */
-  function maintainingInBlockRange(
+  function maintainedInBlockRange(
     address _consensusAddr,
     uint256 _fromBlock,
     uint256 _toBlock
   ) external view returns (bool);
 
   /**
-   * @dev Returns the bool array indicating the validator is maintaining or not.
+   * @dev Returns the bool array indicating the validators maintained at block number `_block` or not.
    */
   function bulkMaintaining(address[] calldata _addrList, uint256 _block) external view returns (bool[] memory);
 

--- a/contracts/interfaces/IMaintenance.sol
+++ b/contracts/interfaces/IMaintenance.sol
@@ -23,12 +23,12 @@ interface IMaintenance {
   /**
    * @dev Returns whether the validator `_consensusAddr` maintained at the block number `_block`.
    */
-  function maintained(address _consensusAddr, uint256 _block) external view returns (bool);
+  function checkMaintained(address _consensusAddr, uint256 _block) external view returns (bool);
 
   /**
    * @dev Returns whether the validator `_consensusAddr` maintained in the inclusive range [`_fromBlock`, `_toBlock`] of blocks.
    */
-  function maintainedInBlockRange(
+  function checkMaintainedInBlockRange(
     address _consensusAddr,
     uint256 _fromBlock,
     uint256 _toBlock
@@ -37,12 +37,12 @@ interface IMaintenance {
   /**
    * @dev Returns the bool array indicating the validators maintained at block number `_block` or not.
    */
-  function getManyMaintained(address[] calldata _addrList, uint256 _block) external view returns (bool[] memory);
+  function checkManyMaintained(address[] calldata _addrList, uint256 _block) external view returns (bool[] memory);
 
   /**
    * @dev Returns a bool array indicating the validators maintained in the inclusive range [`_fromBlock`, `_toBlock`] of blocks or not.
    */
-  function getManyMaintainedInBlockRange(
+  function checkManyMaintainedInBlockRange(
     address[] calldata _addrList,
     uint256 _fromBlock,
     uint256 _toBlock
@@ -51,7 +51,7 @@ interface IMaintenance {
   /**
    * @dev Returns whether the validator `_consensusAddr` has scheduled.
    */
-  function scheduled(address _consensusAddr) external view returns (bool);
+  function checkScheduled(address _consensusAddr) external view returns (bool);
 
   /**
    * @dev Returns the detailed schedule of the validator `_consensusAddr`.

--- a/contracts/interfaces/slash-indicator/ICreditScore.sol
+++ b/contracts/interfaces/slash-indicator/ICreditScore.sol
@@ -92,5 +92,5 @@ interface ICreditScore {
   /**
    * @dev Returns the whether the `_validator` has been bailed out at the `_period`.
    */
-  function bailedOutAtPeriod(address _validator, uint256 _period) external view returns (bool);
+  function checkBailedOutAtPeriod(address _validator, uint256 _period) external view returns (bool);
 }

--- a/contracts/interfaces/slash-indicator/ICreditScore.sol
+++ b/contracts/interfaces/slash-indicator/ICreditScore.sol
@@ -87,7 +87,7 @@ interface ICreditScore {
   /**
    * @dev Returns the current credit score of a list of validators.
    */
-  function getBulkCreditScore(address[] calldata _validators) external view returns (uint256[] memory _resultList);
+  function getManyCreditScores(address[] calldata _validators) external view returns (uint256[] memory _resultList);
 
   /**
    * @dev Returns the whether the `_validator` has been bailed out at the `_period`.

--- a/contracts/interfaces/staking/IRewardPool.sol
+++ b/contracts/interfaces/staking/IRewardPool.sol
@@ -63,5 +63,5 @@ interface IRewardPool is PeriodWrapperConsumer {
   /**
    * @dev Returns the total staking amounts of all users for the pools `_poolAddrs`.
    */
-  function bulkStakingTotal(address[] calldata _poolAddrs) external view returns (uint256[] memory);
+  function getManyStakingTotals(address[] calldata _poolAddrs) external view returns (uint256[] memory);
 }

--- a/contracts/interfaces/staking/IRewardPool.sol
+++ b/contracts/interfaces/staking/IRewardPool.sol
@@ -45,7 +45,7 @@ interface IRewardPool is PeriodWrapperConsumer {
   /**
    * @dev Returns the staking amount of an user.
    */
-  function stakingAmountOf(address _poolAddr, address _user) external view returns (uint256);
+  function getStakingAmount(address _poolAddr, address _user) external view returns (uint256);
 
   /**
    * @dev Returns the staking amounts of the users.

--- a/contracts/interfaces/staking/IRewardPool.sol
+++ b/contracts/interfaces/staking/IRewardPool.sol
@@ -50,7 +50,7 @@ interface IRewardPool is PeriodWrapperConsumer {
   /**
    * @dev Returns the staking amounts of the users.
    */
-  function bulkStakingAmountOf(address[] calldata _poolAddrs, address[] calldata _userList)
+  function getManyStakingAmounts(address[] calldata _poolAddrs, address[] calldata _userList)
     external
     view
     returns (uint256[] memory);

--- a/contracts/interfaces/staking/IRewardPool.sol
+++ b/contracts/interfaces/staking/IRewardPool.sol
@@ -58,7 +58,7 @@ interface IRewardPool is PeriodWrapperConsumer {
   /**
    * @dev Returns the total staking amount of all users for a pool.
    */
-  function stakingTotal(address _poolAddr) external view returns (uint256);
+  function getStakingTotal(address _poolAddr) external view returns (uint256);
 
   /**
    * @dev Returns the total staking amounts of all users for the pools `_poolAddrs`.

--- a/contracts/interfaces/staking/IStaking.sol
+++ b/contracts/interfaces/staking/IStaking.sol
@@ -52,5 +52,5 @@ interface IStaking is IRewardPool, IBaseStaking, ICandidateStaking, IDelegatorSt
   /**
    * @dev Returns the self-staking amounts of the pools.
    */
-  function bulkSelfStaking(address[] calldata) external view returns (uint256[] memory);
+  function getManySelfStakings(address[] calldata) external view returns (uint256[] memory);
 }

--- a/contracts/interfaces/validator/info-fragments/IJailingInfo.sol
+++ b/contracts/interfaces/validator/info-fragments/IJailingInfo.sol
@@ -40,7 +40,7 @@ interface IJailingInfo {
   /**
    * @dev Returns whether the validators are put in jail (cannot join the set of validators) during the current period.
    */
-  function bulkJailed(address[] calldata) external view returns (bool[] memory);
+  function getManyJailed(address[] calldata) external view returns (bool[] memory);
 
   /**
    * @dev Returns whether the incoming reward of the block producers are deprecated during the current period.

--- a/contracts/interfaces/validator/info-fragments/IJailingInfo.sol
+++ b/contracts/interfaces/validator/info-fragments/IJailingInfo.sol
@@ -6,12 +6,12 @@ interface IJailingInfo {
   /**
    * @dev Returns whether the validator are put in jail (cannot join the set of validators) during the current period.
    */
-  function jailed(address) external view returns (bool);
+  function checkJailed(address) external view returns (bool);
 
   /**
    * @dev Returns whether the validator are put in jail and the number of block and epoch that he still is in the jail.
    */
-  function jailedTimeLeft(address _addr)
+  function getJailedTimeLeft(address _addr)
     external
     view
     returns (
@@ -23,12 +23,12 @@ interface IJailingInfo {
   /**
    * @dev Returns whether the validator are put in jail (cannot join the set of validators) at a specific block.
    */
-  function jailedAtBlock(address _addr, uint256 _blockNum) external view returns (bool);
+  function checkJailedAtBlock(address _addr, uint256 _blockNum) external view returns (bool);
 
   /**
    * @dev Returns whether the validator are put in jail at a specific block and the number of block and epoch that he still is in the jail.
    */
-  function jailedTimeLeftAtBlock(address _addr, uint256 _blockNum)
+  function getJailedTimeLeftAtBlock(address _addr, uint256 _blockNum)
     external
     view
     returns (
@@ -40,17 +40,17 @@ interface IJailingInfo {
   /**
    * @dev Returns whether the validators are put in jail (cannot join the set of validators) during the current period.
    */
-  function getManyJailed(address[] calldata) external view returns (bool[] memory);
+  function checkManyJailed(address[] calldata) external view returns (bool[] memory);
 
   /**
    * @dev Returns whether the incoming reward of the block producers are deprecated during the current period.
    */
-  function miningRewardDeprecated(address[] calldata _blockProducers) external view returns (bool[] memory);
+  function checkMiningRewardDeprecated(address[] calldata _blockProducers) external view returns (bool[] memory);
 
   /**
    * @dev Returns whether the incoming reward of the block producers are deprecated during a specific period.
    */
-  function miningRewardDeprecatedAtPeriod(address[] calldata _blockProducers, uint256 _period)
+  function checkMiningRewardDeprecatedAtPeriod(address[] calldata _blockProducers, uint256 _period)
     external
     view
     returns (bool[] memory);

--- a/contracts/mainchain/MainchainGatewayV2.sol
+++ b/contracts/mainchain/MainchainGatewayV2.sol
@@ -94,7 +94,7 @@ contract MainchainGatewayV2 is WithdrawalLimitation, Initializable, AccessContro
   }
 
   /**
-   * @dev See {IBridge-replaceBridgeOperators}.
+   * @inheritdoc IBridge
    */
   function replaceBridgeOperators(address[] calldata _list) external onlyAdmin {
     address _addr;
@@ -124,7 +124,7 @@ contract MainchainGatewayV2 is WithdrawalLimitation, Initializable, AccessContro
   }
 
   /**
-   * @dev See {IBridge-getBridgeOperators}.
+   * @inheritdoc IBridge
    */
   function getBridgeOperators() external view returns (address[] memory) {
     return _bridgeOperators;
@@ -136,28 +136,28 @@ contract MainchainGatewayV2 is WithdrawalLimitation, Initializable, AccessContro
   function receiveEther() external payable {}
 
   /**
-   * @dev See {IMainchainGatewayV2-DOMAIN_SEPARATOR}.
+   * @inheritdoc IMainchainGatewayV2
    */
   function DOMAIN_SEPARATOR() external view virtual returns (bytes32) {
     return _domainSeparator;
   }
 
   /**
-   * @dev See {IMainchainGatewayV2-setWrappedNativeTokenContract}.
+   * @inheritdoc IMainchainGatewayV2
    */
   function setWrappedNativeTokenContract(IWETH _wrappedToken) external virtual onlyAdmin {
     _setWrappedNativeTokenContract(_wrappedToken);
   }
 
   /**
-   * @dev See {IMainchainGatewayV2-requestDepositFor}.
+   * @inheritdoc IMainchainGatewayV2
    */
   function requestDepositFor(Transfer.Request calldata _request) external payable virtual whenNotPaused {
     _requestDepositFor(_request, msg.sender);
   }
 
   /**
-   * @dev See {IMainchainGatewayV2-submitWithdrawal}.
+   * @inheritdoc IMainchainGatewayV2
    */
   function submitWithdrawal(Transfer.Receipt calldata _receipt, Signature[] calldata _signatures)
     external
@@ -169,7 +169,7 @@ contract MainchainGatewayV2 is WithdrawalLimitation, Initializable, AccessContro
   }
 
   /**
-   * @dev See {IMainchainGatewayV2-unlockWithdrawal}.
+   * @inheritdoc IMainchainGatewayV2
    */
   function unlockWithdrawal(Transfer.Receipt calldata _receipt) external onlyRole(WITHDRAWAL_UNLOCKER_ROLE) {
     bytes32 _receiptHash = _receipt.hash();
@@ -195,7 +195,7 @@ contract MainchainGatewayV2 is WithdrawalLimitation, Initializable, AccessContro
   }
 
   /**
-   * @dev See {IMainchainGatewayV2-mapTokens}.
+   * @inheritdoc IMainchainGatewayV2
    */
   function mapTokens(
     address[] calldata _mainchainTokens,
@@ -207,7 +207,7 @@ contract MainchainGatewayV2 is WithdrawalLimitation, Initializable, AccessContro
   }
 
   /**
-   * @dev See {IMainchainGatewayV2-mapTokensAndThresholds}.
+   * @inheritdoc IMainchainGatewayV2
    */
   function mapTokensAndThresholds(
     address[] calldata _mainchainTokens,
@@ -228,7 +228,7 @@ contract MainchainGatewayV2 is WithdrawalLimitation, Initializable, AccessContro
   }
 
   /**
-   * @dev See {IMainchainGatewayV2-getRoninToken}.
+   * @inheritdoc IMainchainGatewayV2
    */
   function getRoninToken(address _mainchainToken) public view returns (MappedToken memory _token) {
     _token = _roninToken[_mainchainToken];

--- a/contracts/mainchain/MainchainGovernanceAdmin.sol
+++ b/contracts/mainchain/MainchainGovernanceAdmin.sol
@@ -38,7 +38,7 @@ contract MainchainGovernanceAdmin is AccessControlEnumerable, GovernanceRelay, G
   }
 
   /**
-   * @dev See {GovernanceRelay-_relayProposal}.
+   * @dev See `GovernanceRelay-_relayProposal`.
    *
    * Requirements:
    * - The method caller is relayer.
@@ -53,7 +53,7 @@ contract MainchainGovernanceAdmin is AccessControlEnumerable, GovernanceRelay, G
   }
 
   /**
-   * @dev See {GovernanceRelay-_relayGlobalProposal}.
+   * @dev See `GovernanceRelay-_relayGlobalProposal`.
    *
    * Requirements:
    * - The method caller is relayer.
@@ -76,7 +76,7 @@ contract MainchainGovernanceAdmin is AccessControlEnumerable, GovernanceRelay, G
   }
 
   /**
-   * @dev See {BOsGovernanceRelay-_relayVotesBySignatures}.
+   * @dev See `BOsGovernanceRelay-_relayVotesBySignatures`.
    *
    * Requirements:
    * - The method caller is relayer.

--- a/contracts/mocks/MockStaking.sol
+++ b/contracts/mocks/MockStaking.sol
@@ -95,5 +95,5 @@ contract MockStaking is RewardCalculation {
     return lastUpdatedPeriod;
   }
 
-  function bulkStakingTotal(address[] calldata _poolAddr) external view override returns (uint256[] memory) {}
+  function getManyStakingTotals(address[] calldata _poolAddr) external view override returns (uint256[] memory) {}
 }

--- a/contracts/mocks/MockStaking.sol
+++ b/contracts/mocks/MockStaking.sol
@@ -76,7 +76,7 @@ contract MockStaking is RewardCalculation {
     _amount = _claimReward(poolAddr, _user);
   }
 
-  function stakingAmountOf(address, address _user) public view override returns (uint256) {
+  function getStakingAmount(address, address _user) public view override returns (uint256) {
     return _stakingAmount[_user];
   }
 

--- a/contracts/mocks/MockStaking.sol
+++ b/contracts/mocks/MockStaking.sol
@@ -87,7 +87,7 @@ contract MockStaking is RewardCalculation {
     returns (uint256[] memory)
   {}
 
-  function stakingTotal(address _addr) public view virtual override returns (uint256) {
+  function getStakingTotal(address _addr) public view virtual override returns (uint256) {
     return _addr == poolAddr ? _stakingTotal : 0;
   }
 

--- a/contracts/mocks/MockStaking.sol
+++ b/contracts/mocks/MockStaking.sol
@@ -80,7 +80,7 @@ contract MockStaking is RewardCalculation {
     return _stakingAmount[_user];
   }
 
-  function bulkStakingAmountOf(address[] calldata _poolAddrs, address[] calldata _userList)
+  function getManyStakingAmounts(address[] calldata _poolAddrs, address[] calldata _userList)
     external
     view
     override

--- a/contracts/mocks/validator/MockValidatorSet.sol
+++ b/contracts/mocks/validator/MockValidatorSet.sol
@@ -37,7 +37,7 @@ contract MockValidatorSet is IRoninValidatorSet, CandidateManager {
 
   function getLastUpdatedBlock() external view override returns (uint256) {}
 
-  function bulkJailed(address[] calldata) external view override returns (bool[] memory) {}
+  function getManyJailed(address[] calldata) external view override returns (bool[] memory) {}
 
   function miningRewardDeprecatedAtPeriod(address[] calldata, uint256 _period)
     external

--- a/contracts/mocks/validator/MockValidatorSet.sol
+++ b/contracts/mocks/validator/MockValidatorSet.sol
@@ -37,16 +37,16 @@ contract MockValidatorSet is IRoninValidatorSet, CandidateManager {
 
   function getLastUpdatedBlock() external view override returns (uint256) {}
 
-  function getManyJailed(address[] calldata) external view override returns (bool[] memory) {}
+  function checkManyJailed(address[] calldata) external view override returns (bool[] memory) {}
 
-  function miningRewardDeprecatedAtPeriod(address[] calldata, uint256 _period)
+  function checkMiningRewardDeprecatedAtPeriod(address[] calldata, uint256 _period)
     external
     view
     override
     returns (bool[] memory)
   {}
 
-  function miningRewardDeprecated(address[] calldata) external view override returns (bool[] memory) {}
+  function checkMiningRewardDeprecated(address[] calldata) external view override returns (bool[] memory) {}
 
   function epochOf(uint256 _block) external view override returns (uint256) {}
 
@@ -107,9 +107,9 @@ contract MockValidatorSet is IRoninValidatorSet, CandidateManager {
     return block.timestamp / 86400;
   }
 
-  function jailed(address) external view override returns (bool) {}
+  function checkJailed(address) external view override returns (bool) {}
 
-  function jailedTimeLeft(address)
+  function getJailedTimeLeft(address)
     external
     view
     override
@@ -122,9 +122,9 @@ contract MockValidatorSet is IRoninValidatorSet, CandidateManager {
 
   function currentPeriodStartAtBlock() external view override returns (uint256) {}
 
-  function jailedAtBlock(address _addr, uint256 _blockNum) external view override returns (bool) {}
+  function checkJailedAtBlock(address _addr, uint256 _blockNum) external view override returns (bool) {}
 
-  function jailedTimeLeftAtBlock(address _addr, uint256 _blockNum)
+  function getJailedTimeLeftAtBlock(address _addr, uint256 _blockNum)
     external
     view
     override

--- a/contracts/ronin/BridgeTracking.sol
+++ b/contracts/ronin/BridgeTracking.sol
@@ -66,7 +66,7 @@ contract BridgeTracking is HasBridgeContract, HasValidatorContract, Initializabl
   /**
    * @inheritdoc IBridgeTracking
    */
-  function bulkTotalBallotsOf(uint256 _period, address[] calldata _bridgeOperators)
+  function getManyTotalBallots(uint256 _period, address[] calldata _bridgeOperators)
     external
     view
     override

--- a/contracts/ronin/Maintenance.sol
+++ b/contracts/ronin/Maintenance.sol
@@ -124,7 +124,7 @@ contract Maintenance is IMaintenance, HasValidatorContract, Initializable {
   {
     _resList = new bool[](_addrList.length);
     for (uint _i = 0; _i < _addrList.length; _i++) {
-      _resList[_i] = maintaining(_addrList[_i], _block);
+      _resList[_i] = maintained(_addrList[_i], _block);
     }
   }
 
@@ -157,7 +157,7 @@ contract Maintenance is IMaintenance, HasValidatorContract, Initializable {
   /**
    * @inheritdoc IMaintenance
    */
-  function maintaining(address _consensusAddr, uint256 _block) public view returns (bool) {
+  function maintained(address _consensusAddr, uint256 _block) public view returns (bool) {
     Schedule storage _s = _schedule[_consensusAddr];
     return _s.from <= _block && _block <= _s.to;
   }
@@ -165,7 +165,7 @@ contract Maintenance is IMaintenance, HasValidatorContract, Initializable {
   /**
    * @inheritdoc IMaintenance
    */
-  function maintainingInBlockRange(
+  function maintainedInBlockRange(
     address _consensusAddr,
     uint256 _fromBlock,
     uint256 _toBlock

--- a/contracts/ronin/Maintenance.sol
+++ b/contracts/ronin/Maintenance.sol
@@ -84,7 +84,7 @@ contract Maintenance is IMaintenance, HasValidatorContract, Initializable {
       _validator.isCandidateAdmin(_consensusAddr, msg.sender),
       "Maintenance: method caller must be a candidate admin"
     );
-    require(!scheduled(_consensusAddr), "Maintenance: already scheduled");
+    require(!checkScheduled(_consensusAddr), "Maintenance: already scheduled");
     require(totalSchedules() < maxSchedules, "Maintenance: exceeds total of schedules");
     require(
       _startedAtBlock.inRange(block.number + minOffsetToStartSchedule, block.number + maxOffsetToStartSchedule),
@@ -116,7 +116,7 @@ contract Maintenance is IMaintenance, HasValidatorContract, Initializable {
   /**
    * @inheritdoc IMaintenance
    */
-  function getManyMaintained(address[] calldata _addrList, uint256 _block)
+  function checkManyMaintained(address[] calldata _addrList, uint256 _block)
     external
     view
     override
@@ -124,14 +124,14 @@ contract Maintenance is IMaintenance, HasValidatorContract, Initializable {
   {
     _resList = new bool[](_addrList.length);
     for (uint _i = 0; _i < _addrList.length; _i++) {
-      _resList[_i] = maintained(_addrList[_i], _block);
+      _resList[_i] = checkMaintained(_addrList[_i], _block);
     }
   }
 
   /**
    * @inheritdoc IMaintenance
    */
-  function getManyMaintainedInBlockRange(
+  function checkManyMaintainedInBlockRange(
     address[] calldata _addrList,
     uint256 _fromBlock,
     uint256 _toBlock
@@ -148,7 +148,7 @@ contract Maintenance is IMaintenance, HasValidatorContract, Initializable {
   function totalSchedules() public view override returns (uint256 _count) {
     address[] memory _validators = _validatorContract.getValidators();
     for (uint _i = 0; _i < _validators.length; _i++) {
-      if (scheduled(_validators[_i])) {
+      if (checkScheduled(_validators[_i])) {
         _count++;
       }
     }
@@ -157,7 +157,7 @@ contract Maintenance is IMaintenance, HasValidatorContract, Initializable {
   /**
    * @inheritdoc IMaintenance
    */
-  function maintained(address _consensusAddr, uint256 _block) public view returns (bool) {
+  function checkMaintained(address _consensusAddr, uint256 _block) public view returns (bool) {
     Schedule storage _s = _schedule[_consensusAddr];
     return _s.from <= _block && _block <= _s.to;
   }
@@ -165,7 +165,7 @@ contract Maintenance is IMaintenance, HasValidatorContract, Initializable {
   /**
    * @inheritdoc IMaintenance
    */
-  function maintainedInBlockRange(
+  function checkMaintainedInBlockRange(
     address _consensusAddr,
     uint256 _fromBlock,
     uint256 _toBlock
@@ -176,7 +176,7 @@ contract Maintenance is IMaintenance, HasValidatorContract, Initializable {
   /**
    * @inheritdoc IMaintenance
    */
-  function scheduled(address _consensusAddr) public view override returns (bool) {
+  function checkScheduled(address _consensusAddr) public view override returns (bool) {
     return block.number <= _schedule[_consensusAddr].to;
   }
 

--- a/contracts/ronin/Maintenance.sol
+++ b/contracts/ronin/Maintenance.sol
@@ -131,7 +131,7 @@ contract Maintenance is IMaintenance, HasValidatorContract, Initializable {
   /**
    * @inheritdoc IMaintenance
    */
-  function bulkMaintainingInBlockRange(
+  function getManyMaintainedInBlockRange(
     address[] calldata _addrList,
     uint256 _fromBlock,
     uint256 _toBlock

--- a/contracts/ronin/Maintenance.sol
+++ b/contracts/ronin/Maintenance.sol
@@ -116,7 +116,7 @@ contract Maintenance is IMaintenance, HasValidatorContract, Initializable {
   /**
    * @inheritdoc IMaintenance
    */
-  function bulkMaintaining(address[] calldata _addrList, uint256 _block)
+  function getManyMaintained(address[] calldata _addrList, uint256 _block)
     external
     view
     override

--- a/contracts/ronin/RoninGatewayV2.sol
+++ b/contracts/ronin/RoninGatewayV2.sol
@@ -151,7 +151,7 @@ contract RoninGatewayV2 is
   }
 
   /**
-   * @dev {IRoninGatewayV2-getWithdrawalSignatures}.
+   * @inheritdoc IRoninGatewayV2
    */
   function getWithdrawalSignatures(uint256 _withdrawalId, address[] calldata _validators)
     external
@@ -165,7 +165,7 @@ contract RoninGatewayV2 is
   }
 
   /**
-   * @dev {IRoninGatewayV2-depositFor}.
+   * @inheritdoc IRoninGatewayV2
    */
   function depositFor(Transfer.Receipt calldata _receipt) external {
     address _sender = msg.sender;
@@ -175,7 +175,7 @@ contract RoninGatewayV2 is
   }
 
   /**
-   * @dev {IRoninGatewayV2-tryBulkAcknowledgeMainchainWithdrew}.
+   * @inheritdoc IRoninGatewayV2
    */
   function tryBulkAcknowledgeMainchainWithdrew(uint256[] calldata _withdrawalIds)
     external
@@ -207,7 +207,7 @@ contract RoninGatewayV2 is
   }
 
   /**
-   * @dev {IRoninGatewayV2-tryBulkDepositFor}.
+   * @inheritdoc IRoninGatewayV2
    */
   function tryBulkDepositFor(Transfer.Receipt[] calldata _receipts) external returns (bool[] memory _executedReceipts) {
     address _sender = msg.sender;
@@ -228,14 +228,14 @@ contract RoninGatewayV2 is
   }
 
   /**
-   * @dev {IRoninGatewayV2-requestWithdrawalFor}.
+   * @inheritdoc IRoninGatewayV2
    */
   function requestWithdrawalFor(Transfer.Request calldata _request, uint256 _chainId) external whenNotPaused {
     _requestWithdrawalFor(_request, msg.sender, _chainId);
   }
 
   /**
-   * @dev {IRoninGatewayV2-bulkRequestWithdrawalFor}.
+   * @inheritdoc IRoninGatewayV2
    */
   function bulkRequestWithdrawalFor(Transfer.Request[] calldata _requests, uint256 _chainId) external whenNotPaused {
     require(_requests.length > 0, "RoninGatewayV2: empty array");
@@ -245,7 +245,7 @@ contract RoninGatewayV2 is
   }
 
   /**
-   * @dev {IRoninGatewayV2-requestWithdrawalSignatures}.
+   * @inheritdoc IRoninGatewayV2
    */
   function requestWithdrawalSignatures(uint256 _withdrawalId) external whenNotPaused {
     require(!mainchainWithdrew(_withdrawalId), "RoninGatewayV2: withdrew on mainchain already");
@@ -255,7 +255,7 @@ contract RoninGatewayV2 is
   }
 
   /**
-   * @dev {IRoninGatewayV2-bulkSubmitWithdrawalSignatures}.
+   * @inheritdoc IRoninGatewayV2
    */
   function bulkSubmitWithdrawalSignatures(uint256[] calldata _withdrawals, bytes[] calldata _signatures) external {
     address _validator = msg.sender;
@@ -276,7 +276,7 @@ contract RoninGatewayV2 is
   }
 
   /**
-   * @dev {IRoninGatewayV2-mapTokens}.
+   * @inheritdoc IRoninGatewayV2
    */
   function mapTokens(
     address[] calldata _roninTokens,
@@ -289,7 +289,7 @@ contract RoninGatewayV2 is
   }
 
   /**
-   * @dev {IRoninGatewayV2-depositVoted}.
+   * @inheritdoc IRoninGatewayV2
    */
   function depositVoted(
     uint256 _chainId,
@@ -300,21 +300,21 @@ contract RoninGatewayV2 is
   }
 
   /**
-   * @dev {IRoninGatewayV2-mainchainWithdrewVoted}.
+   * @inheritdoc IRoninGatewayV2
    */
   function mainchainWithdrewVoted(uint256 _withdrawalId, address _voter) external view returns (bool) {
     return _voted(mainchainWithdrewVote[_withdrawalId], _voter);
   }
 
   /**
-   * @dev {IRoninGatewayV2-mainchainWithdrew}.
+   * @inheritdoc IRoninGatewayV2
    */
   function mainchainWithdrew(uint256 _withdrawalId) public view returns (bool) {
     return mainchainWithdrewVote[_withdrawalId].status == VoteStatus.Executed;
   }
 
   /**
-   * @dev {IRoninGatewayV2-getMainchainToken}.
+   * @inheritdoc IRoninGatewayV2
    */
   function getMainchainToken(address _roninToken, uint256 _chainId) public view returns (MappedToken memory _token) {
     _token = _mainchainToken[_roninToken][_chainId];

--- a/contracts/ronin/RoninGovernanceAdmin.sol
+++ b/contracts/ronin/RoninGovernanceAdmin.sol
@@ -84,7 +84,7 @@ contract RoninGovernanceAdmin is GovernanceAdmin, GovernanceProposal, BOsGoverna
   }
 
   /**
-   * @dev See {CoreGovernance-_proposeProposal}.
+   * @dev See `CoreGovernance-_proposeProposal`.
    *
    * Requirements:
    * - The method caller is governor.
@@ -101,7 +101,7 @@ contract RoninGovernanceAdmin is GovernanceAdmin, GovernanceProposal, BOsGoverna
   }
 
   /**
-   * @dev See {GovernanceProposal-_proposeProposalStructAndCastVotes}.
+   * @dev See `GovernanceProposal-_proposeProposalStructAndCastVotes`.
    *
    * Requirements:
    * - The method caller is governor.
@@ -116,7 +116,7 @@ contract RoninGovernanceAdmin is GovernanceAdmin, GovernanceProposal, BOsGoverna
   }
 
   /**
-   * @dev See {GovernanceProposal-_castProposalBySignatures}.
+   * @dev See `GovernanceProposal-_castProposalBySignatures`.
    */
   function castProposalBySignatures(
     Proposal.ProposalDetail calldata _proposal,
@@ -127,7 +127,7 @@ contract RoninGovernanceAdmin is GovernanceAdmin, GovernanceProposal, BOsGoverna
   }
 
   /**
-   * @dev See {CoreGovernance-_proposeGlobal}.
+   * @dev See `CoreGovernance-_proposeGlobal`.
    *
    * Requirements:
    * - The method caller is governor.
@@ -151,7 +151,7 @@ contract RoninGovernanceAdmin is GovernanceAdmin, GovernanceProposal, BOsGoverna
   }
 
   /**
-   * @dev See {GovernanceProposal-_proposeGlobalProposalStructAndCastVotes}.
+   * @dev See `GovernanceProposal-_proposeGlobalProposalStructAndCastVotes`.
    *
    * Requirements:
    * - The method caller is governor.
@@ -174,7 +174,7 @@ contract RoninGovernanceAdmin is GovernanceAdmin, GovernanceProposal, BOsGoverna
   }
 
   /**
-   * @dev See {GovernanceProposal-_castGlobalProposalBySignatures}.
+   * @dev See `GovernanceProposal-_castGlobalProposalBySignatures`.
    */
   function castGlobalProposalBySignatures(
     GlobalProposal.GlobalProposalDetail calldata _globalProposal,
@@ -192,7 +192,7 @@ contract RoninGovernanceAdmin is GovernanceAdmin, GovernanceProposal, BOsGoverna
   }
 
   /**
-   * @dev See {BOsGovernanceProposal-_castVotesBySignatures}.
+   * @dev See `BOsGovernanceProposal-_castVotesBySignatures`.
    */
   function voteBridgeOperatorsBySignatures(
     uint256 _period,

--- a/contracts/ronin/slash-indicator/CreditScore.sol
+++ b/contracts/ronin/slash-indicator/CreditScore.sol
@@ -161,7 +161,7 @@ abstract contract CreditScore is ICreditScore, HasValidatorContract, HasMaintena
   }
 
   /**
-   * @dev See `ISlashUnavailability`
+   * @dev See `SlashUnavailability`.
    */
   function _setUnavailabilityIndicator(
     address _validator,
@@ -170,7 +170,7 @@ abstract contract CreditScore is ICreditScore, HasValidatorContract, HasMaintena
   ) internal virtual;
 
   /**
-   * @dev See `ICreditScore-CreditScoreConfigsUpdated`.
+   * @dev See `ICreditScore-setCreditScoreConfigs`.
    */
   function _setCreditScoreConfigs(
     uint256 _gainScore,

--- a/contracts/ronin/slash-indicator/CreditScore.sol
+++ b/contracts/ronin/slash-indicator/CreditScore.sol
@@ -35,7 +35,7 @@ abstract contract CreditScore is ICreditScore, HasValidatorContract, HasMaintena
   function updateCreditScores(address[] calldata _validators, uint256 _period) external override onlyValidatorContract {
     uint256 _periodStartAtBlock = _validatorContract.currentPeriodStartAtBlock();
 
-    bool[] memory _jaileds = _validatorContract.bulkJailed(_validators);
+    bool[] memory _jaileds = _validatorContract.getManyJailed(_validators);
     bool[] memory _maintaineds = _maintenanceContract.getManyMaintainedInBlockRange(
       _validators,
       _periodStartAtBlock,

--- a/contracts/ronin/slash-indicator/CreditScore.sol
+++ b/contracts/ronin/slash-indicator/CreditScore.sol
@@ -10,7 +10,7 @@ import "../../libraries/Math.sol";
 
 abstract contract CreditScore is ICreditScore, HasValidatorContract, HasMaintenanceContract, PercentageConsumer {
   /// @dev Mapping from validator address => period index => whether bailed out before
-  mapping(address => mapping(uint256 => bool)) internal _bailedOutAtPeriod;
+  mapping(address => mapping(uint256 => bool)) internal _checkBailedOutAtPeriod;
   /// @dev Mapping from validator address => credit score
   mapping(address => uint256) internal _creditScore;
 
@@ -35,8 +35,8 @@ abstract contract CreditScore is ICreditScore, HasValidatorContract, HasMaintena
   function updateCreditScores(address[] calldata _validators, uint256 _period) external override onlyValidatorContract {
     uint256 _periodStartAtBlock = _validatorContract.currentPeriodStartAtBlock();
 
-    bool[] memory _jaileds = _validatorContract.getManyJailed(_validators);
-    bool[] memory _maintaineds = _maintenanceContract.getManyMaintainedInBlockRange(
+    bool[] memory _jaileds = _validatorContract.checkManyJailed(_validators);
+    bool[] memory _maintaineds = _maintenanceContract.checkManyMaintainedInBlockRange(
       _validators,
       _periodStartAtBlock,
       block.number
@@ -79,11 +79,11 @@ abstract contract CreditScore is ICreditScore, HasValidatorContract, HasMaintena
       "SlashIndicator: method caller must be a candidate admin"
     );
 
-    (bool _isJailed, , uint256 _jailedEpochLeft) = _validatorContract.jailedTimeLeft(_consensusAddr);
+    (bool _isJailed, , uint256 _jailedEpochLeft) = _validatorContract.getJailedTimeLeft(_consensusAddr);
     require(_isJailed, "SlashIndicator: caller must be jailed in the current period");
 
     uint256 _period = _validatorContract.currentPeriod();
-    require(!_bailedOutAtPeriod[_consensusAddr][_period], "SlashIndicator: validator has bailed out previously");
+    require(!_checkBailedOutAtPeriod[_consensusAddr][_period], "SlashIndicator: validator has bailed out previously");
 
     uint256 _score = _creditScore[_consensusAddr];
     uint256 _cost = _jailedEpochLeft * _bailOutCostMultiplier;
@@ -93,7 +93,7 @@ abstract contract CreditScore is ICreditScore, HasValidatorContract, HasMaintena
 
     _creditScore[_consensusAddr] -= _cost;
     _setUnavailabilityIndicator(_consensusAddr, _period, 0);
-    _bailedOutAtPeriod[_consensusAddr][_period] = true;
+    _checkBailedOutAtPeriod[_consensusAddr][_period] = true;
   }
 
   /**
@@ -156,8 +156,8 @@ abstract contract CreditScore is ICreditScore, HasValidatorContract, HasMaintena
   /**
    * @inheritdoc ICreditScore
    */
-  function bailedOutAtPeriod(address _validator, uint256 _period) external view override returns (bool) {
-    return _bailedOutAtPeriod[_validator][_period];
+  function checkBailedOutAtPeriod(address _validator, uint256 _period) external view override returns (bool) {
+    return _checkBailedOutAtPeriod[_validator][_period];
   }
 
   /**

--- a/contracts/ronin/slash-indicator/CreditScore.sol
+++ b/contracts/ronin/slash-indicator/CreditScore.sol
@@ -140,7 +140,7 @@ abstract contract CreditScore is ICreditScore, HasValidatorContract, HasMaintena
   /**
    * @inheritdoc ICreditScore
    */
-  function getBulkCreditScore(address[] calldata _validators)
+  function getManyCreditScores(address[] calldata _validators)
     public
     view
     override

--- a/contracts/ronin/slash-indicator/CreditScore.sol
+++ b/contracts/ronin/slash-indicator/CreditScore.sol
@@ -36,7 +36,7 @@ abstract contract CreditScore is ICreditScore, HasValidatorContract, HasMaintena
     uint256 _periodStartAtBlock = _validatorContract.currentPeriodStartAtBlock();
 
     bool[] memory _jaileds = _validatorContract.bulkJailed(_validators);
-    bool[] memory _maintaineds = _maintenanceContract.bulkMaintainingInBlockRange(
+    bool[] memory _maintaineds = _maintenanceContract.getManyMaintainedInBlockRange(
       _validators,
       _periodStartAtBlock,
       block.number

--- a/contracts/ronin/slash-indicator/SlashIndicator.sol
+++ b/contracts/ronin/slash-indicator/SlashIndicator.sol
@@ -109,6 +109,6 @@ contract SlashIndicator is
     return
       (msg.sender != _addr) &&
       _validatorContract.isBlockProducer(_addr) &&
-      !_maintenanceContract.maintaining(_addr, block.number);
+      !_maintenanceContract.maintained(_addr, block.number);
   }
 }

--- a/contracts/ronin/slash-indicator/SlashIndicator.sol
+++ b/contracts/ronin/slash-indicator/SlashIndicator.sol
@@ -109,6 +109,6 @@ contract SlashIndicator is
     return
       (msg.sender != _addr) &&
       _validatorContract.isBlockProducer(_addr) &&
-      !_maintenanceContract.maintained(_addr, block.number);
+      !_maintenanceContract.checkMaintained(_addr, block.number);
   }
 }

--- a/contracts/ronin/staking/BaseStaking.sol
+++ b/contracts/ronin/staking/BaseStaking.sol
@@ -60,7 +60,7 @@ abstract contract BaseStaking is
   /**
    * @inheritdoc IRewardPool
    */
-  function bulkStakingTotal(address[] calldata _poolList)
+  function getManyStakingTotals(address[] calldata _poolList)
     public
     view
     override

--- a/contracts/ronin/staking/BaseStaking.sol
+++ b/contracts/ronin/staking/BaseStaking.sol
@@ -53,7 +53,7 @@ abstract contract BaseStaking is
   /**
    * @inheritdoc IRewardPool
    */
-  function stakingTotal(address _poolAddr) public view override returns (uint256) {
+  function getStakingTotal(address _poolAddr) public view override returns (uint256) {
     return _stakingPool[_poolAddr].stakingTotal;
   }
 
@@ -68,7 +68,7 @@ abstract contract BaseStaking is
   {
     _stakingAmounts = new uint256[](_poolList.length);
     for (uint _i = 0; _i < _poolList.length; _i++) {
-      _stakingAmounts[_i] = stakingTotal(_poolList[_i]);
+      _stakingAmounts[_i] = getStakingTotal(_poolList[_i]);
     }
   }
 

--- a/contracts/ronin/staking/BaseStaking.sol
+++ b/contracts/ronin/staking/BaseStaking.sol
@@ -82,7 +82,7 @@ abstract contract BaseStaking is
   /**
    * @inheritdoc IRewardPool
    */
-  function bulkStakingAmountOf(address[] calldata _poolAddrs, address[] calldata _userList)
+  function getManyStakingAmounts(address[] calldata _poolAddrs, address[] calldata _userList)
     external
     view
     override

--- a/contracts/ronin/staking/BaseStaking.sol
+++ b/contracts/ronin/staking/BaseStaking.sol
@@ -75,7 +75,7 @@ abstract contract BaseStaking is
   /**
    * @inheritdoc IRewardPool
    */
-  function stakingAmountOf(address _poolAddr, address _user) public view override returns (uint256) {
+  function getStakingAmount(address _poolAddr, address _user) public view override returns (uint256) {
     return _stakingPool[_poolAddr].delegatingAmount[_user];
   }
 

--- a/contracts/ronin/staking/CandidateStaking.sol
+++ b/contracts/ronin/staking/CandidateStaking.sol
@@ -114,7 +114,7 @@ abstract contract CandidateStaking is BaseStaking, ICandidateStaking {
   }
 
   /**
-   * @dev See {ICandidateStaking-applyValidatorCandidate}
+   * @dev See `ICandidateStaking-applyValidatorCandidate`
    */
   function _applyValidatorCandidate(
     address payable _poolAdmin,
@@ -139,7 +139,7 @@ abstract contract CandidateStaking is BaseStaking, ICandidateStaking {
   }
 
   /**
-   * @dev See {ICandidateStaking-stake}
+   * @dev See `ICandidateStaking-stake`
    */
   function _stake(
     PoolDetail storage _pool,
@@ -153,7 +153,7 @@ abstract contract CandidateStaking is BaseStaking, ICandidateStaking {
   }
 
   /**
-   * @dev See {ICandidateStaking-unstake}
+   * @dev See `ICandidateStaking-unstake`
    */
   function _unstake(
     PoolDetail storage _pool,

--- a/contracts/ronin/staking/DelegatorStaking.sol
+++ b/contracts/ronin/staking/DelegatorStaking.sol
@@ -101,7 +101,7 @@ abstract contract DelegatorStaking is BaseStaking, IDelegatorStaking {
 
     for (uint256 _i = 0; _i < _poolAddrList.length; _i++) {
       _consensusAddr = _poolAddrList[_i];
-      _rewards[_i] = _getReward(_consensusAddr, _user, _period, stakingAmountOf(_consensusAddr, _user));
+      _rewards[_i] = _getReward(_consensusAddr, _user, _period, getStakingAmount(_consensusAddr, _user));
     }
   }
 

--- a/contracts/ronin/staking/RewardCalculation.sol
+++ b/contracts/ronin/staking/RewardCalculation.sol
@@ -27,13 +27,13 @@ abstract contract RewardCalculation is IRewardPool {
    * @inheritdoc IRewardPool
    */
   function getReward(address _poolAddr, address _user) external view returns (uint256) {
-    return _getReward(_poolAddr, _user, _currentPeriod(), stakingAmountOf(_poolAddr, _user));
+    return _getReward(_poolAddr, _user, _currentPeriod(), getStakingAmount(_poolAddr, _user));
   }
 
   /**
    * @inheritdoc IRewardPool
    */
-  function stakingAmountOf(address _poolAddr, address _user) public view virtual returns (uint256);
+  function getStakingAmount(address _poolAddr, address _user) public view virtual returns (uint256);
 
   /**
    * @inheritdoc IRewardPool
@@ -87,7 +87,7 @@ abstract contract RewardCalculation is IRewardPool {
     }
 
     UserRewardFields storage _reward = _userReward[_poolAddr][_user];
-    uint256 _currentStakingAmount = stakingAmountOf(_poolAddr, _user);
+    uint256 _currentStakingAmount = getStakingAmount(_poolAddr, _user);
     uint256 _debited = _getReward(_poolAddr, _user, _period, _currentStakingAmount);
 
     if (_reward.debited != _debited) {
@@ -137,7 +137,7 @@ abstract contract RewardCalculation is IRewardPool {
    */
   function _claimReward(address _poolAddr, address _user) internal returns (uint256 _amount) {
     uint256 _latestPeriod = _currentPeriod();
-    _amount = _getReward(_poolAddr, _user, _latestPeriod, stakingAmountOf(_poolAddr, _user));
+    _amount = _getReward(_poolAddr, _user, _latestPeriod, getStakingAmount(_poolAddr, _user));
     emit RewardClaimed(_poolAddr, _user, _amount);
 
     UserRewardFields storage _reward = _userReward[_poolAddr][_user];

--- a/contracts/ronin/staking/RewardCalculation.sol
+++ b/contracts/ronin/staking/RewardCalculation.sol
@@ -38,7 +38,7 @@ abstract contract RewardCalculation is IRewardPool {
   /**
    * @inheritdoc IRewardPool
    */
-  function stakingTotal(address _poolAddr) public view virtual returns (uint256);
+  function getStakingTotal(address _poolAddr) public view virtual returns (uint256);
 
   /**
    * @dev Returns the reward amount that user claimable.
@@ -83,7 +83,7 @@ abstract contract RewardCalculation is IRewardPool {
 
     // Updates the pool shares if it is outdated
     if (_pool.shares.lastPeriod < _period) {
-      _pool.shares = PeriodWrapper(stakingTotal(_poolAddr), _period);
+      _pool.shares = PeriodWrapper(getStakingTotal(_poolAddr), _period);
     }
 
     UserRewardFields storage _reward = _userReward[_poolAddr][_user];
@@ -178,7 +178,7 @@ abstract contract RewardCalculation is IRewardPool {
     for (uint _i = 0; _i < _poolAddrs.length; _i++) {
       _poolAddr = _poolAddrs[_i];
       PoolFields storage _pool = _stakingPool[_poolAddr];
-      _stakingTotal = stakingTotal(_poolAddr);
+      _stakingTotal = getStakingTotal(_poolAddr);
 
       if (_accumulatedRps[_poolAddr][_period].lastPeriod == _period) {
         _conflicted[_count++] = _poolAddr;

--- a/contracts/ronin/staking/Staking.sol
+++ b/contracts/ronin/staking/Staking.sol
@@ -52,7 +52,7 @@ contract Staking is IStaking, CandidateStaking, DelegatorStaking, Initializable 
   /**
    * @inheritdoc IStaking
    */
-  function bulkSelfStaking(address[] calldata _pools) external view returns (uint256[] memory _selfStakings) {
+  function getManySelfStakings(address[] calldata _pools) external view returns (uint256[] memory _selfStakings) {
     _selfStakings = new uint256[](_pools.length);
     for (uint _i = 0; _i < _pools.length; _i++) {
       _selfStakings[_i] = _stakingPool[_pools[_i]].stakingAmount;

--- a/contracts/ronin/validator/CandidateManager.sol
+++ b/contracts/ronin/validator/CandidateManager.sol
@@ -123,7 +123,7 @@ abstract contract CandidateManager is ICandidateManager, PercentageConsumer, Has
   function _removeUnsatisfiedCandidates() internal {
     IStaking _staking = _stakingContract;
     uint256 _minStakingAmount = _stakingContract.minValidatorStakingAmount();
-    uint256[] memory _selfStakings = _staking.bulkSelfStaking(_candidates);
+    uint256[] memory _selfStakings = _staking.getManySelfStakings(_candidates);
 
     uint256 _length = _candidates.length;
     uint256 _unsatisfiedCount;

--- a/contracts/ronin/validator/CoinbaseExecution.sol
+++ b/contracts/ronin/validator/CoinbaseExecution.sol
@@ -385,12 +385,12 @@ abstract contract CoinbaseExecution is
    *
    */
   function _revampBlockProducers(uint256 _newPeriod, address[] memory _currentValidators) private {
-    bool[] memory _maintainingList = _maintenanceContract.bulkMaintaining(_candidates, block.number + 1);
+    bool[] memory _maintainedList = _maintenanceContract.getManyMaintained(_candidates, block.number + 1);
 
     for (uint _i = 0; _i < _currentValidators.length; _i++) {
       address _currentValidator = _currentValidators[_i];
       bool _isProducerBefore = isBlockProducer(_currentValidator);
-      bool _isProducerAfter = !(_jailed(_currentValidator) || _maintainingList[_i]);
+      bool _isProducerAfter = !(_jailed(_currentValidator) || _maintainedList[_i]);
 
       if (!_isProducerBefore && _isProducerAfter) {
         _validatorMap[_currentValidator] = _validatorMap[_currentValidator].addFlag(

--- a/contracts/ronin/validator/CoinbaseExecution.sol
+++ b/contracts/ronin/validator/CoinbaseExecution.sol
@@ -385,7 +385,7 @@ abstract contract CoinbaseExecution is
    *
    */
   function _revampBlockProducers(uint256 _newPeriod, address[] memory _currentValidators) private {
-    bool[] memory _maintainedList = _maintenanceContract.getManyMaintained(_candidates, block.number + 1);
+    bool[] memory _maintainedList = _maintenanceContract.checkManyMaintained(_candidates, block.number + 1);
 
     for (uint _i = 0; _i < _currentValidators.length; _i++) {
       address _currentValidator = _currentValidators[_i];

--- a/contracts/ronin/validator/CoinbaseExecution.sol
+++ b/contracts/ronin/validator/CoinbaseExecution.sol
@@ -130,7 +130,7 @@ abstract contract CoinbaseExecution is
     IBridgeTracking _bridgeTracking = _bridgeTrackingContract;
     uint256 _totalBridgeBallots = _bridgeTracking.totalBallots(_lastPeriod);
     uint256 _totalBridgeVotes = _bridgeTracking.totalVotes(_lastPeriod);
-    uint256[] memory _bridgeBallots = _bridgeTracking.bulkTotalBallotsOf(_lastPeriod, _currentValidators);
+    uint256[] memory _bridgeBallots = _bridgeTracking.getManyTotalBallots(_lastPeriod, _currentValidators);
     (
       uint256 _missingVotesRatioTier1,
       uint256 _missingVotesRatioTier2,

--- a/contracts/ronin/validator/CoinbaseExecution.sol
+++ b/contracts/ronin/validator/CoinbaseExecution.sol
@@ -325,7 +325,7 @@ abstract contract CoinbaseExecution is
     // NOTE: This is a temporary approach since the slashing issue is still not finalized.
     // Read more about slashing issue at: https://www.notion.so/skymavis/Slashing-Issue-9610ae1452434faca1213ab2e1d7d944
     _removeUnsatisfiedCandidates();
-    uint256[] memory _weights = _stakingContract.bulkStakingTotal(_candidates);
+    uint256[] memory _weights = _stakingContract.getManyStakingTotals(_candidates);
     uint256[] memory _trustedWeights = _roninTrustedOrganizationContract.getConsensusWeights(_candidates);
     uint256 _newValidatorCount;
     (_newValidators, _newValidatorCount) = _pcPickValidatorSet(

--- a/contracts/ronin/validator/storage-fragments/CommonStorage.sol
+++ b/contracts/ronin/validator/storage-fragments/CommonStorage.sol
@@ -25,7 +25,7 @@ abstract contract CommonStorage is ICommonInfo, TimingStorage, JailingStorage, V
   uint256[50] private ______gap;
 
   /**
-   * @dev See {ITimingInfo-epochOf}
+   * @inheritdoc ITimingInfo
    */
   function epochOf(uint256 _block)
     public
@@ -38,7 +38,7 @@ abstract contract CommonStorage is ICommonInfo, TimingStorage, JailingStorage, V
   }
 
   /**
-   * @dev See {ITimingInfo-currentPeriod}
+   * @inheritdoc ITimingInfo
    */
   function currentPeriod() public view virtual override(ITimingInfo, JailingStorage, TimingStorage) returns (uint256) {
     return TimingStorage.currentPeriod();

--- a/contracts/ronin/validator/storage-fragments/JailingStorage.sol
+++ b/contracts/ronin/validator/storage-fragments/JailingStorage.sol
@@ -77,7 +77,7 @@ abstract contract JailingStorage is IJailingInfo {
   /**
    * @inheritdoc IJailingInfo
    */
-  function bulkJailed(address[] calldata _addrList) external view override returns (bool[] memory _result) {
+  function getManyJailed(address[] calldata _addrList) external view override returns (bool[] memory _result) {
     _result = new bool[](_addrList.length);
     for (uint256 _i; _i < _addrList.length; _i++) {
       _result[_i] = _jailed(_addrList[_i]);

--- a/contracts/ronin/validator/storage-fragments/JailingStorage.sol
+++ b/contracts/ronin/validator/storage-fragments/JailingStorage.sol
@@ -24,14 +24,14 @@ abstract contract JailingStorage is IJailingInfo {
   /**
    * @inheritdoc IJailingInfo
    */
-  function jailed(address _addr) external view override returns (bool) {
-    return jailedAtBlock(_addr, block.number);
+  function checkJailed(address _addr) external view override returns (bool) {
+    return checkJailedAtBlock(_addr, block.number);
   }
 
   /**
    * @inheritdoc IJailingInfo
    */
-  function jailedTimeLeft(address _addr)
+  function getJailedTimeLeft(address _addr)
     external
     view
     override
@@ -41,20 +41,20 @@ abstract contract JailingStorage is IJailingInfo {
       uint256 epochLeft_
     )
   {
-    return jailedTimeLeftAtBlock(_addr, block.number);
+    return getJailedTimeLeftAtBlock(_addr, block.number);
   }
 
   /**
    * @inheritdoc IJailingInfo
    */
-  function jailedAtBlock(address _addr, uint256 _blockNum) public view override returns (bool) {
+  function checkJailedAtBlock(address _addr, uint256 _blockNum) public view override returns (bool) {
     return _jailedAtBlock(_addr, _blockNum);
   }
 
   /**
    * @inheritdoc IJailingInfo
    */
-  function jailedTimeLeftAtBlock(address _addr, uint256 _blockNum)
+  function getJailedTimeLeftAtBlock(address _addr, uint256 _blockNum)
     public
     view
     override
@@ -77,7 +77,7 @@ abstract contract JailingStorage is IJailingInfo {
   /**
    * @inheritdoc IJailingInfo
    */
-  function getManyJailed(address[] calldata _addrList) external view override returns (bool[] memory _result) {
+  function checkManyJailed(address[] calldata _addrList) external view override returns (bool[] memory _result) {
     _result = new bool[](_addrList.length);
     for (uint256 _i; _i < _addrList.length; _i++) {
       _result[_i] = _jailed(_addrList[_i]);
@@ -87,7 +87,7 @@ abstract contract JailingStorage is IJailingInfo {
   /**
    * @inheritdoc IJailingInfo
    */
-  function miningRewardDeprecated(address[] calldata _blockProducers)
+  function checkMiningRewardDeprecated(address[] calldata _blockProducers)
     external
     view
     override
@@ -103,7 +103,7 @@ abstract contract JailingStorage is IJailingInfo {
   /**
    * @inheritdoc IJailingInfo
    */
-  function miningRewardDeprecatedAtPeriod(address[] calldata _blockProducers, uint256 _period)
+  function checkMiningRewardDeprecatedAtPeriod(address[] calldata _blockProducers, uint256 _period)
     external
     view
     override

--- a/contracts/ronin/validator/storage-fragments/JailingStorage.sol
+++ b/contracts/ronin/validator/storage-fragments/JailingStorage.sol
@@ -116,12 +116,12 @@ abstract contract JailingStorage is IJailingInfo {
   }
 
   /**
-   * @dev See {ITimingInfo-epochOf}
+   * @dev See `ITimingInfo-epochOf`
    */
   function epochOf(uint256 _block) public view virtual returns (uint256);
 
   /**
-   * @dev See {ITimingInfo-currentPeriod}
+   * @dev See `ITimingInfo-currentPeriod`
    */
   function currentPeriod() public view virtual returns (uint256);
 

--- a/test/integration/ActionSlashValidators.test.ts
+++ b/test/integration/ActionSlashValidators.test.ts
@@ -138,7 +138,7 @@ describe('[Integration] Slash validators', () => {
             value: slasheeInitStakingAmount,
           });
 
-        expect(await stakingContract.stakingAmountOf(slashee.address, slashee.address)).eq(slasheeInitStakingAmount);
+        expect(await stakingContract.getStakingAmount(slashee.address, slashee.address)).eq(slasheeInitStakingAmount);
 
         await EpochController.setTimestampToPeriodEnding();
         await mineBatchTxs(async () => {
@@ -194,7 +194,7 @@ describe('[Integration] Slash validators', () => {
 
       it('Should the Staking contract subtract staking amount from validator', async () => {
         let _expectingSlasheeStakingAmount = slasheeInitStakingAmount.sub(slashAmountForUnavailabilityTier2Threshold);
-        expect(await stakingContract.stakingAmountOf(slashee.address, slashee.address)).eq(
+        expect(await stakingContract.getStakingAmount(slashee.address, slashee.address)).eq(
           _expectingSlasheeStakingAmount
         );
       });
@@ -268,7 +268,7 @@ describe('[Integration] Slash validators', () => {
             value: slasheeInitStakingAmount,
           });
 
-        expect(await stakingContract.stakingAmountOf(slashee.address, slashee.address)).eq(slasheeInitStakingAmount);
+        expect(await stakingContract.getStakingAmount(slashee.address, slashee.address)).eq(slasheeInitStakingAmount);
 
         await EpochController.setTimestampToPeriodEnding();
         await mineBatchTxs(async () => {
@@ -323,7 +323,7 @@ describe('[Integration] Slash validators', () => {
 
         it('Should the Staking contract subtract staking amount from validator', async () => {
           let _expectingSlasheeStakingAmount = slasheeInitStakingAmount.sub(slashAmountForUnavailabilityTier2Threshold);
-          expect(await stakingContract.stakingAmountOf(slashee.address, slashee.address)).eq(
+          expect(await stakingContract.getStakingAmount(slashee.address, slashee.address)).eq(
             _expectingSlasheeStakingAmount
           );
         });

--- a/test/maintainance/Maintenance.test.ts
+++ b/test/maintainance/Maintenance.test.ts
@@ -255,7 +255,7 @@ describe('Maintenance test', () => {
       await expect(tx)
         .emit(maintenanceContract, 'MaintenanceScheduled')
         .withArgs(validatorCandidates[0].address, [startedAtBlock, endedAtBlock]);
-      expect(await maintenanceContract.scheduled(validatorCandidates[0].address)).true;
+      expect(await maintenanceContract.checkScheduled(validatorCandidates[0].address)).true;
     });
 
     it('Should not be able to schedule maintenance again', async () => {

--- a/test/slash/CreditScore.test.ts
+++ b/test/slash/CreditScore.test.ts
@@ -221,7 +221,7 @@ describe('Credit score and bail out test', () => {
       localScoreController.increaseAtWithUpperbound(0, maxCreditScore, 0);
       await validateScoreAt(0);
 
-      let _jailLeft = await validatorContract.jailedTimeLeft(validatorCandidates[0].address);
+      let _jailLeft = await validatorContract.getJailedTimeLeft(validatorCandidates[0].address);
       await network.provider.send('hardhat_mine', [_jailLeft.blockLeft_.toHexString(), '0x0']);
     });
     it('Should the score updated correctly, case: max score (y), in jail (N), unavailability (N)', async () => {
@@ -276,7 +276,7 @@ describe('Credit score and bail out test', () => {
 
       it('Should the bailing out cost subtracted correctly', async () => {
         let _latestBlockNum = BigNumber.from(await network.provider.send('eth_blockNumber'));
-        let _jailLeft = await validatorContract.jailedTimeLeftAtBlock(
+        let _jailLeft = await validatorContract.getJailedTimeLeftAtBlock(
           validatorCandidates[0].address,
           _latestBlockNum.add(1)
         );
@@ -361,7 +361,7 @@ describe('Credit score and bail out test', () => {
       });
 
       it('Should the slashed validator become block producer when jailed time over', async () => {
-        let _jailEpochLeft = (await validatorContract.jailedTimeLeft(validatorCandidates[0].address)).epochLeft_;
+        let _jailEpochLeft = (await validatorContract.getJailedTimeLeft(validatorCandidates[0].address)).epochLeft_;
         await endPeriodAndWrapUpAndResetIndicators(_jailEpochLeft.toNumber());
         expect(await validatorContract.isBlockProducer(validatorCandidates[0].address)).eq(true);
       });
@@ -381,7 +381,7 @@ describe('Credit score and bail out test', () => {
       });
 
       it('Should the bailing out cost subtracted correctly', async () => {
-        let _jailLeft = await validatorContract.jailedTimeLeft(validatorCandidates[0].address);
+        let _jailLeft = await validatorContract.getJailedTimeLeft(validatorCandidates[0].address);
         let tx = await slashContract.connect(candidateAdmins[0]).bailOut(validatorCandidates[0].address);
         let _period = validatorContract.currentPeriod();
 
@@ -457,7 +457,7 @@ describe('Credit score and bail out test', () => {
         expect(await validatorContract.isBlockProducer(validatorCandidates[0].address)).eq(true);
 
         let _latestBlockNum = BigNumber.from(await network.provider.send('eth_blockNumber'));
-        let _jailLeft = await validatorContract.jailedTimeLeftAtBlock(
+        let _jailLeft = await validatorContract.getJailedTimeLeftAtBlock(
           validatorCandidates[0].address,
           _latestBlockNum.add(1)
         );
@@ -495,7 +495,7 @@ describe('Credit score and bail out test', () => {
         await endPeriodAndWrapUpAndResetIndicators();
 
         let _latestBlockNum = BigNumber.from(await network.provider.send('eth_blockNumber'));
-        let _jailLeft = await validatorContract.jailedTimeLeftAtBlock(
+        let _jailLeft = await validatorContract.getJailedTimeLeftAtBlock(
           validatorCandidates[0].address,
           _latestBlockNum.add(1)
         );

--- a/test/staking/RewardCalculation.test.ts
+++ b/test/staking/RewardCalculation.test.ts
@@ -33,7 +33,7 @@ describe('Reward Calculation test', () => {
       await expect(txs[0]).not.emit(stakingContract, 'UserRewardUpdated');
       txs[0] = await stakingContract.stake(userA.address, 50);
       await expect(txs[0]).not.emit(stakingContract, 'UserRewardUpdated');
-      expect(await stakingContract.stakingAmountOf(poolAddr, userA.address)).eq(100);
+      expect(await stakingContract.getStakingAmount(poolAddr, userA.address)).eq(100);
     });
 
     it('Should be able to wrap up period for the first period', async () => {
@@ -49,7 +49,7 @@ describe('Reward Calculation test', () => {
       await expect(txs[0]).emit(stakingContract, 'PoolSharesUpdated').withArgs(period, poolAddr, 50);
       txs[0] = await stakingContract.stake(userA.address, 50);
       await expect(txs[0]).not.emit(stakingContract, 'UserRewardUpdated');
-      expect(await stakingContract.stakingAmountOf(poolAddr, userA.address)).eq(100);
+      expect(await stakingContract.getStakingAmount(poolAddr, userA.address)).eq(100);
     });
 
     it('Should be able to record reward for the pool', async () => {
@@ -126,13 +126,13 @@ describe('Reward Calculation test', () => {
       txs[0] = await stakingContract.unstake(userA.address, 350);
       await expect(txs[0]).not.emit(stakingContract, 'UserRewardUpdated');
       await expect(txs[0]).emit(stakingContract, 'PoolSharesUpdated').withArgs(period, poolAddr, 50);
-      expect(await stakingContract.stakingAmountOf(poolAddr, userA.address)).eq(50);
+      expect(await stakingContract.getStakingAmount(poolAddr, userA.address)).eq(50);
       txs[0] = await stakingContract.stake(userA.address, 250);
       await expect(txs[0]).not.emit(stakingContract, 'UserRewardUpdated');
 
       txs[1] = await stakingContract.stake(userB.address, 200);
       await expect(txs[1]).not.emit(stakingContract, 'UserRewardUpdated');
-      expect(await stakingContract.stakingAmountOf(poolAddr, userB.address)).eq(200);
+      expect(await stakingContract.getStakingAmount(poolAddr, userB.address)).eq(200);
     });
 
     it('Should be able to distribute reward based on the smallest amount in the last period', async () => {
@@ -163,12 +163,12 @@ describe('Reward Calculation test', () => {
       txs[0] = await stakingContract.unstake(userA.address, 250);
       await expect(txs[0]).emit(stakingContract, 'UserRewardUpdated').withArgs(poolAddr, userA.address, 1600);
       await expect(txs[0]).emit(stakingContract, 'PoolSharesUpdated').withArgs(period, poolAddr, 250);
-      expect(await stakingContract.stakingAmountOf(poolAddr, userA.address)).eq(50);
+      expect(await stakingContract.getStakingAmount(poolAddr, userA.address)).eq(50);
 
       txs[1] = await stakingContract.unstake(userB.address, 150);
       await expect(txs[1]).emit(stakingContract, 'UserRewardUpdated').withArgs(poolAddr, userB.address, 400);
       await expect(txs[1]).emit(stakingContract, 'PoolSharesUpdated').withArgs(period, poolAddr, 100);
-      expect(await stakingContract.stakingAmountOf(poolAddr, userB.address)).eq(50);
+      expect(await stakingContract.getStakingAmount(poolAddr, userB.address)).eq(50);
 
       aRps = aRps.add(MASK.mul(1000 / 100));
       await stakingContract.increaseReward(1000);
@@ -184,7 +184,7 @@ describe('Reward Calculation test', () => {
       txs[1] = await stakingContract.unstake(userB.address, 50);
       await expect(txs[1]).emit(stakingContract, 'PoolSharesUpdated').withArgs(period, poolAddr, 50);
       await expect(txs[1]).emit(stakingContract, 'UserRewardUpdated').withArgs(poolAddr, userB.address, 900);
-      expect(await stakingContract.stakingAmountOf(poolAddr, userB.address)).eq(0);
+      expect(await stakingContract.getStakingAmount(poolAddr, userB.address)).eq(0);
 
       aRps = aRps.add(MASK.mul(1000 / 50));
       await stakingContract.increaseReward(1000);
@@ -199,8 +199,8 @@ describe('Reward Calculation test', () => {
       txs[0] = await stakingContract.unstake(userA.address, 50);
       await expect(txs[0]).emit(stakingContract, 'PoolSharesUpdated').withArgs(period, poolAddr, 0);
       await expect(txs[0]).emit(stakingContract, 'UserRewardUpdated').withArgs(poolAddr, userA.address, 3100);
-      expect(await stakingContract.stakingAmountOf(poolAddr, userA.address)).eq(0);
-      expect(await stakingContract.stakingAmountOf(poolAddr, userB.address)).eq(0);
+      expect(await stakingContract.getStakingAmount(poolAddr, userA.address)).eq(0);
+      expect(await stakingContract.getStakingAmount(poolAddr, userB.address)).eq(0);
 
       aRps = aRps.add(0);
       await stakingContract.increaseReward(1000);

--- a/test/staking/RewardCalculation.test.ts
+++ b/test/staking/RewardCalculation.test.ts
@@ -142,7 +142,7 @@ describe('Reward Calculation test', () => {
       expect(await stakingContract.getReward(poolAddr, userA.address)).eq(1000);
       await expect(tx)
         .emit(stakingContract, 'PoolsUpdated')
-        .withArgs(period++, [poolAddr], [aRps], [await stakingContract.stakingTotal(poolAddr)]);
+        .withArgs(period++, [poolAddr], [aRps], [await stakingContract.getStakingTotal(poolAddr)]);
     });
   });
 
@@ -175,7 +175,7 @@ describe('Reward Calculation test', () => {
       tx = await stakingContract.endPeriod(); // period 5
       await expect(tx)
         .emit(stakingContract, 'PoolsUpdated')
-        .withArgs(period++, [poolAddr], [aRps], [await stakingContract.stakingTotal(poolAddr)]);
+        .withArgs(period++, [poolAddr], [aRps], [await stakingContract.getStakingTotal(poolAddr)]);
       expect(await stakingContract.getReward(poolAddr, userA.address)).eq(2100); // 50% of 1000 + 1600 from the last period
       expect(await stakingContract.getReward(poolAddr, userB.address)).eq(900); // 50% of 1000 + 400 from the last period
     });
@@ -191,7 +191,7 @@ describe('Reward Calculation test', () => {
       tx = await stakingContract.endPeriod(); // period 6
       await expect(tx)
         .emit(stakingContract, 'PoolsUpdated')
-        .withArgs(period++, [poolAddr], [aRps], [await stakingContract.stakingTotal(poolAddr)]);
+        .withArgs(period++, [poolAddr], [aRps], [await stakingContract.getStakingTotal(poolAddr)]);
       expect(await stakingContract.getReward(poolAddr, userA.address)).eq(3100); // 1000 + 2100 from the last period
     });
 

--- a/test/staking/Staking.test.ts
+++ b/test/staking/Staking.test.ts
@@ -80,7 +80,7 @@ describe('Staking test', () => {
       }
 
       poolAddr = validatorCandidates[1];
-      expect(await stakingContract.stakingTotal(poolAddr.address)).eq(minValidatorStakingAmount.mul(2));
+      expect(await stakingContract.getStakingTotal(poolAddr.address)).eq(minValidatorStakingAmount.mul(2));
     });
 
     it('Should not be able to propose validator again', async () => {
@@ -112,7 +112,7 @@ describe('Staking test', () => {
     it('Should be able to stake as a validator candidate', async () => {
       const tx = await stakingContract.connect(poolAddr).stake(poolAddr.address, { value: 1 });
       await expect(tx!).emit(stakingContract, 'Staked').withArgs(poolAddr.address, 1);
-      expect(await stakingContract.stakingTotal(poolAddr.address)).eq(minValidatorStakingAmount.mul(2).add(1));
+      expect(await stakingContract.getStakingTotal(poolAddr.address)).eq(minValidatorStakingAmount.mul(2).add(1));
     });
 
     it('Should not be able to unstake due to cooldown restriction', async () => {
@@ -125,7 +125,7 @@ describe('Staking test', () => {
       await network.provider.send('evm_increaseTime', [cooldownSecsToUndelegate + 1]);
       const tx = await stakingContract.connect(poolAddr).unstake(poolAddr.address, 1);
       await expect(tx!).emit(stakingContract, 'Unstaked').withArgs(poolAddr.address, 1);
-      expect(await stakingContract.stakingTotal(poolAddr.address)).eq(minValidatorStakingAmount.mul(2));
+      expect(await stakingContract.getStakingTotal(poolAddr.address)).eq(minValidatorStakingAmount.mul(2));
       expect(await stakingContract.getStakingAmount(poolAddr.address, poolAddr.address)).eq(
         minValidatorStakingAmount.mul(2)
       );
@@ -214,7 +214,7 @@ describe('Staking test', () => {
       tx = await stakingContract.connect(userB).delegate(otherPoolAddr.address, { value: 1 });
       await expect(tx!).emit(stakingContract, 'Delegated').withArgs(userB.address, otherPoolAddr.address, 1);
 
-      expect(await stakingContract.stakingTotal(otherPoolAddr.address)).eq(minValidatorStakingAmount.mul(2).add(2));
+      expect(await stakingContract.getStakingTotal(otherPoolAddr.address)).eq(minValidatorStakingAmount.mul(2).add(2));
     });
 
     it('Should not be able to undelegate due to cooldown restriction', async () => {
@@ -227,7 +227,7 @@ describe('Staking test', () => {
       await network.provider.send('evm_increaseTime', [cooldownSecsToUndelegate + 1]);
       const tx = await stakingContract.connect(userA).undelegate(otherPoolAddr.address, 1);
       await expect(tx!).emit(stakingContract, 'Undelegated').withArgs(userA.address, otherPoolAddr.address, 1);
-      expect(await stakingContract.stakingTotal(otherPoolAddr.address)).eq(minValidatorStakingAmount.mul(2).add(1));
+      expect(await stakingContract.getStakingTotal(otherPoolAddr.address)).eq(minValidatorStakingAmount.mul(2).add(1));
     });
 
     it('Should not be able to undelegate with empty amount', async () => {

--- a/test/staking/Staking.test.ts
+++ b/test/staking/Staking.test.ts
@@ -126,17 +126,17 @@ describe('Staking test', () => {
       const tx = await stakingContract.connect(poolAddr).unstake(poolAddr.address, 1);
       await expect(tx!).emit(stakingContract, 'Unstaked').withArgs(poolAddr.address, 1);
       expect(await stakingContract.stakingTotal(poolAddr.address)).eq(minValidatorStakingAmount.mul(2));
-      expect(await stakingContract.stakingAmountOf(poolAddr.address, poolAddr.address)).eq(
+      expect(await stakingContract.getStakingAmount(poolAddr.address, poolAddr.address)).eq(
         minValidatorStakingAmount.mul(2)
       );
     });
 
     it('[Delegator] Should be able to delegate/undelegate to a validator candidate', async () => {
       await stakingContract.delegate(poolAddr.address, { value: 10 });
-      expect(await stakingContract.stakingAmountOf(poolAddr.address, deployer.address)).eq(10);
+      expect(await stakingContract.getStakingAmount(poolAddr.address, deployer.address)).eq(10);
       await network.provider.send('evm_increaseTime', [cooldownSecsToUndelegate + 1]);
       await stakingContract.undelegate(poolAddr.address, 1);
-      expect(await stakingContract.stakingAmountOf(poolAddr.address, deployer.address)).eq(9);
+      expect(await stakingContract.getStakingAmount(poolAddr.address, deployer.address)).eq(9);
     });
 
     it('Should be not able to unstake with the balance left is not larger than the minimum balance threshold', async () => {
@@ -184,7 +184,7 @@ describe('Staking test', () => {
 
     it('Should be able to undelegate from a deprecated validator candidate', async () => {
       await stakingContract.undelegate(poolAddr.address, 1);
-      expect(await stakingContract.stakingAmountOf(poolAddr.address, deployer.address)).eq(8);
+      expect(await stakingContract.getStakingAmount(poolAddr.address, deployer.address)).eq(8);
     });
 
     it('Should not be able to delegate to a deprecated pool', async () => {
@@ -258,12 +258,12 @@ describe('Staking test', () => {
         minValidatorStakingAmount,
         minValidatorStakingAmount.add(8),
       ]);
-      expect(await stakingContract.stakingAmountOf(poolAddr.address, deployer.address)).eq(8);
+      expect(await stakingContract.getStakingAmount(poolAddr.address, deployer.address)).eq(8);
     });
 
     it('Should be able to delegate/undelegate for the rejoined candidate', async () => {
       await stakingContract.delegate(poolAddr.address, { value: 2 });
-      expect(await stakingContract.stakingAmountOf(poolAddr.address, deployer.address)).eq(10);
+      expect(await stakingContract.getStakingAmount(poolAddr.address, deployer.address)).eq(10);
 
       await stakingContract.connect(userA).delegate(poolAddr.address, { value: 2 });
       await stakingContract.connect(userB).delegate(poolAddr.address, { value: 2 });

--- a/test/staking/Staking.test.ts
+++ b/test/staking/Staking.test.ts
@@ -268,14 +268,20 @@ describe('Staking test', () => {
       await stakingContract.connect(userA).delegate(poolAddr.address, { value: 2 });
       await stakingContract.connect(userB).delegate(poolAddr.address, { value: 2 });
       expect(
-        await stakingContract.bulkStakingAmountOf([poolAddr.address, poolAddr.address], [userA.address, userB.address])
+        await stakingContract.getManyStakingAmounts(
+          [poolAddr.address, poolAddr.address],
+          [userA.address, userB.address]
+        )
       ).eql([2, 2].map(BigNumber.from));
 
       await network.provider.send('evm_increaseTime', [cooldownSecsToUndelegate + 1]);
       await stakingContract.connect(userA).undelegate(poolAddr.address, 2);
       await stakingContract.connect(userB).undelegate(poolAddr.address, 1);
       expect(
-        await stakingContract.bulkStakingAmountOf([poolAddr.address, poolAddr.address], [userA.address, userB.address])
+        await stakingContract.getManyStakingAmounts(
+          [poolAddr.address, poolAddr.address],
+          [userA.address, userB.address]
+        )
       ).eql([0, 1].map(BigNumber.from));
     });
   });


### PR DESCRIPTION
### Description
- Revamp function names (#48)
- Normalize comments
- Standardize getter name: `(check|get)(Many|)<action name>`

**ABI Changes:**
- Change `bulkTotalBallotsOf` to `getManyTotalBallots`
- Change `maintaining` to `checkMaintained `
- Change `bulkMaintaining` to `checkManyMaintained`
- Change `bulkMaintainingInBlockRange` to `checkManyMaintainedInBlockRange`
- Change `stakingAmountOf` to `getStakingAmount`
- Change `bulkStakingAmountOf` to `getManyStakingAmounts`
- Change `stakingTotal` to `getStakingTotal`
- Change `bulkStakingTotal` to `getManyStakingTotals`
- Change `getBulkCreditScore` to `getManyCreditScores`
- Change `bulkSelfStaking` to `getManySelfStakings`
- Change `jailed` to `checkJailed`
- Change `bulkJailed` to `checkManyJailed`
- Change `jailedTimeLeft` to `getJailedTimeLeft`
- Change `jailedAtBlock` to `checkJailedAtBlock`
- Change `jailedTimeLeftAtBlock` to `getJailedTimeLeftAtBlock`
- Change `miningRewardDeprecated` to `checkMiningRewardDeprecated`
- Change `miningRewardDeprecatedAtPeriod` to `checkMiningRewardDeprecatedAtPeriod`
- Change `scheduled` to `checkScheduled`
- Change `bailedOutAtPeriod` to `checkBailedOutAtPeriod`


### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
