### PR TITLE
Upgrade solc version. Allow unlimited contract size on hardhat net.

### DIFF
--- a/contracts/mocks/validator/MockRoninValidatorSetExtended.sol
+++ b/contracts/mocks/validator/MockRoninValidatorSetExtended.sol
@@ -23,7 +23,7 @@ contract MockRoninValidatorSetExtended is MockRoninValidatorSetOverridePrecompil
     }
   }
 
-  function epochEndingAt(uint256 _block) public view override returns (bool) {
+  function epochEndingAt(uint256 _block) public view override(ITimingInfo, TimingStorage) returns (bool) {
     for (uint _i = 0; _i < _epochs.length; _i++) {
       if (_block == _epochs[_i]) {
         return true;

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -12,7 +12,8 @@ dotenv.config();
 
 const DEFAULT_MNEMONIC = 'title spike pink garlic hamster sorry few damage silver mushroom clever window';
 
-const { REPORT_GAS, DEVNET_PK, DEVNET_URL, TESTNET_PK, TESTNET_URL, MAINNET_PK, MAINNET_URL, GOERLI_URL, GOERLI_PK } = process.env;
+const { REPORT_GAS, DEVNET_PK, DEVNET_URL, TESTNET_PK, TESTNET_URL, MAINNET_PK, MAINNET_URL, GOERLI_URL, GOERLI_PK } =
+  process.env;
 
 if (!DEVNET_PK) {
   console.warn('DEVNET_PK is unset. Using DEFAULT_MNEMONIC');
@@ -62,11 +63,11 @@ const goerli: NetworkUserConfig = {
 };
 
 const compilerConfig: SolcUserConfig = {
-  version: '0.8.9',
+  version: '0.8.16',
   settings: {
     optimizer: {
       enabled: true,
-      runs: 200,
+      runs: 5000,
     },
   },
 };
@@ -98,7 +99,7 @@ const config: HardhatUserConfig = {
     'ronin-devnet': devnet,
     'ronin-testnet': testnet,
     'ronin-mainnet': mainnet,
-    'goerli': goerli,
+    goerli: goerli,
   },
   gasReporter: {
     enabled: REPORT_GAS ? true : false,

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -94,12 +94,13 @@ const config: HardhatUserConfig = {
         count: 100,
         accountsBalance: '1000000000000000000000000000', // 1B RON
       },
+      allowUnlimitedContractSize: true,
     },
     local,
     'ronin-devnet': devnet,
     'ronin-testnet': testnet,
     'ronin-mainnet': mainnet,
-    goerli: goerli,
+    goerli,
   },
   gasReporter: {
     enabled: REPORT_GAS ? true : false,

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -63,7 +63,7 @@ const goerli: NetworkUserConfig = {
 };
 
 const compilerConfig: SolcUserConfig = {
-  version: '0.8.16',
+  version: '0.8.17',
   settings: {
     optimizer: {
       enabled: true,

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -67,7 +67,7 @@ const compilerConfig: SolcUserConfig = {
   settings: {
     optimizer: {
       enabled: true,
-      runs: 5000,
+      runs: 200,
     },
   },
 };


### PR DESCRIPTION
### Description
- Continue work in #89 
- Allow unlimited contract size on hardhat network to pass compilation of mocking of validator set contract.

### Notices
- [ ] Should write package script to check the size of the non-mock contract that should not exceed maximum Ethereum contract size (~24KB)
- [ ] Should upgrade hardhat version to remove outdated warning of v0.8.17
