### PR TITLE
[Staking] Support fetch pool address from pool admin address

### DIFF
--- a/contracts/interfaces/staking/IBaseStaking.sol
+++ b/contracts/interfaces/staking/IBaseStaking.sol
@@ -29,6 +29,11 @@ interface IBaseStaking {
   function isActivePoolAdmin(address _poolAdminAddr) external view returns (bool);
 
   /**
+   * @dev Returns the consensus address corresponding to the pool admin.
+   */
+  function getPoolAddressOf(address _poolAdminAddr) external view returns (address);
+
+  /**
    * @dev Returns The cooldown time in seconds to undelegate from the last timestamp (s)he delegated.
    */
   function cooldownSecsToUndelegate() external view returns (uint256);

--- a/contracts/ronin/staking/BaseStaking.sol
+++ b/contracts/ronin/staking/BaseStaking.sol
@@ -24,7 +24,7 @@ abstract contract BaseStaking is
   /// @dev The number of seconds that a candidate must wait to be revoked and take the self-staking amount back.
   uint256 internal _waitingSecsToRevoke;
 
-  /// @dev Mapping from pool admin address => consensus address.
+  /// @dev Mapping from active pool admin address => consensus address.
   mapping(address => address) internal _activePoolAdminMapping;
   /**
    * @dev This empty reserved space is put in place to allow future versions to add new
@@ -57,6 +57,13 @@ abstract contract BaseStaking is
    */
   function isActivePoolAdmin(address _poolAdminAddr) public view override returns (bool) {
     return _activePoolAdminMapping[_poolAdminAddr] != address(0);
+  }
+
+  /**
+   * @inheritdoc IBaseStaking
+   */
+  function getPoolAddressOf(address _poolAdminAddr) external view override returns (address) {
+    return _activePoolAdminMapping[_poolAdminAddr];
   }
 
   /**


### PR DESCRIPTION
### Description

Add new getter to fetch pool address from pool admin address

### New ABIs
`function getPoolAddressOf(address _poolAdminAddr) external view override returns (address)`

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
