### PR TITLE
[Staking] Disallow validators to delegate to other validator

### DIFF
--- a/contracts/ronin/staking/DelegatorStaking.sol
+++ b/contracts/ronin/staking/DelegatorStaking.sol
@@ -16,6 +16,12 @@ abstract contract DelegatorStaking is BaseStaking, IDelegatorStaking {
    * @inheritdoc IDelegatorStaking
    */
   function delegate(address _consensusAddr) external payable noEmptyValue poolExists(_consensusAddr) {
+    address[] memory _currValidatorList = _validatorContract.getValidatorCandidates();
+    for (uint _i = 0; _i < _currValidatorList.length; _i++) {
+      PoolDetail storage _pool = _stakingPool[_currValidatorList[_i]];
+      require(msg.sender != _pool.admin, "DelegatorStaking: admin of an arbitrary pool cannot delegate");
+    }
+
     _delegate(_stakingPool[_consensusAddr], msg.sender, msg.value);
   }
 

--- a/test/staking/Staking.test.ts
+++ b/test/staking/Staking.test.ts
@@ -21,6 +21,7 @@ let userA: SignerWithAddress;
 let userB: SignerWithAddress;
 let poolAddr: ValidatorCandidateAddressSet;
 let otherPoolAddr: ValidatorCandidateAddressSet;
+let anotherActivePool: ValidatorCandidateAddressSet;
 
 let validatorContract: MockValidatorSet;
 let stakingContract: Staking;
@@ -76,7 +77,7 @@ describe('Staking test', () => {
     });
 
     it('Should be able to propose validator with sufficient amount', async () => {
-      for (let i = 1; i < validatorCandidates.length; i++) {
+      for (let i = 0; i < validatorCandidates.length; i++) {
         const candidate = validatorCandidates[i];
         const tx = await stakingContract
           .connect(candidate.poolAdmin)
@@ -93,7 +94,7 @@ describe('Staking test', () => {
           .withArgs(candidate.consensusAddr.address, candidate.poolAdmin.address);
       }
 
-      poolAddr = validatorCandidates[1];
+      poolAddr = validatorCandidates[0];
       expect(await stakingContract.getStakingTotal(poolAddr.consensusAddr.address)).eq(
         minValidatorStakingAmount.mul(2)
       );
@@ -208,7 +209,8 @@ describe('Staking test', () => {
 
   describe('Delegator test', () => {
     before(() => {
-      otherPoolAddr = validatorCandidates[2];
+      otherPoolAddr = validatorCandidates[1];
+      anotherActivePool = validatorCandidates[2];
     });
 
     it('Should be able to undelegate from a deprecated validator candidate', async () => {
@@ -231,10 +233,19 @@ describe('Staking test', () => {
     it('Should not be able to delegate/undelegate when the method caller is the pool admin', async () => {
       await expect(
         stakingContract.connect(otherPoolAddr.poolAdmin).delegate(otherPoolAddr.consensusAddr.address, { value: 1 })
-      ).revertedWith('BaseStaking: delegator must not be the pool admin');
+      ).revertedWith('DelegatorStaking: admin of an arbitrary pool cannot delegate');
       await expect(
         stakingContract.connect(otherPoolAddr.poolAdmin).undelegate(otherPoolAddr.consensusAddr.address, 1)
       ).revertedWith('BaseStaking: delegator must not be the pool admin');
+    });
+
+    it('Should not be able to delegate when the method caller is the admin of any arbitrary pool', async () => {
+      await expect(
+        stakingContract.connect(anotherActivePool.poolAdmin).delegate(otherPoolAddr.consensusAddr.address, { value: 1 })
+      ).revertedWith('DelegatorStaking: admin of an arbitrary pool cannot delegate');
+      await expect(
+        stakingContract.connect(otherPoolAddr.poolAdmin).delegate(anotherActivePool.consensusAddr.address, { value: 1 })
+      ).revertedWith('DelegatorStaking: admin of an arbitrary pool cannot delegate');
     });
 
     it('Should multiple accounts be able to delegate to one pool', async () => {


### PR DESCRIPTION
### Description
- https://skymavis.atlassian.net/browse/PSC-106?atlOrigin=eyJpIjoiN2UzY2MzM2I2NjVmNDg2MzkzZGJjNzFlNjFiMTYxOWIiLCJwIjoiaiJ9

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
