### PR TITLE
[ValidatorSet] Recycle deprecated rewards

### DIFF
--- a/contracts/interfaces/staking/ICandidateStaking.sol
+++ b/contracts/interfaces/staking/ICandidateStaking.sol
@@ -24,7 +24,7 @@ interface ICandidateStaking is IRewardPool {
     uint256 amount,
     uint256 contractBalance
   );
-  /// @dev Emitted when the staking amount deducted failed.
+  /// @dev Emitted when the staking amount deducted failed, e.g. when the validator gets slashed.
   event StakingAmountDeductFailed(
     address indexed validator,
     address indexed recipient,

--- a/contracts/interfaces/staking/ICandidateStaking.sol
+++ b/contracts/interfaces/staking/ICandidateStaking.sol
@@ -24,6 +24,13 @@ interface ICandidateStaking is IRewardPool {
     uint256 amount,
     uint256 contractBalance
   );
+  /// @dev Emitted when the staking amount deducted failed.
+  event StakingAmountDeductFailed(
+    address indexed validator,
+    address indexed recipient,
+    uint256 amount,
+    uint256 contractBalance
+  );
 
   /**
    * @dev Returns the minimum threshold for being a validator candidate.

--- a/contracts/interfaces/staking/IStaking.sol
+++ b/contracts/interfaces/staking/IStaking.sol
@@ -35,7 +35,9 @@ interface IStaking is IRewardPool, IBaseStaking, ICandidateStaking, IDelegatorSt
    * Emits the event `Unstaked`.
    *
    */
-  function deductStakingAmount(address _consensusAddr, uint256 _amount) external;
+  function deductStakingAmount(address _consensusAddr, uint256 _amount)
+    external
+    returns (uint256 _actualDeductingAmount);
 
   /**
    * @dev Returns the staking pool detail.

--- a/contracts/interfaces/validator/info-fragments/ICommonInfo.sol
+++ b/contracts/interfaces/validator/info-fragments/ICommonInfo.sol
@@ -8,7 +8,9 @@ import "./IValidatorInfo.sol";
 
 interface ICommonInfo is ITimingInfo, IJailingInfo, IValidatorInfo {
   /// @dev Emitted when the deprecated reward is withdrawn.
-  event DeprecatedRewardWithdrawn(address indexed recipientAddr, uint256 amount);
+  event DeprecatedRewardRecycled(address indexed recipientAddr, uint256 amount);
+  /// @dev Emitted when the deprecated reward withdrawal is failed
+  event DeprecatedRewardRecycleFailed(address indexed recipientAddr, uint256 amount, uint256 balance);
 
   /**
    * @dev Returns the total deprecated reward, which includes reward that is not sent for slashed validators and unsastified bridge operators

--- a/contracts/ronin/staking/CandidateStaking.sol
+++ b/contracts/ronin/staking/CandidateStaking.sol
@@ -185,8 +185,9 @@ abstract contract CandidateStaking is BaseStaking, ICandidateStaking {
    *
    * Emits the event `Unstaked`.
    *
+   * @return The actual deducted amount
    */
-  function _deductStakingAmount(PoolDetail storage _pool, uint256 _amount) internal virtual;
+  function _deductStakingAmount(PoolDetail storage _pool, uint256 _amount) internal virtual returns (uint256);
 
   /**
    * @dev Sets the minimum threshold for being a validator candidate.

--- a/contracts/ronin/staking/Staking.sol
+++ b/contracts/ronin/staking/Staking.sol
@@ -73,10 +73,14 @@ contract Staking is IStaking, CandidateStaking, DelegatorStaking, Initializable 
   /**
    * @inheritdoc IStaking
    */
-  function deductStakingAmount(address _consensusAddr, uint256 _amount) external onlyValidatorContract {
-    uint256 _actualDeductingAmount = _deductStakingAmount(_stakingPool[_consensusAddr], _amount);
+  function deductStakingAmount(address _consensusAddr, uint256 _amount)
+    external
+    onlyValidatorContract
+    returns (uint256 _actualDeductingAmount)
+  {
+    _actualDeductingAmount = _deductStakingAmount(_stakingPool[_consensusAddr], _amount);
     address payable _recipientAddr = payable(validatorContract());
-    if (!_unsafeSendRON(_recipientAddr, _amount)) {
+    if (!_unsafeSendRON(_recipientAddr, _actualDeductingAmount)) {
       emit StakingAmountDeductFailed(_consensusAddr, _recipientAddr, _actualDeductingAmount, address(this).balance);
     }
   }

--- a/contracts/ronin/staking/Staking.sol
+++ b/contracts/ronin/staking/Staking.sol
@@ -76,8 +76,8 @@ contract Staking is IStaking, CandidateStaking, DelegatorStaking, Initializable 
   function deductStakingAmount(address _consensusAddr, uint256 _amount) external onlyValidatorContract {
     uint256 _actualDeductingAmount = _deductStakingAmount(_stakingPool[_consensusAddr], _amount);
     address payable _recipientAddr = payable(validatorContract());
-    if (!_unsafeSendRON(_recipientAddr, _actualDeductingAmount)) {
-      emit StakingAmountTransferFailed(_consensusAddr, _recipientAddr, _actualDeductingAmount, address(this).balance);
+    if (!_unsafeSendRON(_recipientAddr, _amount)) {
+      emit StakingAmountDeductFailed(_consensusAddr, _recipientAddr, _actualDeductingAmount, address(this).balance);
     }
   }
 

--- a/contracts/ronin/staking/Staking.sol
+++ b/contracts/ronin/staking/Staking.sol
@@ -76,7 +76,7 @@ contract Staking is IStaking, CandidateStaking, DelegatorStaking, Initializable 
   function deductStakingAmount(address _consensusAddr, uint256 _amount) external onlyValidatorContract {
     uint256 _actualDeductingAmount = _deductStakingAmount(_stakingPool[_consensusAddr], _amount);
     address payable _recipientAddr = payable(validatorContract());
-    if (!_unsafeSendRON(_recipientAddr, _amount)) {
+    if (!_unsafeSendRON(_recipientAddr, _actualDeductingAmount)) {
       emit StakingAmountTransferFailed(_consensusAddr, _recipientAddr, _actualDeductingAmount, address(this).balance);
     }
   }

--- a/contracts/ronin/validator/CoinbaseExecution.sol
+++ b/contracts/ronin/validator/CoinbaseExecution.sol
@@ -332,7 +332,7 @@ abstract contract CoinbaseExecution is
     if (_withdrawAmount != 0) {
       address _withdrawTarget = stakingVestingContract();
 
-      _totalDeprecatedReward = 0;
+      delete _totalDeprecatedReward;
 
       (bool _success, ) = _withdrawTarget.call{ value: _withdrawAmount }(
         abi.encodeWithSelector(IStakingVesting.receiveRON.selector)

--- a/contracts/ronin/validator/RoninValidatorSet.sol
+++ b/contracts/ronin/validator/RoninValidatorSet.sol
@@ -48,34 +48,13 @@ contract RoninValidatorSet is Initializable, CoinbaseExecution, SlashingExecutio
   }
 
   /**
-   * @dev Withdraw the deprecated rewards e.g. the rewards that get deprecated when validator is slashed, maintained.
-   * The withdraw target is the staking vesting contract.
-   *
-   * Requirement:
-   * - The method caller must be the admin
-   */
-  function withdrawDeprecatedReward() external onlyAdmin {
-    uint256 _withdrawAmount = _totalDeprecatedReward;
-    address _withdrawTarget = stakingVestingContract();
-
-    _totalDeprecatedReward = 0;
-
-    (bool _success, ) = _withdrawTarget.call{ value: _withdrawAmount }(
-      abi.encodeWithSelector(IStakingVesting.receiveRON.selector)
-    );
-
-    require(_success, "RoninValidatorSet: cannot transfer deprecated reward to staking vesting contract");
-
-    emit DeprecatedRewardWithdrawn(_withdrawTarget, _withdrawAmount);
-  }
-
-  /**
-   * @dev Only receives RON from staking vesting contract.
+   * @dev Only receives RON from staking vesting contract (for topping up bonus), and from staking contract (for transferring
+   * deducting amount when slash).
    */
   function _fallback() internal view {
     require(
-      msg.sender == stakingVestingContract(),
-      "RoninValidatorSet: only receives RON from staking vesting contract"
+      msg.sender == stakingVestingContract() || msg.sender == stakingContract(),
+      "RoninValidatorSet: only receives RON from staking vesting contract or staking contract"
     );
   }
 

--- a/contracts/ronin/validator/SlashingExecution.sol
+++ b/contracts/ronin/validator/SlashingExecution.sol
@@ -35,6 +35,7 @@ abstract contract SlashingExecution is
 
     if (_slashAmount > 0) {
       _stakingContract.deductStakingAmount(_validatorAddr, _slashAmount);
+      _totalDeprecatedReward += _slashAmount;
     }
 
     emit ValidatorPunished(_validatorAddr, _period, _jailedUntil[_validatorAddr], _slashAmount, true, false);

--- a/contracts/ronin/validator/SlashingExecution.sol
+++ b/contracts/ronin/validator/SlashingExecution.sol
@@ -34,8 +34,8 @@ abstract contract SlashingExecution is
     }
 
     if (_slashAmount > 0) {
-      _stakingContract.deductStakingAmount(_validatorAddr, _slashAmount);
-      _totalDeprecatedReward += _slashAmount;
+      uint256 _actualAmount = _stakingContract.deductStakingAmount(_validatorAddr, _slashAmount);
+      _totalDeprecatedReward += _actualAmount;
     }
 
     emit ValidatorPunished(_validatorAddr, _period, _jailedUntil[_validatorAddr], _slashAmount, true, false);

--- a/test/helpers/ronin-validator-set.ts
+++ b/test/helpers/ronin-validator-set.ts
@@ -188,14 +188,14 @@ export const expects = {
     );
   },
 
-  emitDeprecatedRewardWithdrawnEvent: async function (
+  emitDeprecatedRewardRecycledEvent: async function (
     tx: ContractTransaction,
     expectingWithdrawnTarget: string,
     expectingWithdrawnAmount: BigNumberish
   ) {
     await expectEvent(
       contractInterface,
-      'DeprecatedRewardWithdrawn',
+      'DeprecatedRewardRecycled',
       tx,
       (event) => {
         expect(event.args[0], 'invalid withdraw target').eq(expectingWithdrawnTarget);


### PR DESCRIPTION
### Description
- https://skymavis.atlassian.net/browse/PSC-107?atlOrigin=eyJpIjoiM2YxYjNhNTMwYzk1NDYzZjhhNjhiNTY2ZThkMGM4YTQiLCJwIjoiaiJ9
- Recycle slashed staking amount / jailed reward amount / deprecated submitted reward -> staking vesting contract
- The recycle is done at the end of every period

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
