### PR TITLE
[Staking] Merge validator's 5 addresses to 3 addresses

### DIFF
--- a/contracts/interfaces/staking/IBaseStaking.sol
+++ b/contracts/interfaces/staking/IBaseStaking.sol
@@ -26,7 +26,7 @@ interface IBaseStaking {
   /**
    * @dev Returns whether the `_poolAdminAddr` is currently active.
    */
-  function isPoolAdminActive(address _poolAdminAddr) external view returns (bool);
+  function isActivePoolAdmin(address _poolAdminAddr) external view returns (bool);
 
   /**
    * @dev Returns The cooldown time in seconds to undelegate from the last timestamp (s)he delegated.

--- a/contracts/interfaces/staking/IBaseStaking.sol
+++ b/contracts/interfaces/staking/IBaseStaking.sol
@@ -24,6 +24,11 @@ interface IBaseStaking {
   event WaitingSecsToRevokeUpdated(uint256 secs);
 
   /**
+   * @dev Returns whether the `_poolAdminAddr` is currently active.
+   */
+  function isPoolAdminActive(address _poolAdminAddr) external view returns (bool);
+
+  /**
    * @dev Returns The cooldown time in seconds to undelegate from the last timestamp (s)he delegated.
    */
   function cooldownSecsToUndelegate() external view returns (uint256);

--- a/contracts/interfaces/staking/ICandidateStaking.sol
+++ b/contracts/interfaces/staking/ICandidateStaking.sol
@@ -72,6 +72,9 @@ interface ICandidateStaking is IRewardPool {
 
   /**
    * @dev Deprecates the pool.
+   * - Deduct self-staking amount of the pool admin to zero.
+   * - Transfer the deducted amount to the pool admin.
+   * - Deactivate the pool admin address in the mapping of active pool admins
    *
    * Requirements:
    * - The method caller is validator contract.

--- a/contracts/libraries/AddressArrayUtils.sol
+++ b/contracts/libraries/AddressArrayUtils.sol
@@ -21,4 +21,21 @@ library AddressArrayUtils {
     }
     return false;
   }
+
+  /**
+   * Returns whether or not all elements in the array are all equal. Runs in O(n).
+   * @param A Array to search
+   * @return Returns true if all equal, false otherwise
+   */
+  function hasAllEqual(address[] memory A) internal pure returns (bool) {
+    if (A.length == 0) {
+      return true;
+    }
+    for (uint i = 0; i < A.length - 1; i++) {
+      if (A[i] != A[i + 1]) {
+        return false;
+      }
+    }
+    return true;
+  }
 }

--- a/contracts/libraries/AddressArrayUtils.sol
+++ b/contracts/libraries/AddressArrayUtils.sol
@@ -21,21 +21,4 @@ library AddressArrayUtils {
     }
     return false;
   }
-
-  /**
-   * Returns whether or not all elements in the array are all equal. Runs in O(n).
-   * @param A Array to search
-   * @return Returns true if all equal, false otherwise
-   */
-  function hasAllEqual(address[] memory A) internal pure returns (bool) {
-    if (A.length == 0) {
-      return true;
-    }
-    for (uint i = 0; i < A.length - 1; i++) {
-      if (A[i] != A[i + 1]) {
-        return false;
-      }
-    }
-    return true;
-  }
 }

--- a/contracts/ronin/staking/BaseStaking.sol
+++ b/contracts/ronin/staking/BaseStaking.sol
@@ -55,7 +55,7 @@ abstract contract BaseStaking is
   /**
    * @inheritdoc IBaseStaking
    */
-  function isPoolAdminActive(address _poolAdminAddr) public view returns (bool) {
+  function isActivePoolAdmin(address _poolAdminAddr) public view returns (bool) {
     return _activePoolAdminMapping[_poolAdminAddr] != address(0);
   }
 

--- a/contracts/ronin/staking/BaseStaking.sol
+++ b/contracts/ronin/staking/BaseStaking.sol
@@ -24,11 +24,13 @@ abstract contract BaseStaking is
   /// @dev The number of seconds that a candidate must wait to be revoked and take the self-staking amount back.
   uint256 internal _waitingSecsToRevoke;
 
+  /// @dev Mapping from pool admin address => consensus address.
+  mapping(address => address) internal _activePoolAdminMapping;
   /**
    * @dev This empty reserved space is put in place to allow future versions to add new
    * variables without shifting down storage in the inheritance chain.
    */
-  uint256[50] private ______gap;
+  uint256[49] private ______gap;
 
   modifier noEmptyValue() {
     require(msg.value > 0, "BaseStaking: query with empty value");
@@ -48,6 +50,13 @@ abstract contract BaseStaking is
   modifier poolExists(address _poolAddr) {
     require(_validatorContract.isValidatorCandidate(_poolAddr), "BaseStaking: query for non-existent pool");
     _;
+  }
+
+  /**
+   * @inheritdoc IBaseStaking
+   */
+  function isPoolAdminActive(address _poolAdminAddr) public view returns (bool) {
+    return _activePoolAdminMapping[_poolAdminAddr] != address(0);
   }
 
   /**

--- a/contracts/ronin/staking/BaseStaking.sol
+++ b/contracts/ronin/staking/BaseStaking.sol
@@ -55,7 +55,7 @@ abstract contract BaseStaking is
   /**
    * @inheritdoc IBaseStaking
    */
-  function isActivePoolAdmin(address _poolAdminAddr) public view returns (bool) {
+  function isActivePoolAdmin(address _poolAdminAddr) public view override returns (bool) {
     return _activePoolAdminMapping[_poolAdminAddr] != address(0);
   }
 

--- a/contracts/ronin/staking/CandidateStaking.sol
+++ b/contracts/ronin/staking/CandidateStaking.sol
@@ -150,12 +150,8 @@ abstract contract CandidateStaking is BaseStaking, ICandidateStaking {
     require(_sendRON(_treasuryAddr, 0), "CandidateStaking: treasury cannot receive RON");
     require(_amount >= _minValidatorStakingAmount, "CandidateStaking: insufficient amount");
 
-    address[] memory _equalAddrs = new address[](3);
-    _equalAddrs[0] = _poolAdmin;
-    _equalAddrs[1] = _candidateAdmin;
-    _equalAddrs[2] = _treasuryAddr;
     require(
-      AddressArrayUtils.hasAllEqual(_equalAddrs),
+      _poolAdmin == _candidateAdmin && _candidateAdmin == _treasuryAddr,
       "CandidateStaking: three interaction addresses must be of the same"
     );
 

--- a/contracts/ronin/staking/CandidateStaking.sol
+++ b/contracts/ronin/staking/CandidateStaking.sol
@@ -40,7 +40,7 @@ abstract contract CandidateStaking is BaseStaking, ICandidateStaking {
     address _bridgeOperatorAddr,
     uint256 _commissionRate
   ) external payable override nonReentrant {
-    require(!isPoolAdminActive(msg.sender), "CandidateStaking: pool admin is active");
+    require(!isActivePoolAdmin(msg.sender), "CandidateStaking: pool admin is active");
 
     uint256 _amount = msg.value;
     address payable _poolAdmin = payable(msg.sender);

--- a/contracts/ronin/staking/CandidateStaking.sol
+++ b/contracts/ronin/staking/CandidateStaking.sol
@@ -40,6 +40,8 @@ abstract contract CandidateStaking is BaseStaking, ICandidateStaking {
     address _bridgeOperatorAddr,
     uint256 _commissionRate
   ) external payable override nonReentrant {
+    require(!isPoolAdminActive(msg.sender), "CandidateStaking: pool admin is active");
+
     uint256 _amount = msg.value;
     address payable _poolAdmin = payable(msg.sender);
     _applyValidatorCandidate(
@@ -55,6 +57,8 @@ abstract contract CandidateStaking is BaseStaking, ICandidateStaking {
     PoolDetail storage _pool = _stakingPool[_consensusAddr];
     _pool.admin = _poolAdmin;
     _pool.addr = _consensusAddr;
+    _activePoolAdminMapping[_poolAdmin] = _consensusAddr;
+
     _stake(_stakingPool[_consensusAddr], _poolAdmin, _amount);
     emit PoolApproved(_consensusAddr, _poolAdmin);
   }
@@ -81,6 +85,10 @@ abstract contract CandidateStaking is BaseStaking, ICandidateStaking {
     uint256 _amount;
     for (uint _i = 0; _i < _pools.length; _i++) {
       PoolDetail storage _pool = _stakingPool[_pools[_i]];
+      // Deactivate the pool admin in the active mapping.
+      delete _activePoolAdminMapping[_pool.admin];
+
+      // Deduct and transfer the self staking amount to the pool admin.
       _amount = _pool.stakingAmount;
       if (_amount > 0) {
         _deductStakingAmount(_pool, _amount);
@@ -142,13 +150,23 @@ abstract contract CandidateStaking is BaseStaking, ICandidateStaking {
     require(_sendRON(_treasuryAddr, 0), "CandidateStaking: treasury cannot receive RON");
     require(_amount >= _minValidatorStakingAmount, "CandidateStaking: insufficient amount");
 
-    address[] memory _addresses = new address[](5);
-    _addresses[0] = _poolAdmin;
-    _addresses[1] = _candidateAdmin;
-    _addresses[2] = _consensusAddr;
-    _addresses[3] = _treasuryAddr;
-    _addresses[4] = _bridgeOperatorAddr;
-    require(!AddressArrayUtils.hasDuplicate(_addresses), "CandidateStaking: five addresses must be distinct");
+    address[] memory _equalAddrs = new address[](3);
+    _equalAddrs[0] = _poolAdmin;
+    _equalAddrs[1] = _candidateAdmin;
+    _equalAddrs[2] = _treasuryAddr;
+    require(
+      AddressArrayUtils.hasAllEqual(_equalAddrs),
+      "CandidateStaking: three interaction addresses must be of the same"
+    );
+
+    address[] memory _diffAddrs = new address[](3);
+    _diffAddrs[0] = _poolAdmin;
+    _diffAddrs[1] = _consensusAddr;
+    _diffAddrs[2] = _bridgeOperatorAddr;
+    require(
+      !AddressArrayUtils.hasDuplicate(_diffAddrs),
+      "CandidateStaking: three operation addresses must be distinct"
+    );
 
     _validatorContract.grantValidatorCandidate(
       _candidateAdmin,

--- a/contracts/ronin/staking/DelegatorStaking.sol
+++ b/contracts/ronin/staking/DelegatorStaking.sol
@@ -16,7 +16,7 @@ abstract contract DelegatorStaking is BaseStaking, IDelegatorStaking {
    * @inheritdoc IDelegatorStaking
    */
   function delegate(address _consensusAddr) external payable noEmptyValue poolExists(_consensusAddr) {
-    require(!isPoolAdminActive(msg.sender), "DelegatorStaking: admin of an active pool cannot delegate");
+    require(!isActivePoolAdmin(msg.sender), "DelegatorStaking: admin of an active pool cannot delegate");
     _delegate(_stakingPool[_consensusAddr], msg.sender, msg.value);
   }
 

--- a/contracts/ronin/staking/DelegatorStaking.sol
+++ b/contracts/ronin/staking/DelegatorStaking.sol
@@ -16,12 +16,7 @@ abstract contract DelegatorStaking is BaseStaking, IDelegatorStaking {
    * @inheritdoc IDelegatorStaking
    */
   function delegate(address _consensusAddr) external payable noEmptyValue poolExists(_consensusAddr) {
-    address[] memory _currValidatorList = _validatorContract.getValidatorCandidates();
-    for (uint _i = 0; _i < _currValidatorList.length; _i++) {
-      PoolDetail storage _pool = _stakingPool[_currValidatorList[_i]];
-      require(msg.sender != _pool.admin, "DelegatorStaking: admin of an arbitrary pool cannot delegate");
-    }
-
+    require(!isPoolAdminActive(msg.sender), "DelegatorStaking: admin of an active pool cannot delegate");
     _delegate(_stakingPool[_consensusAddr], msg.sender, msg.value);
   }
 

--- a/contracts/ronin/validator/CandidateManager.sol
+++ b/contracts/ronin/validator/CandidateManager.sol
@@ -65,7 +65,7 @@ abstract contract CandidateManager is ICandidateManager, PercentageConsumer, Has
    * @inheritdoc ICandidateManager
    */
   function grantValidatorCandidate(
-    address _admin,
+    address _candidateAdmin,
     address _consensusAddr,
     address payable _treasuryAddr,
     address _bridgeOperatorAddr,
@@ -79,12 +79,12 @@ abstract contract CandidateManager is ICandidateManager, PercentageConsumer, Has
     for (uint _i = 0; _i < _candidates.length; _i++) {
       ValidatorCandidate storage existentInfo = _candidateInfo[_candidates[_i]];
 
-      if (_admin == existentInfo.admin) {
+      if (_candidateAdmin == existentInfo.admin) {
         revert(
           string(
             abi.encodePacked(
               "CandidateManager: candidate admin address ",
-              Strings.toHexString(uint160(_admin), 20),
+              Strings.toHexString(uint160(_candidateAdmin), 20),
               " is already exist"
             )
           )
@@ -120,12 +120,12 @@ abstract contract CandidateManager is ICandidateManager, PercentageConsumer, Has
     _candidates.push(_consensusAddr);
 
     ValidatorCandidate storage _info = _candidateInfo[_consensusAddr];
-    _info.admin = _admin;
+    _info.admin = _candidateAdmin;
     _info.consensusAddr = _consensusAddr;
     _info.treasuryAddr = _treasuryAddr;
     _info.bridgeOperatorAddr = _bridgeOperatorAddr;
     _info.commissionRate = _commissionRate;
-    emit CandidateGranted(_consensusAddr, _treasuryAddr, _admin, _bridgeOperatorAddr);
+    emit CandidateGranted(_consensusAddr, _treasuryAddr, _candidateAdmin, _bridgeOperatorAddr);
   }
 
   /**

--- a/test/bridge/BridgeTracking.test.ts
+++ b/test/bridge/BridgeTracking.test.ts
@@ -61,7 +61,7 @@ const numberOfBlocksInEpoch = 600;
 describe('Bridge Tracking test', () => {
   before(async () => {
     [deployer, coinbase, ...signers] = await ethers.getSigners();
-    candidates = createManyValidatorCandidateAddressSets(signers.slice(0, maxValidatorNumber * 5));
+    candidates = createManyValidatorCandidateAddressSets(signers.slice(0, maxValidatorNumber * 3));
 
     trustedOrgs = createManyTrustedOrganizationAddressSets([
       ...signers.slice(0, maxPrioritizedValidatorNumber),

--- a/test/helpers/address-set-types.ts
+++ b/test/helpers/address-set-types.ts
@@ -71,16 +71,16 @@ export function createManyTrustedOrganizationAddressSets(
 export const createValidatorCandidateAddressSet = (
   addrs: SignerWithAddress[]
 ): ValidatorCandidateAddressSet | undefined => {
-  if (addrs.length != 5) {
+  if (addrs.length != 3) {
     return;
   }
 
   return {
     poolAdmin: addrs[0],
-    candidateAdmin: addrs[1],
-    consensusAddr: addrs[2],
-    treasuryAddr: addrs[3],
-    bridgeOperator: addrs[4],
+    candidateAdmin: addrs[0],
+    treasuryAddr: addrs[0],
+    consensusAddr: addrs[1],
+    bridgeOperator: addrs[2],
   };
 };
 
@@ -104,12 +104,12 @@ export function createManyValidatorCandidateAddressSets(
   let poolAdmins: SignerWithAddress[] = [];
 
   if (!candidateAdmins || !consensusAddrs || !treasuryAddrs || !bridgeOperators) {
-    expect(signers.length % 5).eq(0, 'createManyValidatorCandidateAddressSets: signers length must be divisible by 5');
-    let _length = signers.length / 5;
+    expect(signers.length % 3).eq(0, 'createManyValidatorCandidateAddressSets: signers length must be divisible by 3');
+    let _length = signers.length / 3;
     poolAdmins = signers.splice(0, _length);
-    candidateAdmins = signers.splice(0, _length);
+    candidateAdmins = poolAdmins;
+    treasuryAddrs = poolAdmins;
     consensusAddrs = signers.splice(0, _length);
-    treasuryAddrs = signers.splice(0, _length);
     bridgeOperators = signers.splice(0, _length);
   }
 

--- a/test/integration/ActionSlashValidators.test.ts
+++ b/test/integration/ActionSlashValidators.test.ts
@@ -53,7 +53,7 @@ describe('[Integration] Slash validators', () => {
   before(async () => {
     [deployer, coinbase, ...signers] = await ethers.getSigners();
     trustedOrgs = createManyTrustedOrganizationAddressSets(signers.splice(0, 3));
-    validatorCandidates = createManyValidatorCandidateAddressSets(signers.slice(0, maxValidatorNumber * 5));
+    validatorCandidates = createManyValidatorCandidateAddressSets(signers.slice(0, maxValidatorNumber * 3));
 
     await network.provider.send('hardhat_setCoinbase', [coinbase.address]);
 

--- a/test/integration/ActionSubmitReward.test.ts
+++ b/test/integration/ActionSubmitReward.test.ts
@@ -49,7 +49,7 @@ describe('[Integration] Submit Block Reward', () => {
   before(async () => {
     [deployer, coinbase, ...signers] = await ethers.getSigners();
 
-    validatorCandidates = createManyValidatorCandidateAddressSets(signers.splice(0, 2 * 5));
+    validatorCandidates = createManyValidatorCandidateAddressSets(signers.splice(0, 2 * 3));
     trustedOrgs = createManyTrustedOrganizationAddressSets([...signers.slice(0, 1 * 3)]);
 
     await network.provider.send('hardhat_setCoinbase', [coinbase.address]);

--- a/test/integration/ActionWrapUpEpoch.test.ts
+++ b/test/integration/ActionWrapUpEpoch.test.ts
@@ -52,7 +52,7 @@ describe('[Integration] Wrap up epoch', () => {
     await network.provider.send('hardhat_setCoinbase', [coinbase.address]);
 
     trustedOrgs = createManyTrustedOrganizationAddressSets(signers.splice(0, 3));
-    validatorCandidates = createManyValidatorCandidateAddressSets(signers.splice(0, maxValidatorNumber * 3 * 5));
+    validatorCandidates = createManyValidatorCandidateAddressSets(signers.splice(0, maxValidatorNumber * 3 * 3));
 
     const { slashContractAddress, stakingContractAddress, validatorContractAddress, roninGovernanceAdminAddress } =
       await initTest('ActionWrapUpEpoch')({

--- a/test/maintainance/Maintenance.test.ts
+++ b/test/maintainance/Maintenance.test.ts
@@ -58,7 +58,7 @@ describe('Maintenance test', () => {
   before(async () => {
     [deployer, coinbase, ...signers] = await ethers.getSigners();
     trustedOrgs = createManyTrustedOrganizationAddressSets(signers.splice(0, 3));
-    validatorCandidates = createManyValidatorCandidateAddressSets(signers.slice(0, maxValidatorNumber * 5));
+    validatorCandidates = createManyValidatorCandidateAddressSets(signers.slice(0, maxValidatorNumber * 3));
 
     const {
       maintenanceContractAddress,

--- a/test/slash/CreditScore.test.ts
+++ b/test/slash/CreditScore.test.ts
@@ -125,7 +125,7 @@ describe('Credit score and bail out test', () => {
     [deployer, coinbase, ...signers] = await ethers.getSigners();
 
     trustedOrgs = createManyTrustedOrganizationAddressSets(signers.splice(0, 3));
-    validatorCandidates = createManyValidatorCandidateAddressSets(signers.slice(0, (maxValidatorNumber + 1) * 5));
+    validatorCandidates = createManyValidatorCandidateAddressSets(signers.slice(0, (maxValidatorNumber + 1) * 3));
 
     const { slashContractAddress, stakingContractAddress, validatorContractAddress, roninGovernanceAdminAddress } =
       await initTest('CreditScore')({

--- a/test/slash/SlashIndicator.test.ts
+++ b/test/slash/SlashIndicator.test.ts
@@ -64,7 +64,7 @@ describe('Slash indicator test', () => {
   before(async () => {
     [deployer, coinbase, vagabond, ...signers] = await ethers.getSigners();
     trustedOrgs = createManyTrustedOrganizationAddressSets(signers.splice(0, 3));
-    validatorCandidates = createManyValidatorCandidateAddressSets(signers.slice(0, maxValidatorNumber * 5));
+    validatorCandidates = createManyValidatorCandidateAddressSets(signers.slice(0, maxValidatorNumber * 3));
 
     const { slashContractAddress, stakingContractAddress, validatorContractAddress, roninGovernanceAdminAddress } =
       await initTest('SlashIndicator')({

--- a/test/staking/Staking.test.ts
+++ b/test/staking/Staking.test.ts
@@ -351,7 +351,7 @@ describe('Staking test', () => {
         stakingContract
           .connect(otherPoolAddrSet.poolAdmin)
           .delegate(otherPoolAddrSet.consensusAddr.address, { value: 1 })
-      ).revertedWith('DelegatorStaking: admin of an arbitrary pool cannot delegate');
+      ).revertedWith('DelegatorStaking: admin of an active pool cannot delegate');
       await expect(
         stakingContract.connect(otherPoolAddrSet.poolAdmin).undelegate(otherPoolAddrSet.consensusAddr.address, 1)
       ).revertedWith('BaseStaking: delegator must not be the pool admin');
@@ -362,12 +362,12 @@ describe('Staking test', () => {
         stakingContract
           .connect(anotherActivePoolSet.poolAdmin)
           .delegate(otherPoolAddrSet.consensusAddr.address, { value: 1 })
-      ).revertedWith('DelegatorStaking: admin of an arbitrary pool cannot delegate');
+      ).revertedWith('DelegatorStaking: admin of an active pool cannot delegate');
       await expect(
         stakingContract
           .connect(otherPoolAddrSet.poolAdmin)
           .delegate(anotherActivePoolSet.consensusAddr.address, { value: 1 })
-      ).revertedWith('DelegatorStaking: admin of an arbitrary pool cannot delegate');
+      ).revertedWith('DelegatorStaking: admin of an active pool cannot delegate');
     });
 
     it('Should multiple accounts be able to delegate to one pool', async () => {


### PR DESCRIPTION
### Description
- Assert `poolAdmin`, `candidateAdmin`, `treasuryAddr` must be of the same
- Assert `poolAdmin`, `consensusAddr`, `bridgeAddr` must be distinct
- Introduce terms of `existPool` and `activePool`
   + An `existPool` is a pool that has been created once in the contract, regardless of the status of the corresponding validator candidate, including existent / kicked / re-joined candidates.
   + An `activePool` is a pool corresponding to an existent validator candidate.

### New ABIs
- `function isActivePoolAdmin(address _poolAdminAddr) external view returns (bool)`


### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
