### PR TITLE
[Staking|CandidateManager] Allow pool admin to update commission rate of validator

### DIFF
--- a/contracts/interfaces/staking/ICandidateStaking.sol
+++ b/contracts/interfaces/staking/ICandidateStaking.sol
@@ -101,6 +101,20 @@ interface ICandidateStaking is IRewardPool {
   function unstake(address _consensusAddr, uint256 _amount) external;
 
   /**
+   * @dev Pool admin requests update validator commission rate. The request will be forwarded to the candidate manager
+   * contract, and the value is getting updated in {ICandidateManager-execUpdateCommissionRate}.
+   *
+   * Requirements:
+   * - The consensus address is a validator candidate.
+   * - The method caller is the pool admin.
+   * - The `_rate` must be in range of [0_00; 100_00].
+   *
+   * Emits the event `CommissionRateUpdated`.
+   *
+   */
+  function requestUpdateCommissionRate(address _consensusAddr, uint256 _rate) external;
+
+  /**
    * @dev Renounces being a validator candidate and takes back the delegating/staking amount.
    *
    * Requirements:

--- a/contracts/interfaces/validator/ICandidateManager.sol
+++ b/contracts/interfaces/validator/ICandidateManager.sol
@@ -37,6 +37,9 @@ interface ICandidateManager {
   /// @dev Emitted when the validator candidate is revoked.
   event CandidatesRevoked(address[] consensusAddrs);
 
+  /// @dev Emitted when the commission rate of a validator is updated.
+  event CommissionRateUpdated(address consensusAddr, uint256 rate);
+
   /**
    * @dev Returns the maximum number of validator candidate.
    */
@@ -80,6 +83,18 @@ interface ICandidateManager {
    *
    */
   function requestRevokeCandidate(address, uint256 _secsLeft) external;
+
+  /**
+   * @dev Fallback function of `{CandidateStaking-requestUpdateCommissionRate}`.
+   *
+   * Requirements:
+   * - The method caller is the staking contract.
+   * - The `_rate` must be in range of [0_00; 100_00].
+   *
+   * Emits the event `CommissionRateUpdated`.
+   *
+   */
+  function execUpdateCommissionRate(address _consensusAddr, uint256 _rate) external;
 
   /**
    * @dev Returns whether the address is a validator (candidate).

--- a/contracts/interfaces/validator/ICandidateManager.sol
+++ b/contracts/interfaces/validator/ICandidateManager.sol
@@ -85,7 +85,7 @@ interface ICandidateManager {
   function requestRevokeCandidate(address, uint256 _secsLeft) external;
 
   /**
-   * @dev Fallback function of `{CandidateStaking-requestUpdateCommissionRate}`.
+   * @dev Fallback function of `CandidateStaking-requestUpdateCommissionRate`.
    *
    * Requirements:
    * - The method caller is the staking contract.

--- a/contracts/interfaces/validator/ICandidateManager.sol
+++ b/contracts/interfaces/validator/ICandidateManager.sol
@@ -38,7 +38,7 @@ interface ICandidateManager {
   event CandidatesRevoked(address[] consensusAddrs);
 
   /// @dev Emitted when the commission rate of a validator is updated.
-  event CommissionRateUpdated(address consensusAddr, uint256 rate);
+  event CommissionRateUpdated(address indexed consensusAddr, uint256 rate);
 
   /**
    * @dev Returns the maximum number of validator candidate.

--- a/contracts/ronin/staking/CandidateStaking.sol
+++ b/contracts/ronin/staking/CandidateStaking.sol
@@ -62,6 +62,18 @@ abstract contract CandidateStaking is BaseStaking, ICandidateStaking {
   /**
    * @inheritdoc ICandidateStaking
    */
+  function requestUpdateCommissionRate(address _consensusAddr, uint256 _rate)
+    external
+    override
+    poolExists(_consensusAddr)
+    onlyPoolAdmin(_stakingPool[_consensusAddr], msg.sender)
+  {
+    _validatorContract.execUpdateCommissionRate(_consensusAddr, _rate);
+  }
+
+  /**
+   * @inheritdoc ICandidateStaking
+   */
   function deprecatePools(address[] calldata _pools) external override onlyValidatorContract {
     if (_pools.length == 0) {
       return;

--- a/contracts/ronin/staking/CandidateStaking.sol
+++ b/contracts/ronin/staking/CandidateStaking.sol
@@ -108,6 +108,7 @@ abstract contract CandidateStaking is BaseStaking, ICandidateStaking {
    */
   function requestRenounce(address _consensusAddr)
     external
+    override
     poolExists(_consensusAddr)
     onlyPoolAdmin(_stakingPool[_consensusAddr], msg.sender)
   {

--- a/test/staking/Staking.test.ts
+++ b/test/staking/Staking.test.ts
@@ -7,12 +7,7 @@ import { Staking, Staking__factory, TransparentUpgradeableProxyV2__factory } fro
 import { MockValidatorSet__factory } from '../../src/types/factories/MockValidatorSet__factory';
 import { StakingVesting__factory } from '../../src/types/factories/StakingVesting__factory';
 import { MockValidatorSet } from '../../src/types/MockValidatorSet';
-import {
-  createManyTrustedOrganizationAddressSets,
-  createManyValidatorCandidateAddressSets,
-  TrustedOrganizationAddressSet,
-  ValidatorCandidateAddressSet,
-} from '../helpers/address-set-types';
+import { createManyValidatorCandidateAddressSets, ValidatorCandidateAddressSet } from '../helpers/address-set-types';
 
 let deployer: SignerWithAddress;
 
@@ -25,7 +20,6 @@ let otherPoolAddr: ValidatorCandidateAddressSet;
 let validatorContract: MockValidatorSet;
 let stakingContract: Staking;
 let signers: SignerWithAddress[];
-let trustedOrgs: TrustedOrganizationAddressSet[];
 let validatorCandidates: ValidatorCandidateAddressSet[];
 
 const minValidatorStakingAmount = BigNumber.from(20);
@@ -37,7 +31,6 @@ const waitingSecsToRevoke = 7 * 86400;
 describe('Staking test', () => {
   before(async () => {
     [deployer, proxyAdmin, userA, userB, ...signers] = await ethers.getSigners();
-    trustedOrgs = createManyTrustedOrganizationAddressSets(signers.splice(0, 3));
     validatorCandidates = createManyValidatorCandidateAddressSets(signers.slice(0, 3 * 5));
 
     const stakingVestingContract = await new StakingVesting__factory(deployer).deploy();
@@ -178,6 +171,27 @@ describe('Staking test', () => {
       await expect(stakingContract.connect(deployer).requestRenounce(poolAddr.consensusAddr.address)).revertedWith(
         'BaseStaking: requester must be the pool admin'
       );
+    });
+
+    it('Should the pool admin be able to update the commission rate', async () => {
+      let tx = stakingContract.connect(poolAddr.poolAdmin).requestUpdateCommissionRate(
+        poolAddr.consensusAddr.address,
+        20_00 // 20%
+      );
+
+      await expect(tx).emit(validatorContract, 'CommissionRateUpdated').withArgs(poolAddr.consensusAddr.address, 20_00);
+
+      let _info = await validatorContract.getCandidateInfo(poolAddr.consensusAddr.address);
+      await expect(_info.commissionRate).eq(20_00);
+    });
+
+    it('Should the non-pool-admin not be able to update the commission rate', async () => {
+      await expect(
+        stakingContract.connect(poolAddr.bridgeOperator).requestUpdateCommissionRate(
+          poolAddr.consensusAddr.address,
+          20_00 // 20%
+        )
+      ).revertedWith('BaseStaking: requester must be the pool admin');
     });
 
     it('Should be able to request renounce using pool admin', async () => {


### PR DESCRIPTION
### Description
- https://skymavis.atlassian.net/browse/PSC-108?atlOrigin=eyJpIjoiM2EyZDZmODE2OTZmNGJmNjk4Y2Q5M2IwOGJiY2QxOTIiLCJwIjoiaiJ9
- Allow pool admin to update the commission rate of a validator

### New ABI
- `requestUpdateCommissionRate(address _consensusAddr, uint256 _rate)`

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
