### PR TITLE
[CandidateManager] Add getter for schedule of commision change

### DIFF
--- a/contracts/interfaces/validator/ICandidateManager.sol
+++ b/contracts/interfaces/validator/ICandidateManager.sol
@@ -152,4 +152,9 @@ interface ICandidateManager {
    * @dev Returns whether the address is the candidate admin.
    */
   function isCandidateAdmin(address _candidate, address _admin) external view returns (bool);
+
+  /**
+   * @dev Returns the schedule of changing commission rate of a candidate address.
+   */
+  function getCommissionChangeSchedule(address _candidate) external view returns (CommissionSchedule memory);
 }

--- a/contracts/ronin/validator/CandidateManager.sol
+++ b/contracts/ronin/validator/CandidateManager.sol
@@ -14,9 +14,9 @@ abstract contract CandidateManager is ICandidateManager, PercentageConsumer, Has
 
   /// @dev The validator candidate array
   address[] internal _candidates;
-  /// @dev Mapping from candidate address => bitwise negation of validator index in `_candidates`
+  /// @dev Mapping from candidate consensus address => bitwise negation of validator index in `_candidates`
   mapping(address => uint256) internal _candidateIndex;
-  /// @dev Mapping from candidate address => their info
+  /// @dev Mapping from candidate consensus address => their info
   mapping(address => ValidatorCandidate) internal _candidateInfo;
 
   /**
@@ -24,7 +24,7 @@ abstract contract CandidateManager is ICandidateManager, PercentageConsumer, Has
    * Value of 1 means the change gets affected at the beginning of the following day.
    **/
   uint256 internal _minEffectiveDaysOnwards;
-  /// @dev Mapping from candidate address => schedule commission change.
+  /// @dev Mapping from candidate consensus address => schedule commission change.
   mapping(address => CommissionSchedule) internal _candidateCommissionChangeSchedule;
 
   /**
@@ -194,6 +194,13 @@ abstract contract CandidateManager is ICandidateManager, PercentageConsumer, Has
    */
   function getValidatorCandidates() public view override returns (address[] memory) {
     return _candidates;
+  }
+
+  /**
+   * @inheritdoc ICandidateManager
+   */
+  function getCommissionChangeSchedule(address _candidate) external view override returns (CommissionSchedule memory) {
+    return _candidateCommissionChangeSchedule[_candidate];
   }
 
   /**


### PR DESCRIPTION
### Description
https://skymavis.atlassian.net/browse/PSC-120?atlOrigin=eyJpIjoiODdlMDQyOTZmZDg3NDBiMzlhMGE1Yjc2MTBjMTY0MjgiLCJwIjoiaiJ9

### New ABIs
`function getCommissionChangeSchedule(address _candidate) external view returns (CommissionSchedule memory);`

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
