### PR TITLE
[CandidateManager] Implement effective date for commission rate

### DIFF
--- a/contracts/interfaces/staking/ICandidateStaking.sol
+++ b/contracts/interfaces/staking/ICandidateStaking.sol
@@ -109,17 +109,22 @@ interface ICandidateStaking is IRewardPool {
 
   /**
    * @dev Pool admin requests update validator commission rate. The request will be forwarded to the candidate manager
-   * contract, and the value is getting updated in {ICandidateManager-execUpdateCommissionRate}.
+   * contract, and the value is getting updated in {ICandidateManager-execRequestUpdateCommissionRate}.
    *
    * Requirements:
    * - The consensus address is a validator candidate.
    * - The method caller is the pool admin.
+   * - The `_effectiveDaysOnwards` must be equal to or larger than the {CandidateManager-_minEffectiveDaysOnwards}.
    * - The `_rate` must be in range of [0_00; 100_00].
    *
    * Emits the event `CommissionRateUpdated`.
    *
    */
-  function requestUpdateCommissionRate(address _consensusAddr, uint256 _rate) external;
+  function requestUpdateCommissionRate(
+    address _consensusAddr,
+    uint256 _effectiveDaysOnwards,
+    uint256 _commissionRate
+  ) external;
 
   /**
    * @dev Renounces being a validator candidate and takes back the delegating/staking amount.

--- a/contracts/interfaces/validator/ICandidateManager.sol
+++ b/contracts/interfaces/validator/ICandidateManager.sol
@@ -57,6 +57,11 @@ interface ICandidateManager {
   function maxValidatorCandidate() external view returns (uint256);
 
   /**
+   * @dev Returns the minimum number of days to the effective date of commission rate change.
+   */
+  function minEffectiveDaysOnwards() external view returns (uint256);
+
+  /**
    * @dev Sets the maximum number of validator candidate.
    *
    * Requirements:

--- a/contracts/interfaces/validator/ICandidateManager.sol
+++ b/contracts/interfaces/validator/ICandidateManager.sol
@@ -22,7 +22,7 @@ interface ICandidateManager {
   }
 
   struct CommissionSchedule {
-    // The timestamp that the commission schedule gets affected.
+    // The timestamp that the commission schedule gets affected (no schedule=0).
     uint256 effectiveTimestamp;
     // The new commission rate. Value is in range [0; 100_00], stands for 0-100%
     uint256 commissionRate;

--- a/contracts/interfaces/validator/ICandidateManager.sol
+++ b/contracts/interfaces/validator/ICandidateManager.sol
@@ -24,7 +24,7 @@ interface ICandidateManager {
   struct CommissionSchedule {
     // The timestamp that the commission schedule gets affected.
     uint256 effectiveTimestamp;
-    // The new commission rate.
+    // The new commission rate. Value is in range [0; 100_00], stands for 0-100%
     uint256 commissionRate;
   }
 

--- a/contracts/mocks/validator/MockValidatorSet.sol
+++ b/contracts/mocks/validator/MockValidatorSet.sol
@@ -31,7 +31,7 @@ contract MockValidatorSet is IRoninValidatorSet, CandidateManager {
   function submitBlockReward() external payable override {}
 
   function wrapUpEpoch() external payable override {
-    _removeUnsatisfiedCandidates();
+    _syncCandidateSet();
     _lastUpdatedPeriod = currentPeriod();
   }
 

--- a/contracts/mocks/validator/MockValidatorSet.sol
+++ b/contracts/mocks/validator/MockValidatorSet.sol
@@ -19,13 +19,15 @@ contract MockValidatorSet is IRoninValidatorSet, CandidateManager {
     address _slashIndicatorContract,
     address _stakingVestingContract,
     uint256 __maxValidatorCandidate,
-    uint256 __numberOfBlocksInEpoch
+    uint256 __numberOfBlocksInEpoch,
+    uint256 __minEffectiveDaysOnwards
   ) {
     _setStakingContract(__stakingContract);
     _setMaxValidatorCandidate(__maxValidatorCandidate);
     slashIndicatorContract = _slashIndicatorContract;
     stakingVestingContract = _stakingVestingContract;
     _numberOfBlocksInEpoch = __numberOfBlocksInEpoch;
+    _minEffectiveDaysOnwards = __minEffectiveDaysOnwards;
   }
 
   function submitBlockReward() external payable override {}

--- a/contracts/ronin/staking/CandidateStaking.sol
+++ b/contracts/ronin/staking/CandidateStaking.sol
@@ -62,13 +62,12 @@ abstract contract CandidateStaking is BaseStaking, ICandidateStaking {
   /**
    * @inheritdoc ICandidateStaking
    */
-  function requestUpdateCommissionRate(address _consensusAddr, uint256 _rate)
-    external
-    override
-    poolExists(_consensusAddr)
-    onlyPoolAdmin(_stakingPool[_consensusAddr], msg.sender)
-  {
-    _validatorContract.execUpdateCommissionRate(_consensusAddr, _rate);
+  function requestUpdateCommissionRate(
+    address _consensusAddr,
+    uint256 _effectiveDaysOnwards,
+    uint256 _commissionRate
+  ) external override poolExists(_consensusAddr) onlyPoolAdmin(_stakingPool[_consensusAddr], msg.sender) {
+    _validatorContract.execRequestUpdateCommissionRate(_consensusAddr, _effectiveDaysOnwards, _commissionRate);
   }
 
   /**

--- a/contracts/ronin/validator/CandidateManager.sol
+++ b/contracts/ronin/validator/CandidateManager.sol
@@ -147,7 +147,7 @@ abstract contract CandidateManager is ICandidateManager, PercentageConsumer, Has
       "CandidateManager: commission change schedule exists"
     );
     require(_commissionRate <= _MAX_PERCENTAGE, "CandidateManager: invalid commission rate");
-    require(_effectiveDaysOnwards >= _minEffectiveDaysOnwards);
+    require(_effectiveDaysOnwards >= _minEffectiveDaysOnwards, "CandidateManager: invalid effective date");
 
     CommissionSchedule storage _schedule = _candidateCommissionChangeSchedule[_consensusAddr];
     uint256 _effectiveTimestamp = ((block.timestamp / 1 days) + _effectiveDaysOnwards) * 1 days;
@@ -210,7 +210,6 @@ abstract contract CandidateManager is ICandidateManager, PercentageConsumer, Has
       uint256 _i;
       address _addr;
       ValidatorCandidate storage _info;
-      CommissionSchedule storage _schedule;
       while (_i < _length) {
         _addr = _candidates[_i];
         _info = _candidateInfo[_addr];
@@ -241,9 +240,9 @@ abstract contract CandidateManager is ICandidateManager, PercentageConsumer, Has
         }
 
         // Checks for schedule of commission change and updates commission rate
-        _schedule = _candidateCommissionChangeSchedule[_addr];
-        if (_schedule.effectiveTimestamp >= block.timestamp) {
-          uint256 _commisionRate = _schedule.commissionRate;
+        uint256 _scheduleTimestamp = _candidateCommissionChangeSchedule[_addr].effectiveTimestamp;
+        if (_scheduleTimestamp != 0 && _scheduleTimestamp <= block.timestamp) {
+          uint256 _commisionRate = _candidateCommissionChangeSchedule[_addr].commissionRate;
           delete _candidateCommissionChangeSchedule[_addr];
           _info.commissionRate = _commisionRate;
           emit CommissionRateUpdated(_addr, _commisionRate);

--- a/contracts/ronin/validator/CandidateManager.sol
+++ b/contracts/ronin/validator/CandidateManager.sol
@@ -143,7 +143,7 @@ abstract contract CandidateManager is ICandidateManager, PercentageConsumer, Has
     uint256 _commissionRate
   ) external override onlyStakingContract {
     require(
-      _candidateCommissionChangeSchedule[_consensusAddr].effectiveTimestamp != 0,
+      _candidateCommissionChangeSchedule[_consensusAddr].effectiveTimestamp == 0,
       "CandidateManager: commission change schedule exists"
     );
     require(_commissionRate <= _MAX_PERCENTAGE, "CandidateManager: invalid commission rate");

--- a/contracts/ronin/validator/CandidateManager.sol
+++ b/contracts/ronin/validator/CandidateManager.sol
@@ -43,6 +43,13 @@ abstract contract CandidateManager is ICandidateManager, PercentageConsumer, Has
   /**
    * @inheritdoc ICandidateManager
    */
+  function minEffectiveDaysOnwards() external view override returns (uint256) {
+    return _minEffectiveDaysOnwards;
+  }
+
+  /**
+   * @inheritdoc ICandidateManager
+   */
   function setMaxValidatorCandidate(uint256 _number) external override onlyAdmin {
     _setMaxValidatorCandidate(_number);
   }

--- a/contracts/ronin/validator/CandidateManager.sol
+++ b/contracts/ronin/validator/CandidateManager.sol
@@ -19,7 +19,10 @@ abstract contract CandidateManager is ICandidateManager, PercentageConsumer, Has
   /// @dev Mapping from candidate address => their info
   mapping(address => ValidatorCandidate) internal _candidateInfo;
 
-  /// @dev The minimum offset in day from current date to the effective date of a new commission schedule.
+  /**
+   * @dev The minimum offset in day from current date to the effective date of a new commission schedule.
+   * Value of 1 means the change gets affected at the beginning of the following day.
+   **/
   uint256 internal _minEffectiveDaysOnwards;
   /// @dev Mapping from candidate address => schedule commission change.
   mapping(address => CommissionSchedule) internal _candidateCommissionChangeSchedule;

--- a/contracts/ronin/validator/CoinbaseExecution.sol
+++ b/contracts/ronin/validator/CoinbaseExecution.sol
@@ -356,7 +356,7 @@ abstract contract CoinbaseExecution is
    *
    */
   function _syncValidatorSet(uint256 _newPeriod) private returns (address[] memory _newValidators) {
-    _removeUnsatisfiedCandidates();
+    _syncCandidateSet();
     uint256[] memory _weights = _stakingContract.getManyStakingTotals(_candidates);
     uint256[] memory _trustedWeights = _roninTrustedOrganizationContract.getConsensusWeights(_candidates);
     uint256 _newValidatorCount;

--- a/contracts/ronin/validator/RoninValidatorSet.sol
+++ b/contracts/ronin/validator/RoninValidatorSet.sol
@@ -33,6 +33,7 @@ contract RoninValidatorSet is Initializable, CoinbaseExecution, SlashingExecutio
     uint256 __maxValidatorNumber,
     uint256 __maxValidatorCandidate,
     uint256 __maxPrioritizedValidatorNumber,
+    uint256 __minEffectiveDaysOnwards,
     uint256 __numberOfBlocksInEpoch
   ) external initializer {
     _setSlashIndicatorContract(__slashIndicatorContract);
@@ -44,6 +45,7 @@ contract RoninValidatorSet is Initializable, CoinbaseExecution, SlashingExecutio
     _setMaxValidatorNumber(__maxValidatorNumber);
     _setMaxValidatorCandidate(__maxValidatorCandidate);
     _setMaxPrioritizedValidatorNumber(__maxPrioritizedValidatorNumber);
+    _setMinEffectiveDaysOnwards(__minEffectiveDaysOnwards);
     _numberOfBlocksInEpoch = __numberOfBlocksInEpoch;
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -163,6 +163,7 @@ const defaultRoninValidatorSetConf: RoninValidatorSetArguments = {
   maxPrioritizedValidatorNumber: 11,
   maxValidatorCandidate: 100,
   numberOfBlocksInEpoch: 600,
+  minEffectiveDaysOnwards: 7,
 };
 
 // TODO: update config for testnet & mainnet
@@ -174,6 +175,7 @@ export const roninValidatorSetConf: RoninValidatorSetConfig = {
     maxPrioritizedValidatorNumber: 22,
     maxValidatorCandidate: 100,
     numberOfBlocksInEpoch: 200,
+    minEffectiveDaysOnwards: 7,
   },
   [Network.Mainnet]: undefined,
 };

--- a/src/deploy/proxy/ronin-validator-proxy.ts
+++ b/src/deploy/proxy/ronin-validator-proxy.ts
@@ -24,6 +24,7 @@ const deploy = async ({ getNamedAccounts, deployments }: HardhatRuntimeEnvironme
     roninValidatorSetConf[network.name]!.maxValidatorNumber,
     roninValidatorSetConf[network.name]!.maxValidatorCandidate,
     roninValidatorSetConf[network.name]!.maxPrioritizedValidatorNumber,
+    roninValidatorSetConf[network.name]!.minEffectiveDaysOnwards,
     roninValidatorSetConf[network.name]!.numberOfBlocksInEpoch,
   ]);
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -140,6 +140,7 @@ export interface RoninValidatorSetArguments {
   maxValidatorCandidate?: BigNumberish;
   maxPrioritizedValidatorNumber?: BigNumberish;
   numberOfBlocksInEpoch?: BigNumberish;
+  minEffectiveDaysOnwards?: BigNumberish;
 }
 
 export interface RoninValidatorSetConfig {

--- a/test/helpers/fixture.ts
+++ b/test/helpers/fixture.ts
@@ -108,6 +108,7 @@ export const defaultTestConfig: InitTestInput = {
     maxPrioritizedValidatorNumber: 0,
     numberOfBlocksInEpoch: 600,
     maxValidatorCandidate: 10,
+    minEffectiveDaysOnwards: 7,
   },
 
   roninTrustedOrganizationArguments: {

--- a/test/integration/Configuration.test.ts
+++ b/test/integration/Configuration.test.ts
@@ -241,6 +241,9 @@ describe('[Integration] Configuration check', () => {
     expect(await validatorContract.maxPrioritizedValidatorNumber()).to.eq(
       config.roninValidatorSetArguments?.maxPrioritizedValidatorNumber
     );
+    expect(await validatorContract.minEffectiveDaysOnwards()).to.eq(
+      config.roninValidatorSetArguments?.minEffectiveDaysOnwards
+    );
     expect(await validatorContract.numberOfBlocksInEpoch()).to.eq(
       config.roninValidatorSetArguments?.numberOfBlocksInEpoch
     );

--- a/test/integration/Configuration.test.ts
+++ b/test/integration/Configuration.test.ts
@@ -88,6 +88,7 @@ const config: InitTestInput = {
     maxPrioritizedValidatorNumber: 0,
     numberOfBlocksInEpoch: 600,
     maxValidatorCandidate: 10,
+    minEffectiveDaysOnwards: 7,
   },
   roninTrustedOrganizationArguments: {
     trustedOrganizations: [],


### PR DESCRIPTION
### Description
- See https://skymavis.atlassian.net/jira/software/projects/PSC/boards/47?selectedIssue=PSC-108

### ABI changes
| Old | New |
| --- | ----------- |
| `requestUpdateCommissionRate(address _consensusAddr, uint256 _rate)` | `requestUpdateCommissionRate(address _consensusAddr, uint256 _effectiveDaysOnwards, uint256 _commissionRate)` |


### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
