### PR TITLE
Implement function emergency exit for Validators

### DIFF
--- a/contracts/extensions/collections/HasValidatorContract.sol
+++ b/contracts/extensions/collections/HasValidatorContract.sol
@@ -23,7 +23,7 @@ contract HasValidatorContract is IHasValidatorContract, HasProxyAdmin {
   /**
    * @inheritdoc IHasValidatorContract
    */
-  function setValidatorContract(address _addr) external override onlyAdmin {
+  function setValidatorContract(address _addr) external virtual override onlyAdmin {
     require(_addr.code.length > 0, "HasValidatorContract: set to non-contract");
     _setValidatorContract(_addr);
   }

--- a/contracts/extensions/isolated-governance/IsolatedGovernance.sol
+++ b/contracts/extensions/isolated-governance/IsolatedGovernance.sol
@@ -12,6 +12,10 @@ abstract contract IsolatedGovernance is VoteStatusConsumer {
     mapping(address => bytes32) voteHashOf;
     /// @dev Mapping from receipt hash => vote weight
     mapping(bytes32 => uint256) weight;
+    /// @dev The timestamp that voting is expired (no expiration=0)
+    uint256 expiredAt;
+    /// @dev The timestamp that voting is created
+    uint256 createdAt;
   }
 
   /**
@@ -29,6 +33,11 @@ abstract contract IsolatedGovernance is VoteStatusConsumer {
     uint256 _minimumVoteWeight,
     bytes32 _hash
   ) internal virtual returns (VoteStatus _status) {
+    if (_proposal.expiredAt > 0 && _proposal.expiredAt <= block.timestamp) {
+      _proposal.status = VoteStatus.Expired;
+      return _proposal.status;
+    }
+
     if (_voted(_proposal, _voter)) {
       revert(
         string(abi.encodePacked("IsolatedGovernance: ", Strings.toHexString(uint160(_voter), 20), " already voted"))

--- a/contracts/extensions/isolated-governance/bridge-operator-governance/BOsGovernanceProposal.sol
+++ b/contracts/extensions/isolated-governance/bridge-operator-governance/BOsGovernanceProposal.sol
@@ -52,7 +52,7 @@ abstract contract BOsGovernanceProposal is SignatureConsumer, IsolatedGovernance
     Signature memory _sig;
     address _signer;
     address _lastSigner;
-    bytes32 _hash = BridgeOperatorsBallot.hash(_period, _operators);
+    bytes32 _hash = BridgeOperatorsBallot.hash(_period, _epoch, _operators);
     bytes32 _digest = ECDSA.toTypedDataHash(_domainSeperator, _hash);
     IsolatedVote storage _v = _vote[_period][_epoch];
     bool _hasValidVotes;

--- a/contracts/extensions/isolated-governance/bridge-operator-governance/BOsGovernanceProposal.sol
+++ b/contracts/extensions/isolated-governance/bridge-operator-governance/BOsGovernanceProposal.sol
@@ -9,13 +9,15 @@ import "../../../interfaces/IRoninGovernanceAdmin.sol";
 abstract contract BOsGovernanceProposal is SignatureConsumer, IsolatedGovernance, IRoninGovernanceAdmin {
   /// @dev The last period that the brige operators synced.
   uint256 internal _lastSyncedPeriod;
-  /// @dev Mapping from period index => bridge operators vote
-  mapping(uint256 => IsolatedVote) internal _vote;
+  /// @dev The last epoch that the brige operators synced.
+  uint256 internal _lastSyncedEpoch;
+  /// @dev Mapping from period index => epoch index => bridge operators vote
+  mapping(uint256 => mapping(uint256 => IsolatedVote)) internal _vote;
 
   /// @dev Mapping from bridge voter address => last block that the address voted
   mapping(address => uint256) internal _lastVotedBlock;
-  /// @dev Mapping from period => voter => signatures
-  mapping(uint256 => mapping(address => Signature)) internal _votingSig;
+  /// @dev Mapping from period index => epoch index => voter => signatures
+  mapping(uint256 => mapping(uint256 => mapping(address => Signature))) internal _votingSig;
 
   /**
    * @inheritdoc IRoninGovernanceAdmin
@@ -37,10 +39,14 @@ abstract contract BOsGovernanceProposal is SignatureConsumer, IsolatedGovernance
     address[] calldata _operators,
     Signature[] calldata _signatures,
     uint256 _period,
+    uint256 _epoch,
     uint256 _minimumVoteWeight,
     bytes32 _domainSeperator
   ) internal {
-    require(_period >= _lastSyncedPeriod, "BOsGovernanceProposal: query for outdated period");
+    require(
+      _period >= _lastSyncedPeriod && _epoch >= _lastSyncedEpoch,
+      "BOsGovernanceProposal: query for outdated bridge operator set"
+    );
     require(_operators.length > 0 && _signatures.length > 0, "BOsGovernanceProposal: invalid array length");
 
     Signature memory _sig;
@@ -48,7 +54,7 @@ abstract contract BOsGovernanceProposal is SignatureConsumer, IsolatedGovernance
     address _lastSigner;
     bytes32 _hash = BridgeOperatorsBallot.hash(_period, _operators);
     bytes32 _digest = ECDSA.toTypedDataHash(_domainSeperator, _hash);
-    IsolatedVote storage _v = _vote[_period];
+    IsolatedVote storage _v = _vote[_period][_epoch];
     bool _hasValidVotes;
 
     for (uint256 _i = 0; _i < _signatures.length; _i++) {
@@ -61,7 +67,7 @@ abstract contract BOsGovernanceProposal is SignatureConsumer, IsolatedGovernance
       if (_weight > 0) {
         _hasValidVotes = true;
         _lastVotedBlock[_signer] = block.number;
-        _votingSig[_period][_signer] = _sig;
+        _votingSig[_period][_epoch][_signer] = _sig;
         if (_castVote(_v, _signer, _weight, _minimumVoteWeight, _hash) == VoteStatus.Approved) {
           return;
         }

--- a/contracts/extensions/isolated-governance/bridge-operator-governance/BOsGovernanceRelay.sol
+++ b/contracts/extensions/isolated-governance/bridge-operator-governance/BOsGovernanceRelay.sol
@@ -41,7 +41,7 @@ abstract contract BOsGovernanceRelay is SignatureConsumer, IsolatedGovernance {
     Signature memory _sig;
     address[] memory _signers = new address[](_signatures.length);
     address _lastSigner;
-    bytes32 _hash = BridgeOperatorsBallot.hash(_period, _operators);
+    bytes32 _hash = BridgeOperatorsBallot.hash(_period, _epoch, _operators);
     bytes32 _digest = ECDSA.toTypedDataHash(_domainSeperator, _hash);
 
     for (uint256 _i = 0; _i < _signatures.length; _i++) {

--- a/contracts/extensions/isolated-governance/bridge-operator-governance/BOsGovernanceRelay.sol
+++ b/contracts/extensions/isolated-governance/bridge-operator-governance/BOsGovernanceRelay.sol
@@ -8,8 +8,10 @@ import "../../../libraries/BridgeOperatorsBallot.sol";
 abstract contract BOsGovernanceRelay is SignatureConsumer, IsolatedGovernance {
   /// @dev The last period that the brige operators synced.
   uint256 internal _lastSyncedPeriod;
-  /// @dev Mapping from period index => bridge operators vote
-  mapping(uint256 => IsolatedVote) internal _vote;
+  /// @dev The last epoch that the brige operators synced.
+  uint256 internal _lastSyncedEpoch;
+  /// @dev Mapping from period index => epoch index => bridge operators vote
+  mapping(uint256 => mapping(uint256 => IsolatedVote)) internal _vote;
 
   /**
    * @dev Relays votes by signatures.
@@ -26,10 +28,15 @@ abstract contract BOsGovernanceRelay is SignatureConsumer, IsolatedGovernance {
     address[] calldata _operators,
     Signature[] calldata _signatures,
     uint256 _period,
+    uint256 _epoch,
     uint256 _minimumVoteWeight,
     bytes32 _domainSeperator
   ) internal {
-    require(_period > _lastSyncedPeriod, "BOsGovernanceRelay: query for outdated period");
+    require(
+      (_period > _lastSyncedPeriod && _epoch > _lastSyncedEpoch) ||
+        (_period == _lastSyncedPeriod && _epoch > _lastSyncedEpoch),
+      "BOsGovernanceRelay: query for outdated bridge operator set"
+    );
     require(_operators.length > 0 && _signatures.length > 0, "BOsGovernanceRelay: invalid array length");
 
     Signature memory _sig;
@@ -45,12 +52,13 @@ abstract contract BOsGovernanceRelay is SignatureConsumer, IsolatedGovernance {
       _lastSigner = _signers[_i];
     }
 
-    IsolatedVote storage _v = _vote[_period];
+    IsolatedVote storage _v = _vote[_period][_epoch];
     uint256 _totalVoteWeight = _sumBridgeVoterWeights(_signers);
     if (_totalVoteWeight >= _minimumVoteWeight) {
       require(_totalVoteWeight > 0, "BOsGovernanceRelay: invalid vote weight");
       _v.status = VoteStatus.Approved;
       _lastSyncedPeriod = _period;
+      _lastSyncedEpoch = _epoch;
       return;
     }
 

--- a/contracts/extensions/isolated-governance/bridge-operator-governance/BOsGovernanceRelay.sol
+++ b/contracts/extensions/isolated-governance/bridge-operator-governance/BOsGovernanceRelay.sol
@@ -33,8 +33,7 @@ abstract contract BOsGovernanceRelay is SignatureConsumer, IsolatedGovernance {
     bytes32 _domainSeperator
   ) internal {
     require(
-      (_period > _lastSyncedPeriod && _epoch > _lastSyncedEpoch) ||
-        (_period == _lastSyncedPeriod && _epoch > _lastSyncedEpoch),
+      (_period >= _lastSyncedPeriod && _epoch > _lastSyncedEpoch),
       "BOsGovernanceRelay: query for outdated bridge operator set"
     );
     require(_operators.length > 0 && _signatures.length > 0, "BOsGovernanceRelay: invalid array length");

--- a/contracts/interfaces/IRoninGovernanceAdmin.sol
+++ b/contracts/interfaces/IRoninGovernanceAdmin.sol
@@ -14,7 +14,7 @@ interface IRoninGovernanceAdmin {
    * - The method caller is validator contract.
    *
    */
-  function createEmergencyExitVote(
+  function createEmergencyExitPoll(
     address _consensusAddr,
     address _recipientAfterUnlockedFund,
     uint256 _requestedAt,

--- a/contracts/interfaces/IRoninGovernanceAdmin.sol
+++ b/contracts/interfaces/IRoninGovernanceAdmin.sol
@@ -6,4 +6,18 @@ interface IRoninGovernanceAdmin {
    * @dev Returns the last voted block of the bridge voter.
    */
   function lastVotedBlock(address _bridgeVoter) external view returns (uint256);
+
+  /**
+   * @dev Create a vote to agree that an emergency exit is valid and should return the locked funds back.a
+   *
+   * Requirements:
+   * - The method caller is validator contract.
+   *
+   */
+  function createEmergencyExitVote(
+    address _consensusAddr,
+    address _recipientAfterUnlockedFund,
+    uint256 _requestedAt,
+    uint256 _expiredAt
+  ) external;
 }

--- a/contracts/interfaces/IRoninGovernanceAdmin.sol
+++ b/contracts/interfaces/IRoninGovernanceAdmin.sol
@@ -2,6 +2,21 @@
 pragma solidity ^0.8.0;
 
 interface IRoninGovernanceAdmin {
+  /// @dev Emitted when the bridge operators are approved.
+  event BridgeOperatorsApproved(uint256 _period, uint256 _epoch, address[] _operators);
+  /// @dev Emitted when an emergency exit poll is created.
+  event EmergencyExitPollCreated(
+    bytes32 _voteHash,
+    address _consensusAddr,
+    address _recipientAfterUnlockedFund,
+    uint256 _requestedAt,
+    uint256 _expiredAt
+  );
+  /// @dev Emitted when an emergency exit poll is approved.
+  event EmergencyExitPollApproved(bytes32 _voteHash);
+  /// @dev Emitted when an emergency exit poll is expired.
+  event EmergencyExitPollExpired(bytes32 _voteHash);
+
   /**
    * @dev Returns the last voted block of the bridge voter.
    */

--- a/contracts/interfaces/consumers/VoteStatusConsumer.sol
+++ b/contracts/interfaces/consumers/VoteStatusConsumer.sol
@@ -6,6 +6,7 @@ interface VoteStatusConsumer {
     Pending,
     Approved,
     Executed,
-    Rejected
+    Rejected,
+    Expired
   }
 }

--- a/contracts/interfaces/staking/ICandidateStaking.sol
+++ b/contracts/interfaces/staking/ICandidateStaking.sol
@@ -138,4 +138,14 @@ interface ICandidateStaking is IRewardPool {
    *
    */
   function requestRenounce(address _consensusAddr) external;
+
+  /**
+   * @dev Renounces being a validator candidate and takes back the delegating/staking amount.
+   *
+   * Requirements:
+   * - The consensus address is a validator candidate.
+   * - The method caller is the pool admin.
+   *
+   */
+  function requestEmergencyExit(address _consensusAddr) external;
 }

--- a/contracts/interfaces/validator/ICoinbaseExecution.sol
+++ b/contracts/interfaces/validator/ICoinbaseExecution.sol
@@ -14,9 +14,9 @@ interface ICoinbaseExecution is ISlashingExecution {
   /// @dev Emitted when the validator set is updated
   event ValidatorSetUpdated(uint256 indexed period, address[] consensusAddrs);
   /// @dev Emitted when the bridge operator set is updated, to mirror the in-jail and maintaining status of the validator.
-  event BlockProducerSetUpdated(uint256 indexed period, address[] consensusAddrs);
+  event BlockProducerSetUpdated(uint256 indexed period, uint256 indexed epoch, address[] consensusAddrs);
   /// @dev Emitted when the bridge operator set is updated.
-  event BridgeOperatorSetUpdated(uint256 indexed period, address[] bridgeOperators);
+  event BridgeOperatorSetUpdated(uint256 indexed period, uint256 indexed epoch, address[] bridgeOperators);
 
   /// @dev Emitted when the reward of the block producer is deprecated.
   event BlockRewardDeprecated(

--- a/contracts/interfaces/validator/IEmergencyExit.sol
+++ b/contracts/interfaces/validator/IEmergencyExit.sol
@@ -4,11 +4,15 @@ pragma solidity ^0.8.9;
 
 interface IEmergencyExit {
   /// @dev Emitted when the fund is locked from an emergency exit request
-  event EmergencyExitFundLocked(address indexed consensusAddr, uint256 lockedAmount);
+  event EmergencyExitRequested(address indexed consensusAddr, uint256 lockedAmount);
   /// @dev Emitted when the fund that locked from an emergency exit request is transferred to the recipient.
-  event EmergencyExitFundUnlocked(address indexed consensusAddr, address indexed recipient, uint256 unlockedAmount);
+  event EmergencyExitLockedFundReleased(
+    address indexed consensusAddr,
+    address indexed recipient,
+    uint256 unlockedAmount
+  );
   /// @dev Emitted when the fund that locked from an emergency exit request is failed to transferred back.
-  event EmergencyExitFundUnlockFailed(
+  event EmergencyExitLockedFundReleasingFailed(
     address indexed consensusAddr,
     address indexed recipient,
     uint256 unlockedAmount,
@@ -58,8 +62,8 @@ interface IEmergencyExit {
    * Requirements:
    * - The method caller is admin.
    *
-   * Emits the event `EmergencyExitFundUnlocked` if the fund is successfully unlocked.
-   * Emits the event `EmergencyExitFundUnlockFailed` if the fund is failed to unlock.
+   * Emits the event `EmergencyExitLockedFundReleased` if the fund is successfully unlocked.
+   * Emits the event `EmergencyExitLockedFundReleasingFailed` if the fund is failed to unlock.
    *
    */
   function execReleaseLockedFundForEmergencyExitRequest(address _consensusAddr, address payable _recipient) external;

--- a/contracts/interfaces/validator/IEmergencyExit.sol
+++ b/contracts/interfaces/validator/IEmergencyExit.sol
@@ -3,6 +3,8 @@
 pragma solidity ^0.8.9;
 
 interface IEmergencyExit {
+  /// @dev Emitted when the fund is locked from an emergency exit request
+  event EmergencyExitFundLocked(address indexed consensusAddr, uint256 lockedAmount);
   /// @dev Emitted when the fund that locked from an emergency exit request is transferred to the recipient.
   event EmergencyExitFundUnlocked(address indexed consensusAddr, address indexed recipient, uint256 unlockedAmount);
   /// @dev Emitted when the fund that locked from an emergency exit request is failed to transferred back.
@@ -61,4 +63,13 @@ interface IEmergencyExit {
    *
    */
   function unlockFundForEmergencyExitRequest(address _consensusAddr, address payable _recipient) external;
+
+  /**
+   * @dev Fallback function of `IStaking-requestEmergencyExit`.
+   *
+   * Requirements:
+   * - The method caller is staking contract.
+   *
+   */
+  function execEmergencyExit(address _consensusAddr, uint256 _secLeftToRevoke) external;
 }

--- a/contracts/interfaces/validator/IEmergencyExit.sol
+++ b/contracts/interfaces/validator/IEmergencyExit.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.9;
+
+interface IEmergencyExit {
+  function unlockFundForEmergencyExitRequest(address _consensusAddr, address payable _recipient) external;
+}

--- a/contracts/interfaces/validator/IEmergencyExit.sol
+++ b/contracts/interfaces/validator/IEmergencyExit.sol
@@ -62,7 +62,7 @@ interface IEmergencyExit {
    * Emits the event `EmergencyExitFundUnlockFailed` if the fund is failed to unlock.
    *
    */
-  function unlockFundForEmergencyExitRequest(address _consensusAddr, address payable _recipient) external;
+  function execReleaseLockedFundForEmergencyExitRequest(address _consensusAddr, address payable _recipient) external;
 
   /**
    * @dev Fallback function of `IStaking-requestEmergencyExit`.

--- a/contracts/interfaces/validator/IEmergencyExit.sol
+++ b/contracts/interfaces/validator/IEmergencyExit.sol
@@ -3,5 +3,62 @@
 pragma solidity ^0.8.9;
 
 interface IEmergencyExit {
+  /// @dev Emitted when the fund that locked from an emergency exit request is transferred to the recipient.
+  event EmergencyExitFundUnlocked(address indexed consensusAddr, address indexed recipient, uint256 unlockedAmount);
+  /// @dev Emitted when the fund that locked from an emergency exit request is failed to transferred back.
+  event EmergencyExitFundUnlockFailed(
+    address indexed consensusAddr,
+    address indexed recipient,
+    uint256 unlockedAmount,
+    uint256 contractBalance
+  );
+
+  /// @dev Emitted when the emergency exit locked amount is updated.
+  event EmergencyExitLockedAmountUpdated(uint256 amount);
+  /// @dev Emitted when the emergency expiry duration is updated.
+  event EmergencyExpiryDurationUpdated(uint256 amount);
+
+  /**
+   * @dev Returns the amount of RON to lock from a consensus address.
+   */
+  function emergencyExitLockedAmount() external returns (uint256);
+
+  /**
+   * @dev Returns the duration that an emergency request is expired and the fund will be recycled.
+   */
+  function emergencyExpiryDuration() external returns (uint256);
+
+  /**
+   * @dev Sets the amount of RON to lock from a consensus address.
+   *
+   * Requirements:
+   * - The method caller is admin.
+   *
+   * Emits the event `EmergencyExitLockedAmountUpdated`.
+   *
+   */
+  function setEmergencyExitLockedAmount(uint256 _emergencyExitLockedAmount) external;
+
+  /**
+   * @dev Sets the duration that an emergency request is expired and the fund will be recycled.
+   *
+   * Requirements:
+   * - The method caller is admin.
+   *
+   * Emits the event `EmergencyExpiryDurationUpdated`.
+   *
+   */
+  function setEmergencyExpiryDuration(uint256 _emergencyExpiryDuration) external;
+
+  /**
+   * @dev Unlocks fund for emergency exit request.
+   *
+   * Requirements:
+   * - The method caller is admin.
+   *
+   * Emits the event `EmergencyExitFundUnlocked` if the fund is successfully unlocked.
+   * Emits the event `EmergencyExitFundUnlockFailed` if the fund is failed to unlock.
+   *
+   */
   function unlockFundForEmergencyExitRequest(address _consensusAddr, address payable _recipient) external;
 }

--- a/contracts/interfaces/validator/IRoninValidatorSet.sol
+++ b/contracts/interfaces/validator/IRoninValidatorSet.sol
@@ -6,5 +6,12 @@ import "./ICandidateManager.sol";
 import "./info-fragments/ICommonInfo.sol";
 import "./ICoinbaseExecution.sol";
 import "./ISlashingExecution.sol";
+import "./IEmergencyExit.sol";
 
-interface IRoninValidatorSet is ICandidateManager, ICommonInfo, ISlashingExecution, ICoinbaseExecution {}
+interface IRoninValidatorSet is
+  ICandidateManager,
+  ICommonInfo,
+  ISlashingExecution,
+  ICoinbaseExecution,
+  IEmergencyExit
+{}

--- a/contracts/interfaces/validator/info-fragments/ICommonInfo.sol
+++ b/contracts/interfaces/validator/info-fragments/ICommonInfo.sol
@@ -7,6 +7,12 @@ import "./ITimingInfo.sol";
 import "./IValidatorInfo.sol";
 
 interface ICommonInfo is ITimingInfo, IJailingInfo, IValidatorInfo {
+  struct EmergencyExitInfo {
+    uint256 lockedAmount;
+    // The timestamp that this locked amount will be recycled to staking vesting contract
+    uint256 recyclingAt;
+  }
+
   /// @dev Emitted when the deprecated reward is withdrawn.
   event DeprecatedRewardRecycled(address indexed recipientAddr, uint256 amount);
   /// @dev Emitted when the deprecated reward withdrawal is failed
@@ -16,4 +22,9 @@ interface ICommonInfo is ITimingInfo, IJailingInfo, IValidatorInfo {
    * @dev Returns the total deprecated reward, which includes reward that is not sent for slashed validators and unsastified bridge operators
    */
   function totalDeprecatedReward() external view returns (uint256);
+
+  /**
+   * @dev Returns the emergency exit request.
+   */
+  function getEmergencyExitInfo(address _consensusAddr) external view returns (EmergencyExitInfo memory);
 }

--- a/contracts/interfaces/validator/info-fragments/IValidatorInfo.sol
+++ b/contracts/interfaces/validator/info-fragments/IValidatorInfo.sol
@@ -54,11 +54,6 @@ interface IValidatorInfo {
   function isBridgeOperator(address _addr) external view returns (bool);
 
   /**
-   * @dev Returns the bridge operator of a consensus address.
-   */
-  function bridgeOperatorOf(address _consensusAddr) external view returns (address);
-
-  /**
    * @dev Returns total numbers of the bridge operators.
    */
   function totalBridgeOperators() external view returns (uint256);

--- a/contracts/interfaces/validator/info-fragments/IValidatorInfo.sol
+++ b/contracts/interfaces/validator/info-fragments/IValidatorInfo.sol
@@ -54,6 +54,11 @@ interface IValidatorInfo {
   function isBridgeOperator(address _addr) external view returns (bool);
 
   /**
+   * @dev Returns the bridge operator of a consensus address.
+   */
+  function bridgeOperatorOf(address _consensusAddr) external view returns (address);
+
+  /**
    * @dev Returns total numbers of the bridge operators.
    */
   function totalBridgeOperators() external view returns (uint256);

--- a/contracts/interfaces/validator/info-fragments/IValidatorInfo.sol
+++ b/contracts/interfaces/validator/info-fragments/IValidatorInfo.sol
@@ -54,6 +54,11 @@ interface IValidatorInfo {
   function isBridgeOperator(address _addr) external view returns (bool);
 
   /**
+   * @dev Returns whether the consensus address is operatoring the bridge or not.
+   */
+  function isOperatingBridge(address _consensusAddr) external view returns (bool);
+
+  /**
    * @dev Returns total numbers of the bridge operators.
    */
   function totalBridgeOperators() external view returns (uint256);

--- a/contracts/libraries/BridgeOperatorsBallot.sol
+++ b/contracts/libraries/BridgeOperatorsBallot.sol
@@ -4,19 +4,23 @@ pragma solidity ^0.8.0;
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 
 library BridgeOperatorsBallot {
-  // keccak256("BridgeOperatorsBallot(uint256 period,address[] operators)");
+  // keccak256("BridgeOperatorsBallot(uint256 period,uint256 epoch,address[] operators)");
   bytes32 public constant BRIDGE_OPERATORS_BALLOT_TYPEHASH =
-    0xeea5e3908ac28cbdbbce8853e49444c558a0a03597e98ef19e6ff86162ed9ae3;
+    0xd679a49e9e099fa9ed83a5446aaec83e746b03ec6723d6f5efb29d37d7f0b78a;
 
   /**
    * @dev Returns hash of the ballot.
    */
-  function hash(uint256 _period, address[] memory _operators) internal pure returns (bytes32) {
+  function hash(
+    uint256 _period,
+    uint256 _epoch,
+    address[] memory _operators
+  ) internal pure returns (bytes32) {
     bytes32 _operatorsHash;
     assembly {
       _operatorsHash := keccak256(add(_operators, 32), mul(mload(_operators), 32))
     }
 
-    return keccak256(abi.encode(BRIDGE_OPERATORS_BALLOT_TYPEHASH, _period, _operatorsHash));
+    return keccak256(abi.encode(BRIDGE_OPERATORS_BALLOT_TYPEHASH, _period, _epoch, _operatorsHash));
   }
 }

--- a/contracts/libraries/BridgeOperatorsBallot.sol
+++ b/contracts/libraries/BridgeOperatorsBallot.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
-import "../interfaces/consumers/WeightedAddressConsumer.sol";
 
 library BridgeOperatorsBallot {
   // keccak256("BridgeOperatorsBallot(uint256 period,address[] operators)");

--- a/contracts/libraries/EmergencyExitBallot.sol
+++ b/contracts/libraries/EmergencyExitBallot.sol
@@ -4,9 +4,9 @@ pragma solidity ^0.8.0;
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 
 library EmergencyExitBallot {
-  // keccak256("EmergencyExitBallot(address consensusAddress,address recipientAfterUnlockedFund,uint256 requestedAt)");
+  // keccak256("EmergencyExitBallot(address consensusAddress,address recipientAfterUnlockedFund,uint256 requestedAt,uint256 expiredAt)");
   bytes32 public constant EMERGENCY_EXIT_BALLOT_TYPEHASH =
-    0x10e263cc106e7f73f987b170d2d40c1f3a1c905ac487982dec61e8bbceaa2071;
+    0x697acba4deaf1a718d8c2d93e42860488cb7812696f28ca10eed17bac41e7027;
 
   /**
    * @dev Returns hash of the ballot.
@@ -14,11 +14,18 @@ library EmergencyExitBallot {
   function hash(
     address _consensusAddress,
     address _recipientAfterUnlockedFund,
-    uint256 _requestedAt
+    uint256 _requestedAt,
+    uint256 _expiredAt
   ) internal pure returns (bytes32) {
     return
       keccak256(
-        abi.encode(EMERGENCY_EXIT_BALLOT_TYPEHASH, _consensusAddress, _recipientAfterUnlockedFund, _requestedAt)
+        abi.encode(
+          EMERGENCY_EXIT_BALLOT_TYPEHASH,
+          _consensusAddress,
+          _recipientAfterUnlockedFund,
+          _requestedAt,
+          _expiredAt
+        )
       );
   }
 }

--- a/contracts/libraries/EmergencyExitBallot.sol
+++ b/contracts/libraries/EmergencyExitBallot.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+
+library EmergencyExitBallot {
+  // keccak256("EmergencyExitBallot(address consensusAddress,address recipientAfterUnlockedFund,uint256 requestedAt)");
+  bytes32 public constant EMERGENCY_EXIT_BALLOT_TYPEHASH =
+    0x10e263cc106e7f73f987b170d2d40c1f3a1c905ac487982dec61e8bbceaa2071;
+
+  /**
+   * @dev Returns hash of the ballot.
+   */
+  function hash(
+    address _consensusAddress,
+    address _recipientAfterUnlockedFund,
+    uint256 _requestedAt
+  ) internal pure returns (bytes32) {
+    return
+      keccak256(
+        abi.encode(EMERGENCY_EXIT_BALLOT_TYPEHASH, _consensusAddress, _recipientAfterUnlockedFund, _requestedAt)
+      );
+  }
+}

--- a/contracts/mainchain/MainchainGovernanceAdmin.sol
+++ b/contracts/mainchain/MainchainGovernanceAdmin.sol
@@ -34,8 +34,8 @@ contract MainchainGovernanceAdmin is AccessControlEnumerable, GovernanceRelay, G
   /**
    * @dev Returns whether the voter `_voter` casted vote for bridge operators at a specific period.
    */
-  function bridgeOperatorsRelayed(uint256 _period) external view returns (bool) {
-    return _vote[_period].status != VoteStatus.Pending;
+  function bridgeOperatorsRelayed(uint256 _period, uint256 _epoch) external view returns (bool) {
+    return _vote[_period][_epoch].status != VoteStatus.Pending;
   }
 
   /**
@@ -85,10 +85,11 @@ contract MainchainGovernanceAdmin is AccessControlEnumerable, GovernanceRelay, G
    */
   function relayBridgeOperators(
     uint256 _period,
+    uint256 _epoch,
     address[] calldata _operators,
     Signature[] calldata _signatures
   ) external onlyRole(RELAYER_ROLE) {
-    _relayVotesBySignatures(_operators, _signatures, _period, _getMinimumVoteWeight(), DOMAIN_SEPARATOR);
+    _relayVotesBySignatures(_operators, _signatures, _period, _epoch, _getMinimumVoteWeight(), DOMAIN_SEPARATOR);
     TransparentUpgradeableProxyV2(payable(bridgeContract())).functionDelegateCall(
       abi.encodeWithSelector(_bridgeContract.replaceBridgeOperators.selector, _operators)
     );

--- a/contracts/mocks/validator/MockRoninValidatorSetExtended.sol
+++ b/contracts/mocks/validator/MockRoninValidatorSetExtended.sol
@@ -6,9 +6,17 @@ import "./MockRoninValidatorSetOverridePrecompile.sol";
 import "../../libraries/EnumFlags.sol";
 
 contract MockRoninValidatorSetExtended is MockRoninValidatorSetOverridePrecompile {
+  bool private _initialized;
   uint256[] internal _epochs;
 
   constructor() {}
+
+  function initEpoch() public {
+    if (!_initialized) {
+      _epochs.push(0);
+      _initialized = true;
+    }
+  }
 
   function endEpoch() external {
     _epochs.push(block.number);
@@ -16,7 +24,7 @@ contract MockRoninValidatorSetExtended is MockRoninValidatorSetOverridePrecompil
 
   function epochOf(uint256 _block) public view override returns (uint256 _epoch) {
     for (uint256 _i = _epochs.length; _i > 0; _i--) {
-      if (_block >= _epochs[_i - 1]) {
+      if (_block > _epochs[_i - 1]) {
         return _i;
       }
     }

--- a/contracts/mocks/validator/MockRoninValidatorSetExtended.sol
+++ b/contracts/mocks/validator/MockRoninValidatorSetExtended.sol
@@ -42,7 +42,7 @@ contract MockRoninValidatorSetExtended is MockRoninValidatorSetOverridePrecompil
   function getJailUntils(address[] calldata _addrs) public view returns (uint256[] memory jailUntils_) {
     jailUntils_ = new uint256[](_addrs.length);
     for (uint _i = 0; _i < _addrs.length; _i++) {
-      jailUntils_[_i] = _jailedUntil[_addrs[_i]];
+      jailUntils_[_i] = _blockProducerJailedBlock[_addrs[_i]];
     }
   }
 

--- a/contracts/mocks/validator/MockValidatorSet.sol
+++ b/contracts/mocks/validator/MockValidatorSet.sol
@@ -156,4 +156,10 @@ contract MockValidatorSet is IRoninValidatorSet, CandidateManager {
   function setEmergencyExpiryDuration(uint256 _emergencyExpiryDuration) external override {}
 
   function getEmergencyExitInfo(address _consensusAddr) external view override returns (EmergencyExitInfo memory) {}
+
+  function execEmergencyExit(address, uint256) external {}
+
+  function isOperatingBridge(address) external view returns (bool) {}
+
+  function _emergencyExitFundUnlocked(address _consensusAddr) internal virtual override returns (bool) {}
 }

--- a/contracts/mocks/validator/MockValidatorSet.sol
+++ b/contracts/mocks/validator/MockValidatorSet.sol
@@ -140,4 +140,15 @@ contract MockValidatorSet is IRoninValidatorSet, CandidateManager {
   {}
 
   function totalDeprecatedReward() external view override returns (uint256) {}
+
+  function bridgeOperatorOf(address _consensusAddr)
+    public
+    view
+    override(CandidateManager, IValidatorInfo)
+    returns (address)
+  {
+    return super.bridgeOperatorOf(_consensusAddr);
+  }
+
+  function unlockFundForEmergencyExitRequest(address _consensusAddr, address payable _recipient) external override {}
 }

--- a/contracts/mocks/validator/MockValidatorSet.sol
+++ b/contracts/mocks/validator/MockValidatorSet.sol
@@ -141,14 +141,19 @@ contract MockValidatorSet is IRoninValidatorSet, CandidateManager {
 
   function totalDeprecatedReward() external view override returns (uint256) {}
 
-  function bridgeOperatorOf(address _consensusAddr)
-    public
-    view
-    override(CandidateManager, IValidatorInfo)
-    returns (address)
-  {
-    return super.bridgeOperatorOf(_consensusAddr);
+  function _bridgeOperatorOf(address _consensusAddr) internal view override returns (address) {
+    return super._bridgeOperatorOf(_consensusAddr);
   }
 
   function unlockFundForEmergencyExitRequest(address _consensusAddr, address payable _recipient) external override {}
+
+  function emergencyExitLockedAmount() external override returns (uint256) {}
+
+  function emergencyExpiryDuration() external override returns (uint256) {}
+
+  function setEmergencyExitLockedAmount(uint256 _emergencyExitLockedAmount) external override {}
+
+  function setEmergencyExpiryDuration(uint256 _emergencyExpiryDuration) external override {}
+
+  function getEmergencyExitInfo(address _consensusAddr) external view override returns (EmergencyExitInfo memory) {}
 }

--- a/contracts/mocks/validator/MockValidatorSet.sol
+++ b/contracts/mocks/validator/MockValidatorSet.sol
@@ -145,7 +145,10 @@ contract MockValidatorSet is IRoninValidatorSet, CandidateManager {
     return super._bridgeOperatorOf(_consensusAddr);
   }
 
-  function unlockFundForEmergencyExitRequest(address _consensusAddr, address payable _recipient) external override {}
+  function execReleaseLockedFundForEmergencyExitRequest(address _consensusAddr, address payable _recipient)
+    external
+    override
+  {}
 
   function emergencyExitLockedAmount() external override returns (uint256) {}
 
@@ -161,5 +164,5 @@ contract MockValidatorSet is IRoninValidatorSet, CandidateManager {
 
   function isOperatingBridge(address) external view returns (bool) {}
 
-  function _emergencyExitFundUnlocked(address _consensusAddr) internal virtual override returns (bool) {}
+  function _emergencyExitLockedFundReleased(address _consensusAddr) internal virtual override returns (bool) {}
 }

--- a/contracts/ronin/RoninGovernanceAdmin.sol
+++ b/contracts/ronin/RoninGovernanceAdmin.sol
@@ -16,8 +16,8 @@ contract RoninGovernanceAdmin is
   BOsGovernanceProposal,
   HasValidatorContract
 {
-  /// @dev Mapping from request hash => bridge operators vote
-  mapping(bytes32 => IsolatedVote) internal _emergecyVote;
+  /// @dev Mapping from request hash => emergency poll
+  mapping(bytes32 => IsolatedVote) internal _emergencyExitPoll;
 
   /// @dev Emitted when the bridge operators are approved.
   event BridgeOperatorsApproved(uint256 _period, uint256 _epoch, address[] _operators);
@@ -266,7 +266,7 @@ contract RoninGovernanceAdmin is
     uint256 _expiredAt
   ) external onlyValidatorContract {
     bytes32 _hash = EmergencyExitBallot.hash(_consensusAddr, _recipientAfterUnlockedFund, _requestedAt, _expiredAt);
-    IsolatedVote storage _v = _emergecyVote[_hash];
+    IsolatedVote storage _v = _emergencyExitPoll[_hash];
     _v.createdAt = block.timestamp;
     _v.expiredAt = _expiredAt;
     emit EmergencyExitVoteCreated(_hash, _consensusAddr, _recipientAfterUnlockedFund, _requestedAt, _expiredAt);
@@ -295,7 +295,7 @@ contract RoninGovernanceAdmin is
     bytes32 _hash = EmergencyExitBallot.hash(_consensusAddr, _recipientAfterUnlockedFund, _requestedAt, _expiredAt);
     require(_voteHash == _hash, "RoninGovernanceAdmin: invalid vote hash");
 
-    IsolatedVote storage _v = _emergecyVote[_hash];
+    IsolatedVote storage _v = _emergencyExitPoll[_hash];
     require(_v.createdAt > 0, "RoninGovernanceAdmin: query for un-existent vote");
     require(_v.expiredAt > 0 && block.timestamp <= _v.expiredAt, "RoninGovernanceAdmin: query for expired vote");
 

--- a/contracts/ronin/RoninGovernanceAdmin.sol
+++ b/contracts/ronin/RoninGovernanceAdmin.sol
@@ -265,7 +265,7 @@ contract RoninGovernanceAdmin is
     uint256 _requestedAt,
     uint256 _expiredAt
   ) external onlyValidatorContract {
-    bytes32 _hash = EmergencyExitBallot.hash(_consensusAddr, _recipientAfterUnlockedFund, _requestedAt);
+    bytes32 _hash = EmergencyExitBallot.hash(_consensusAddr, _recipientAfterUnlockedFund, _requestedAt, _expiredAt);
     IsolatedVote storage _v = _emergecyVote[_hash];
     _v.createdAt = block.timestamp;
     _v.expiredAt = _expiredAt;
@@ -285,18 +285,19 @@ contract RoninGovernanceAdmin is
     bytes32 _voteHash,
     address _consensusAddr,
     address _recipientAfterUnlockedFund,
-    uint256 _requestedAt
+    uint256 _requestedAt,
+    uint256 _expiredAt
   ) external {
     address _voter = msg.sender;
     uint256 _weight = _getWeight(_voter);
     require(_weight > 0, "RoninGovernanceAdmin: sender is not governor");
 
-    bytes32 _hash = EmergencyExitBallot.hash(_consensusAddr, _recipientAfterUnlockedFund, _requestedAt);
+    bytes32 _hash = EmergencyExitBallot.hash(_consensusAddr, _recipientAfterUnlockedFund, _requestedAt, _expiredAt);
     require(_voteHash == _hash, "RoninGovernanceAdmin: invalid vote hash");
 
     IsolatedVote storage _v = _emergecyVote[_hash];
     require(_v.createdAt > 0, "RoninGovernanceAdmin: query for un-existent vote");
-    require(_v.expiredAt > 0 && _v.expiredAt <= block.timestamp, "RoninGovernanceAdmin: query for expired vote");
+    require(_v.expiredAt > 0 && block.timestamp <= _v.expiredAt, "RoninGovernanceAdmin: query for expired vote");
 
     if (_castVote(_v, _voter, _weight, _getMinimumVoteWeight(), _hash) == VoteStatus.Approved) {
       _unlockFundForEmergencyExitRequest(_consensusAddr, _recipientAfterUnlockedFund);

--- a/contracts/ronin/RoninGovernanceAdmin.sol
+++ b/contracts/ronin/RoninGovernanceAdmin.sol
@@ -38,8 +38,11 @@ contract RoninGovernanceAdmin is
   constructor(
     address _roninTrustedOrganizationContract,
     address _bridgeContract,
+    address _validatorContract,
     uint256 _proposalExpiryDuration
-  ) GovernanceAdmin(_roninTrustedOrganizationContract, _bridgeContract, _proposalExpiryDuration) {}
+  ) GovernanceAdmin(_roninTrustedOrganizationContract, _bridgeContract, _proposalExpiryDuration) {
+    _setValidatorContract(_validatorContract);
+  }
 
   /**
    * @inheritdoc IHasValidatorContract

--- a/contracts/ronin/RoninGovernanceAdmin.sol
+++ b/contracts/ronin/RoninGovernanceAdmin.sol
@@ -296,7 +296,7 @@ contract RoninGovernanceAdmin is
     require(_voteHash == _hash, "RoninGovernanceAdmin: invalid vote hash");
 
     IsolatedVote storage _v = _emergencyExitPoll[_hash];
-    require(_v.createdAt > 0, "RoninGovernanceAdmin: query for un-existent vote");
+    require(_v.createdAt > 0, "RoninGovernanceAdmin: query for non-existent vote");
     require(_v.expiredAt > 0 && block.timestamp <= _v.expiredAt, "RoninGovernanceAdmin: query for expired vote");
 
     if (_castVote(_v, _voter, _weight, _getMinimumVoteWeight(), _hash) == VoteStatus.Approved) {

--- a/contracts/ronin/RoninGovernanceAdmin.sol
+++ b/contracts/ronin/RoninGovernanceAdmin.sol
@@ -19,19 +19,6 @@ contract RoninGovernanceAdmin is
   /// @dev Mapping from request hash => emergency poll
   mapping(bytes32 => IsolatedVote) internal _emergencyExitPoll;
 
-  /// @dev Emitted when the bridge operators are approved.
-  event BridgeOperatorsApproved(uint256 _period, uint256 _epoch, address[] _operators);
-  /// @dev Emitted when an emergency exit poll is created.
-  event EmergencyExitPollCreated(
-    bytes32 _voteHash,
-    address _consensusAddr,
-    address _recipientAfterUnlockedFund,
-    uint256 _requestedAt,
-    uint256 _expiredAt
-  );
-  /// @dev Emitted when an emergency exit poll is expired.
-  event EmergencyExitPollExpired(bytes32 _voteHash);
-
   modifier onlyGovernor() {
     require(_getWeight(msg.sender) > 0, "RoninGovernanceAdmin: sender is not governor");
     _;
@@ -311,6 +298,7 @@ contract RoninGovernanceAdmin is
     VoteStatus _stt = _castVote(_v, _voter, _weight, _getMinimumVoteWeight(), _hash);
     if (_stt == VoteStatus.Approved) {
       _execReleaseLockedFundForEmergencyExitRequest(_consensusAddr, _recipientAfterUnlockedFund);
+      emit EmergencyExitPollApproved(_hash);
       _v.status = VoteStatus.Executed;
     } else if (_stt == VoteStatus.Expired) {
       emit EmergencyExitPollExpired(_hash);

--- a/contracts/ronin/RoninGovernanceAdmin.sol
+++ b/contracts/ronin/RoninGovernanceAdmin.sol
@@ -259,7 +259,7 @@ contract RoninGovernanceAdmin is
   /**
    * @inheritdoc IRoninGovernanceAdmin
    */
-  function createEmergencyExitVote(
+  function createEmergencyExitPoll(
     address _consensusAddr,
     address _recipientAfterUnlockedFund,
     uint256 _requestedAt,

--- a/contracts/ronin/staking/CandidateStaking.sol
+++ b/contracts/ronin/staking/CandidateStaking.sol
@@ -135,6 +135,18 @@ abstract contract CandidateStaking is BaseStaking, ICandidateStaking {
   }
 
   /**
+   * @inheritdoc ICandidateStaking
+   */
+  function requestEmergencyExit(address _consensusAddr)
+    external
+    override
+    poolExists(_consensusAddr)
+    onlyPoolAdmin(_stakingPool[_consensusAddr], msg.sender)
+  {
+    _validatorContract.execEmergencyExit(_consensusAddr, _waitingSecsToRevoke);
+  }
+
+  /**
    * @dev See `ICandidateStaking-applyValidatorCandidate`
    */
   function _applyValidatorCandidate(

--- a/contracts/ronin/validator/CandidateManager.sol
+++ b/contracts/ronin/validator/CandidateManager.sol
@@ -240,7 +240,8 @@ abstract contract CandidateManager is ICandidateManager, PercentageConsumer, Has
         }
 
         // Removes unsastisfied candidates
-        bool _revokingActivated = _info.revokingTimestamp != 0 && _info.revokingTimestamp <= block.timestamp;
+        bool _revokingActivated = (_info.revokingTimestamp != 0 && _info.revokingTimestamp <= block.timestamp) ||
+          _emergencyExitFundUnlocked(_addr);
         bool _topupDeadlineMissed = _info.topupDeadline != 0 && _info.topupDeadline <= block.timestamp;
         if (_revokingActivated || _topupDeadlineMissed) {
           _selfStakings[_i] = _selfStakings[--_length];
@@ -311,7 +312,7 @@ abstract contract CandidateManager is ICandidateManager, PercentageConsumer, Has
   /**
    * @dev Removes the candidate.
    */
-  function _removeCandidate(address _addr) private {
+  function _removeCandidate(address _addr) internal virtual {
     uint256 _idx = _candidateIndex[_addr];
     if (_idx == 0) {
       return;
@@ -338,4 +339,9 @@ abstract contract CandidateManager is ICandidateManager, PercentageConsumer, Has
     _candidate.revokingTimestamp = _timestamp;
     emit CandidateRevokingTimestampUpdated(_candidate.consensusAddr, _timestamp);
   }
+
+  /**
+   * @dev Returns a flag indicating whether the fund is unlocked.
+   */
+  function _emergencyExitFundUnlocked(address _consensusAddr) internal virtual returns (bool);
 }

--- a/contracts/ronin/validator/CandidateManager.sol
+++ b/contracts/ronin/validator/CandidateManager.sol
@@ -241,7 +241,7 @@ abstract contract CandidateManager is ICandidateManager, PercentageConsumer, Has
 
         // Removes unsastisfied candidates
         bool _revokingActivated = (_info.revokingTimestamp != 0 && _info.revokingTimestamp <= block.timestamp) ||
-          _emergencyExitFundUnlocked(_addr);
+          _emergencyExitLockedFundReleased(_addr);
         bool _topupDeadlineMissed = _info.topupDeadline != 0 && _info.topupDeadline <= block.timestamp;
         if (_revokingActivated || _topupDeadlineMissed) {
           _selfStakings[_i] = _selfStakings[--_length];
@@ -343,5 +343,5 @@ abstract contract CandidateManager is ICandidateManager, PercentageConsumer, Has
   /**
    * @dev Returns a flag indicating whether the fund is unlocked.
    */
-  function _emergencyExitFundUnlocked(address _consensusAddr) internal virtual returns (bool);
+  function _emergencyExitLockedFundReleased(address _consensusAddr) internal virtual returns (bool);
 }

--- a/contracts/ronin/validator/CandidateManager.sol
+++ b/contracts/ronin/validator/CandidateManager.sol
@@ -281,7 +281,7 @@ abstract contract CandidateManager is ICandidateManager, PercentageConsumer, Has
   /**
    * @dev Override `ValidatorInfoStorage-_bridgeOperatorOf`.
    */
-  function bridgeOperatorOf(address _consensusAddr) public view virtual returns (address) {
+  function _bridgeOperatorOf(address _consensusAddr) internal view virtual returns (address) {
     return _candidateInfo[_consensusAddr].bridgeOperatorAddr;
   }
 

--- a/contracts/ronin/validator/CoinbaseExecution.sol
+++ b/contracts/ronin/validator/CoinbaseExecution.sol
@@ -14,6 +14,7 @@ import "../../precompile-usages/PrecompileUsageSortValidators.sol";
 import "../../precompile-usages/PrecompileUsagePickValidatorSet.sol";
 import "./storage-fragments/CommonStorage.sol";
 import "./CandidateManager.sol";
+import "./EmergencyExit.sol";
 
 abstract contract CoinbaseExecution is
   ICoinbaseExecution,
@@ -24,8 +25,7 @@ abstract contract CoinbaseExecution is
   HasBridgeTrackingContract,
   HasMaintenanceContract,
   HasSlashIndicatorContract,
-  CandidateManager,
-  CommonStorage
+  EmergencyExit
 {
   using EnumFlags for EnumFlags.ValidatorFlag;
 
@@ -117,24 +117,12 @@ abstract contract CoinbaseExecution is
       _recycleDeprecatedRewards();
       _slashIndicatorContract.updateCreditScores(_currentValidators, _lastPeriod);
       _currentValidators = _syncValidatorSet(_newPeriod);
+      _tryRecycleLockedFundsFromEmergencyExits();
     }
     _revampRoles(_newPeriod, _nextEpoch, _currentValidators);
     emit WrappedUpEpoch(_lastPeriod, _epoch, _periodEnding);
     _periodOf[_nextEpoch] = _newPeriod;
     _lastUpdatedPeriod = _newPeriod;
-  }
-
-  /**
-   * @inheritdoc IValidatorInfo
-   */
-  function bridgeOperatorOf(address _consensusAddr)
-    public
-    view
-    virtual
-    override(CandidateManager, IValidatorInfo, ValidatorInfoStorage)
-    returns (address)
-  {
-    return super.bridgeOperatorOf(_consensusAddr);
   }
 
   /**

--- a/contracts/ronin/validator/CoinbaseExecution.sol
+++ b/contracts/ronin/validator/CoinbaseExecution.sol
@@ -104,8 +104,8 @@ abstract contract CoinbaseExecution is
 
     address[] memory _currentValidators = getValidators();
     uint256 _epoch = epochOf(block.number);
-    uint256 _lastPeriod = currentPeriod();
     uint256 _nextEpoch = _epoch + 1;
+    uint256 _lastPeriod = currentPeriod();
 
     if (_periodEnding) {
       _syncBridgeOperatingReward(_lastPeriod, _currentValidators);

--- a/contracts/ronin/validator/CoinbaseExecution.sol
+++ b/contracts/ronin/validator/CoinbaseExecution.sol
@@ -191,11 +191,14 @@ abstract contract CoinbaseExecution is
     if (_missedRatio > _ratioTier2) {
       _bridgeRewardDeprecatedAtPeriod[_validator][_period] = true;
       _miningRewardDeprecatedAtPeriod[_validator][_period] = true;
-      _jailedUntil[_validator] = Math.max(block.number + _jailDurationTier2, _jailedUntil[_validator]);
-      emit ValidatorPunished(_validator, _period, _jailedUntil[_validator], 0, true, true);
+      _blockProducerJailedBlock[_validator] = Math.max(
+        block.number + _jailDurationTier2,
+        _blockProducerJailedBlock[_validator]
+      );
+      emit ValidatorPunished(_validator, _period, _blockProducerJailedBlock[_validator], 0, true, true);
     } else if (_missedRatio > _ratioTier1) {
       _bridgeRewardDeprecatedAtPeriod[_validator][_period] = true;
-      emit ValidatorPunished(_validator, _period, _jailedUntil[_validator], 0, false, true);
+      emit ValidatorPunished(_validator, _period, _blockProducerJailedBlock[_validator], 0, false, true);
     } else if (_totalBallots > 0) {
       _bridgeOperatingReward[_validator] = (_totalBridgeReward * _validatorBallots) / _totalBallots;
     }

--- a/contracts/ronin/validator/EmergencyExit.sol
+++ b/contracts/ronin/validator/EmergencyExit.sol
@@ -43,7 +43,7 @@ abstract contract EmergencyExit is IEmergencyExit, RONTransferHelper, CandidateM
       _lockedConsensusList.push(_consensusAddr);
       _info.lockedAmount = _deductedAmount;
       _info.recyclingAt = _recyclingAt;
-      IRoninGovernanceAdmin(_getAdmin()).createEmergencyExitVote(
+      IRoninGovernanceAdmin(_getAdmin()).createEmergencyExitPoll(
         _consensusAddr,
         _candidateInfo[_consensusAddr].treasuryAddr,
         block.timestamp,

--- a/contracts/ronin/validator/EmergencyExit.sol
+++ b/contracts/ronin/validator/EmergencyExit.sol
@@ -38,7 +38,6 @@ abstract contract EmergencyExit is IEmergencyExit, RONTransferHelper, CandidateM
 
     uint256 _deductedAmount = _stakingContract.deductStakingAmount(_consensusAddr, _emergencyExitLockedAmount);
     if (_deductedAmount > 0) {
-      emit EmergencyExitFundLocked(_consensusAddr, _deductedAmount);
       uint256 _recyclingAt = block.timestamp + _emergencyExpiryDuration;
       _lockedConsensusList.push(_consensusAddr);
       _info.lockedAmount = _deductedAmount;
@@ -50,6 +49,7 @@ abstract contract EmergencyExit is IEmergencyExit, RONTransferHelper, CandidateM
         _recyclingAt
       );
     }
+    emit EmergencyExitRequested(_consensusAddr, _deductedAmount);
   }
 
   /**
@@ -102,11 +102,11 @@ abstract contract EmergencyExit is IEmergencyExit, RONTransferHelper, CandidateM
 
       _lockedFundReleased[_consensusAddr] = true;
       if (_unsafeSendRON(_recipient, _amount, 3500)) {
-        emit EmergencyExitFundUnlocked(_consensusAddr, _recipient, _amount);
+        emit EmergencyExitLockedFundReleased(_consensusAddr, _recipient, _amount);
         return;
       }
 
-      emit EmergencyExitFundUnlockFailed(_consensusAddr, _recipient, _amount, address(this).balance);
+      emit EmergencyExitLockedFundReleasingFailed(_consensusAddr, _recipient, _amount, address(this).balance);
     }
   }
 

--- a/contracts/ronin/validator/EmergencyExit.sol
+++ b/contracts/ronin/validator/EmergencyExit.sol
@@ -2,33 +2,32 @@
 
 pragma solidity ^0.8.9;
 
-import "../../extensions/collections/HasBridgeTrackingContract.sol";
-import "../../extensions/collections/HasMaintenanceContract.sol";
-import "../../extensions/collections/HasSlashIndicatorContract.sol";
-import "../../extensions/collections/HasStakingVestingContract.sol";
 import "../../extensions/RONTransferHelper.sol";
-import "../../interfaces/validator/ICoinbaseExecution.sol";
-import "../../libraries/EnumFlags.sol";
-import "../../libraries/Math.sol";
+import "../../interfaces/IRoninGovernanceAdmin.sol";
+import "../../interfaces/validator/IEmergencyExit.sol";
 import "../../precompile-usages/PrecompileUsageSortValidators.sol";
 import "../../precompile-usages/PrecompileUsagePickValidatorSet.sol";
 import "./storage-fragments/CommonStorage.sol";
 import "./CandidateManager.sol";
 
-abstract contract EmergencyExit is ICoinbaseExecution, RONTransferHelper, CandidateManager, CommonStorage {
-  struct EmergencyExitInfo {
-    uint256 lockedAmount;
-    // The timestamp that this locked amount will be recycled to staking vesting contract
-    uint256 recyclingAt;
+abstract contract EmergencyExit is IEmergencyExit, RONTransferHelper, CandidateManager, CommonStorage {
+  /**
+   * @inheritdoc IEmergencyExit
+   */
+  function emergencyExitLockedAmount() external view returns (uint256) {
+    return _emergencyExitLockedAmount;
   }
 
-  uint256 public emergencyExitLockedAmount;
+  /**
+   * @inheritdoc IEmergencyExit
+   */
+  function emergencyExpiryDuration() external view returns (uint256) {
+    return _emergencyExpiryDuration;
+  }
 
-  address[] internal _lockedConsensusList;
-
-  /// @dev Mapping from consensus => exit request
-  mapping(address => EmergencyExitInfo) internal _exitInfo;
-
+  /**
+   * @dev Fallback function of ``. TODO
+   */
   function execEmergencyExit(address _consensusAddr, uint256 _secLeftToRevoke) external onlyStakingContract {
     EmergencyExitInfo storage _info = _exitInfo[_consensusAddr];
     require(_info.recyclingAt == 0, "EmergencyExit: already requested");
@@ -37,17 +36,39 @@ abstract contract EmergencyExit is ICoinbaseExecution, RONTransferHelper, Candid
     _setRevokingTimestamp(_candidateInfo[_consensusAddr], _revokingTimestamp);
     _bridgeOperatorJailedTimestamp[_consensusAddr] = _revokingTimestamp;
 
-    uint256 _deductedAmount = _stakingContract.deductStakingAmount(_consensusAddr, emergencyExitLockedAmount);
+    uint256 _deductedAmount = _stakingContract.deductStakingAmount(_consensusAddr, _emergencyExitLockedAmount);
     if (_deductedAmount > 0) {
+      uint256 _recyclingAt = block.timestamp + _emergencyExpiryDuration;
       _lockedConsensusList.push(_consensusAddr);
       _info.lockedAmount = _deductedAmount;
-      _info.recyclingAt = block.timestamp + 14 days; // TODO
-      // sends request to GA
+      _info.recyclingAt = _recyclingAt;
+      IRoninGovernanceAdmin(_getAdmin()).createEmergencyExitVote(
+        _consensusAddr,
+        _candidateInfo[_consensusAddr].treasuryAddr,
+        block.timestamp,
+        _recyclingAt
+      );
     }
   }
 
   /**
-   * @dev _.
+   * @inheritdoc IEmergencyExit
+   */
+  function setEmergencyExitLockedAmount(uint256 _emergencyExitLockedAmount) external onlyAdmin {
+    _emergencyExitLockedAmount = _emergencyExitLockedAmount;
+    emit EmergencyExitLockedAmountUpdated(_emergencyExitLockedAmount);
+  }
+
+  /**
+   * @inheritdoc IEmergencyExit
+   */
+  function setEmergencyExpiryDuration(uint256 _emergencyExpiryDuration) external onlyAdmin {
+    _emergencyExpiryDuration = _emergencyExpiryDuration;
+    emit EmergencyExpiryDurationUpdated(_emergencyExpiryDuration);
+  }
+
+  /**
+   * @inheritdoc IEmergencyExit
    */
   function unlockFundForEmergencyExitRequest(address _consensusAddr, address payable _recipient) external onlyAdmin {
     uint256 _length = _lockedConsensusList.length;
@@ -60,29 +81,28 @@ abstract contract EmergencyExit is ICoinbaseExecution, RONTransferHelper, Candid
       }
     }
 
-    // The locked amount might be recycled
+    // The locked amount might be recycled.
     if (_index == _length) {
       return;
     }
 
     uint256 _amount = _exitInfo[_consensusAddr].lockedAmount;
-    if (_amount > 0) {
-      if (_unsafeSendRON(_recipient, _amount)) {
-        // emit Event(_consensusAddr, _recipient, _amount);
-        return;
-      }
-      // emit EventFailed(_consensusAddr, _recipient, _amount, address(this).balance);
-    }
-
     delete _exitInfo[_consensusAddr];
     _lockedConsensusList[_index] = _lockedConsensusList[_length - 1];
     _lockedConsensusList.pop();
+    if (_amount > 0) {
+      if (_unsafeSendRON(_recipient, _amount)) {
+        emit EmergencyExitFundUnlocked(_consensusAddr, _recipient, _amount);
+        return;
+      }
+      emit EmergencyExitFundUnlockFailed(_consensusAddr, _recipient, _amount, address(this).balance);
+    }
   }
 
   /**
-   * @dev _.
+   * @dev Tries to recycle the locked funds from emergency exit requests.
    */
-  function _tryRecycleLockedAmounts() internal {
+  function _tryRecycleLockedFundsFromEmergencyExits() internal {
     uint256 _length = _lockedConsensusList.length;
 
     uint256 _i;
@@ -106,16 +126,13 @@ abstract contract EmergencyExit is ICoinbaseExecution, RONTransferHelper, Candid
     }
   }
 
-  /**
-   * @inheritdoc IValidatorInfo
-   */
-  function bridgeOperatorOf(address _consensusAddr)
-    public
+  function _bridgeOperatorOf(address _consensusAddr)
+    internal
     view
     virtual
-    override(CandidateManager, IValidatorInfo, ValidatorInfoStorage)
+    override(CandidateManager, ValidatorInfoStorage)
     returns (address)
   {
-    return CandidateManager.bridgeOperatorOf(_consensusAddr);
+    return CandidateManager._bridgeOperatorOf(_consensusAddr);
   }
 }

--- a/contracts/ronin/validator/EmergencyExit.sol
+++ b/contracts/ronin/validator/EmergencyExit.sol
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.9;
+
+import "../../extensions/collections/HasBridgeTrackingContract.sol";
+import "../../extensions/collections/HasMaintenanceContract.sol";
+import "../../extensions/collections/HasSlashIndicatorContract.sol";
+import "../../extensions/collections/HasStakingVestingContract.sol";
+import "../../extensions/RONTransferHelper.sol";
+import "../../interfaces/validator/ICoinbaseExecution.sol";
+import "../../libraries/EnumFlags.sol";
+import "../../libraries/Math.sol";
+import "../../precompile-usages/PrecompileUsageSortValidators.sol";
+import "../../precompile-usages/PrecompileUsagePickValidatorSet.sol";
+import "./storage-fragments/CommonStorage.sol";
+import "./CandidateManager.sol";
+
+abstract contract EmergencyExit is ICoinbaseExecution, RONTransferHelper, CandidateManager, CommonStorage {
+  struct EmergencyExitInfo {
+    uint256 lockedAmount;
+    // The timestamp that this locked amount will be recycled to staking vesting contract
+    uint256 recyclingAt;
+  }
+
+  uint256 public emergencyExitLockedAmount;
+
+  address[] internal _lockedConsensusList;
+
+  /// @dev Mapping from consensus => exit request
+  mapping(address => EmergencyExitInfo) internal _exitInfo;
+
+  function execEmergencyExit(address _consensusAddr, uint256 _secLeftToRevoke) external onlyStakingContract {
+    EmergencyExitInfo storage _info = _exitInfo[_consensusAddr];
+    require(_info.recyclingAt == 0, "EmergencyExit: already requested");
+
+    uint256 _revokingTimestamp = block.timestamp + _secLeftToRevoke;
+    _setRevokingTimestamp(_candidateInfo[_consensusAddr], _revokingTimestamp);
+    _bridgeOperatorJailedTimestamp[_consensusAddr] = _revokingTimestamp;
+
+    uint256 _deductedAmount = _stakingContract.deductStakingAmount(_consensusAddr, emergencyExitLockedAmount);
+    if (_deductedAmount > 0) {
+      _lockedConsensusList.push(_consensusAddr);
+      _info.lockedAmount = _deductedAmount;
+      _info.recyclingAt = block.timestamp + 14 days; // TODO
+      // sends request to GA
+    }
+  }
+
+  /**
+   * @dev _.
+   */
+  function unlockFundForEmergencyExitRequest(address _consensusAddr, address payable _recipient) external onlyAdmin {
+    uint256 _length = _lockedConsensusList.length;
+    uint256 _index = _length;
+
+    for (uint _i = 0; _i < _length; _i++) {
+      if (_lockedConsensusList[_i] == _consensusAddr) {
+        _index = _i;
+        break;
+      }
+    }
+
+    // The locked amount might be recycled
+    if (_index == _length) {
+      return;
+    }
+
+    uint256 _amount = _exitInfo[_consensusAddr].lockedAmount;
+    if (_amount > 0) {
+      if (_unsafeSendRON(_recipient, _amount)) {
+        // emit Event(_consensusAddr, _recipient, _amount);
+        return;
+      }
+      // emit EventFailed(_consensusAddr, _recipient, _amount, address(this).balance);
+    }
+
+    delete _exitInfo[_consensusAddr];
+    _lockedConsensusList[_index] = _lockedConsensusList[_length - 1];
+    _lockedConsensusList.pop();
+  }
+
+  /**
+   * @dev _.
+   */
+  function _tryRecycleLockedAmounts() internal {
+    uint256 _length = _lockedConsensusList.length;
+
+    uint256 _i;
+    address _addr;
+    EmergencyExitInfo storage _info;
+
+    while (_i < _length) {
+      _addr = _lockedConsensusList[_i];
+      _info = _exitInfo[_addr];
+
+      if (_info.recyclingAt <= block.timestamp) {
+        _totalDeprecatedReward += _info.lockedAmount;
+
+        delete _exitInfo[_addr];
+        _lockedConsensusList[_i] = _lockedConsensusList[--_length];
+        _lockedConsensusList.pop();
+        continue;
+      }
+
+      _i++;
+    }
+  }
+
+  /**
+   * @inheritdoc IValidatorInfo
+   */
+  function bridgeOperatorOf(address _consensusAddr)
+    public
+    view
+    virtual
+    override(CandidateManager, IValidatorInfo, ValidatorInfoStorage)
+    returns (address)
+  {
+    return CandidateManager.bridgeOperatorOf(_consensusAddr);
+  }
+}

--- a/contracts/ronin/validator/RoninValidatorSet.sol
+++ b/contracts/ronin/validator/RoninValidatorSet.sol
@@ -52,7 +52,7 @@ contract RoninValidatorSet is Initializable, CoinbaseExecution, SlashingExecutio
 
   /**
    * @dev Only receives RON from staking vesting contract (for topping up bonus), and from staking contract (for transferring
-   * deducting amount when slash).
+   * deducting amount on slashing).
    */
   function _fallback() internal view {
     require(
@@ -61,15 +61,12 @@ contract RoninValidatorSet is Initializable, CoinbaseExecution, SlashingExecutio
     );
   }
 
-  /**
-   * @dev Override `ValidatorInfoStorage-_bridgeOperatorOf`.
-   */
-  function bridgeOperatorOf(address _consensusAddr)
-    public
+  function _bridgeOperatorOf(address _consensusAddr)
+    internal
     view
-    override(CoinbaseExecution, IValidatorInfo, ValidatorInfoStorage)
+    override(EmergencyExit, ValidatorInfoStorage)
     returns (address)
   {
-    return super.bridgeOperatorOf(_consensusAddr);
+    return super._bridgeOperatorOf(_consensusAddr);
   }
 }

--- a/contracts/ronin/validator/RoninValidatorSet.sol
+++ b/contracts/ronin/validator/RoninValidatorSet.sol
@@ -7,6 +7,7 @@ import "../../interfaces/validator/IRoninValidatorSet.sol";
 import "./CoinbaseExecution.sol";
 import "./SlashingExecution.sol";
 
+// IRoninValidatorSet
 contract RoninValidatorSet is Initializable, CoinbaseExecution, SlashingExecution {
   constructor() {
     _disableInitializers();
@@ -63,12 +64,12 @@ contract RoninValidatorSet is Initializable, CoinbaseExecution, SlashingExecutio
   /**
    * @dev Override `ValidatorInfoStorage-_bridgeOperatorOf`.
    */
-  function _bridgeOperatorOf(address _consensusAddr)
-    internal
+  function bridgeOperatorOf(address _consensusAddr)
+    public
     view
-    override(CoinbaseExecution, ValidatorInfoStorage)
+    override(CoinbaseExecution, IValidatorInfo, ValidatorInfoStorage)
     returns (address)
   {
-    return CoinbaseExecution._bridgeOperatorOf(_consensusAddr);
+    return super.bridgeOperatorOf(_consensusAddr);
   }
 }

--- a/contracts/ronin/validator/RoninValidatorSet.sol
+++ b/contracts/ronin/validator/RoninValidatorSet.sol
@@ -7,7 +7,6 @@ import "../../interfaces/validator/IRoninValidatorSet.sol";
 import "./CoinbaseExecution.sol";
 import "./SlashingExecution.sol";
 
-// IRoninValidatorSet
 contract RoninValidatorSet is Initializable, CoinbaseExecution, SlashingExecution {
   constructor() {
     _disableInitializers();

--- a/contracts/ronin/validator/RoninValidatorSet.sol
+++ b/contracts/ronin/validator/RoninValidatorSet.sol
@@ -34,7 +34,10 @@ contract RoninValidatorSet is Initializable, CoinbaseExecution, SlashingExecutio
     uint256 __maxValidatorCandidate,
     uint256 __maxPrioritizedValidatorNumber,
     uint256 __minEffectiveDaysOnwards,
-    uint256 __numberOfBlocksInEpoch
+    uint256 __numberOfBlocksInEpoch,
+    // __emergencyExitConfigs[0]: emergencyExitLockedAmount
+    // __emergencyExitConfigs[1]: emergencyExpiryDuration
+    uint256[2] calldata __emergencyExitConfigs
   ) external initializer {
     _setSlashIndicatorContract(__slashIndicatorContract);
     _setStakingContract(__stakingContract);
@@ -46,6 +49,8 @@ contract RoninValidatorSet is Initializable, CoinbaseExecution, SlashingExecutio
     _setMaxValidatorCandidate(__maxValidatorCandidate);
     _setMaxPrioritizedValidatorNumber(__maxPrioritizedValidatorNumber);
     _setMinEffectiveDaysOnwards(__minEffectiveDaysOnwards);
+    _setEmergencyExitLockedAmount(__emergencyExitConfigs[0]);
+    _setEmergencyExpiryDuration(__emergencyExitConfigs[1]);
     _numberOfBlocksInEpoch = __numberOfBlocksInEpoch;
   }
 
@@ -60,6 +65,9 @@ contract RoninValidatorSet is Initializable, CoinbaseExecution, SlashingExecutio
     );
   }
 
+  /**
+   * @dev Override `ValidatorInfoStorage-_bridgeOperatorOf`.
+   */
   function _bridgeOperatorOf(address _consensusAddr)
     internal
     view

--- a/contracts/ronin/validator/SlashingExecution.sol
+++ b/contracts/ronin/validator/SlashingExecution.sol
@@ -29,8 +29,8 @@ abstract contract SlashingExecution is
     delete _miningReward[_validatorAddr];
     delete _delegatingReward[_validatorAddr];
 
-    if (_newJailedUntil > _jailedUntil[_validatorAddr]) {
-      _jailedUntil[_validatorAddr] = _newJailedUntil;
+    if (_newJailedUntil > _blockProducerJailedBlock[_validatorAddr]) {
+      _blockProducerJailedBlock[_validatorAddr] = _newJailedUntil;
     }
 
     if (_slashAmount > 0) {
@@ -38,7 +38,14 @@ abstract contract SlashingExecution is
       _totalDeprecatedReward += _actualAmount;
     }
 
-    emit ValidatorPunished(_validatorAddr, _period, _jailedUntil[_validatorAddr], _slashAmount, true, false);
+    emit ValidatorPunished(
+      _validatorAddr,
+      _period,
+      _blockProducerJailedBlock[_validatorAddr],
+      _slashAmount,
+      true,
+      false
+    );
   }
 
   /**
@@ -49,7 +56,7 @@ abstract contract SlashingExecution is
     // removed previously in the `slash` function.
     _miningRewardBailoutCutOffAtPeriod[_validatorAddr][_period] = true;
     _miningRewardDeprecatedAtPeriod[_validatorAddr][_period] = false;
-    _jailedUntil[_validatorAddr] = block.number - 1;
+    _blockProducerJailedBlock[_validatorAddr] = block.number - 1;
 
     emit ValidatorUnjailed(_validatorAddr, _period);
   }

--- a/contracts/ronin/validator/storage-fragments/CommonStorage.sol
+++ b/contracts/ronin/validator/storage-fragments/CommonStorage.sol
@@ -29,8 +29,8 @@ abstract contract CommonStorage is ICommonInfo, TimingStorage, JailingStorage, V
   address[] internal _lockedConsensusList;
   /// @dev Mapping from consensus => request exist info
   mapping(address => EmergencyExitInfo) internal _exitInfo;
-  /// @dev Mapping from consensus => flag indicating whether the fund is unlocked
-  mapping(address => bool) internal _fundUnlocked;
+  /// @dev Mapping from consensus => flag indicating whether the locked fund is released
+  mapping(address => bool) internal _lockedFundReleased;
 
   /**
    * @dev This empty reserved space is put in place to allow future versions to add new

--- a/contracts/ronin/validator/storage-fragments/CommonStorage.sol
+++ b/contracts/ronin/validator/storage-fragments/CommonStorage.sol
@@ -29,12 +29,14 @@ abstract contract CommonStorage is ICommonInfo, TimingStorage, JailingStorage, V
   address[] internal _lockedConsensusList;
   /// @dev Mapping from consensus => request exist info
   mapping(address => EmergencyExitInfo) internal _exitInfo;
+  /// @dev Mapping from consensus => flag indicating whether the fund is unlocked
+  mapping(address => bool) internal _fundUnlocked;
 
   /**
    * @dev This empty reserved space is put in place to allow future versions to add new
    * variables without shifting down storage in the inheritance chain.
    */
-  uint256[45] private ______gap;
+  uint256[44] private ______gap;
 
   /**
    * @inheritdoc ICommonInfo

--- a/contracts/ronin/validator/storage-fragments/CommonStorage.sol
+++ b/contracts/ronin/validator/storage-fragments/CommonStorage.sol
@@ -21,11 +21,33 @@ abstract contract CommonStorage is ICommonInfo, TimingStorage, JailingStorage, V
   /// @dev The deprecated reward that has not been withdrawn by admin
   uint256 internal _totalDeprecatedReward;
 
+  /// @dev The amount of RON to lock from a consensus address.
+  uint256 internal _emergencyExitLockedAmount;
+  /// @dev The duration that an emergency request is expired and the fund will be recycled.
+  uint256 internal _emergencyExpiryDuration;
+  /// @dev The address list of consensus addresses that being locked fund.
+  address[] internal _lockedConsensusList;
+  /// @dev Mapping from consensus => request exist info
+  mapping(address => EmergencyExitInfo) internal _exitInfo;
+
   /**
    * @dev This empty reserved space is put in place to allow future versions to add new
    * variables without shifting down storage in the inheritance chain.
    */
-  uint256[49] private ______gap;
+  uint256[45] private ______gap;
+
+  /**
+   * @inheritdoc ICommonInfo
+   */
+  function getEmergencyExitInfo(address _consensusAddr)
+    external
+    view
+    override
+    returns (EmergencyExitInfo memory _info)
+  {
+    _info = _exitInfo[_consensusAddr];
+    require(_info.recyclingAt > 0, "CommonStorage: non-existent info");
+  }
 
   /**
    * @inheritdoc ICommonInfo

--- a/contracts/ronin/validator/storage-fragments/JailingStorage.sol
+++ b/contracts/ronin/validator/storage-fragments/JailingStorage.sol
@@ -14,7 +14,7 @@ abstract contract JailingStorage is IJailingInfo {
   mapping(address => mapping(uint256 => bool)) internal _bridgeRewardDeprecatedAtPeriod;
 
   /// @dev Mapping from consensus address => the last block that the block producer is jailed
-  mapping(address => uint256) internal _jailedUntil;
+  mapping(address => uint256) internal _blockProducerJailedBlock;
   /// @dev Mapping from consensus address => the last timestamp that the bridge operator is jailed
   mapping(address => uint256) internal _emergencyExitJailedTimestamp;
 
@@ -67,7 +67,7 @@ abstract contract JailingStorage is IJailingInfo {
       uint256 epochLeft_
     )
   {
-    uint256 _jailedBlock = _jailedUntil[_addr];
+    uint256 _jailedBlock = _blockProducerJailedBlock[_addr];
     if (_jailedBlock < _blockNum) {
       return (false, 0, 0);
     }
@@ -139,7 +139,7 @@ abstract contract JailingStorage is IJailingInfo {
    * @dev Returns whether the reward of the validator is put in jail (cannot join the set of validators) at a specific block.
    */
   function _jailedAtBlock(address _validatorAddr, uint256 _blockNum) internal view returns (bool) {
-    return _blockNum <= _jailedUntil[_validatorAddr];
+    return _blockNum <= _blockProducerJailedBlock[_validatorAddr];
   }
 
   /**

--- a/contracts/ronin/validator/storage-fragments/JailingStorage.sol
+++ b/contracts/ronin/validator/storage-fragments/JailingStorage.sol
@@ -16,7 +16,7 @@ abstract contract JailingStorage is IJailingInfo {
   /// @dev Mapping from consensus address => the last block that the block producer is jailed
   mapping(address => uint256) internal _jailedUntil;
   /// @dev Mapping from consensus address => the last timestamp that the bridge operator is jailed
-  mapping(address => uint256) internal _bridgeOperatorJailedTimestamp;
+  mapping(address => uint256) internal _emergencyExitJailedTimestamp;
 
   /**
    * @dev This empty reserved space is put in place to allow future versions to add new

--- a/contracts/ronin/validator/storage-fragments/JailingStorage.sol
+++ b/contracts/ronin/validator/storage-fragments/JailingStorage.sol
@@ -12,14 +12,17 @@ abstract contract JailingStorage is IJailingInfo {
   mapping(address => mapping(uint256 => bool)) internal _miningRewardBailoutCutOffAtPeriod;
   /// @dev Mapping from consensus address => period number => block operator has no pending reward
   mapping(address => mapping(uint256 => bool)) internal _bridgeRewardDeprecatedAtPeriod;
-  /// @dev Mapping from consensus address => the last block that the validator is jailed
+
+  /// @dev Mapping from consensus address => the last block that the block producer is jailed
   mapping(address => uint256) internal _jailedUntil;
+  /// @dev Mapping from consensus address => the last timestamp that the bridge operator is jailed
+  mapping(address => uint256) internal _bridgeOperatorJailedTimestamp;
 
   /**
    * @dev This empty reserved space is put in place to allow future versions to add new
    * variables without shifting down storage in the inheritance chain.
    */
-  uint256[50] private ______gap;
+  uint256[49] private ______gap;
 
   /**
    * @inheritdoc IJailingInfo

--- a/contracts/ronin/validator/storage-fragments/ValidatorInfoStorage.sol
+++ b/contracts/ronin/validator/storage-fragments/ValidatorInfoStorage.sol
@@ -85,7 +85,7 @@ abstract contract ValidatorInfoStorage is IValidatorInfo, HasRoninTrustedOrganiz
   function getBridgeOperators() public view override returns (address[] memory _bridgeOperatorList) {
     _bridgeOperatorList = new address[](validatorCount);
     for (uint _i = 0; _i < _bridgeOperatorList.length; _i++) {
-      _bridgeOperatorList[_i] = bridgeOperatorOf(_validators[_i]);
+      _bridgeOperatorList[_i] = _bridgeOperatorOf(_validators[_i]);
     }
   }
 
@@ -94,7 +94,7 @@ abstract contract ValidatorInfoStorage is IValidatorInfo, HasRoninTrustedOrganiz
    */
   function isBridgeOperator(address _bridgeOperatorAddr) external view override returns (bool _result) {
     for (uint _i = 0; _i < validatorCount; _i++) {
-      if (bridgeOperatorOf(_validators[_i]) == _bridgeOperatorAddr) {
+      if (_bridgeOperatorOf(_validators[_i]) == _bridgeOperatorAddr) {
         _result = true;
         break;
       }
@@ -139,9 +139,9 @@ abstract contract ValidatorInfoStorage is IValidatorInfo, HasRoninTrustedOrganiz
   }
 
   /**
-   * @inheritdoc IValidatorInfo
+   * @dev Returns the bridge operator of a consensus address.
    */
-  function bridgeOperatorOf(address _consensusAddr) public view virtual returns (address);
+  function _bridgeOperatorOf(address _consensusAddr) internal view virtual returns (address);
 
   /**
    * @dev See `IValidatorInfo-setMaxValidatorNumber`

--- a/contracts/ronin/validator/storage-fragments/ValidatorInfoStorage.sol
+++ b/contracts/ronin/validator/storage-fragments/ValidatorInfoStorage.sol
@@ -85,7 +85,7 @@ abstract contract ValidatorInfoStorage is IValidatorInfo, HasRoninTrustedOrganiz
   function getBridgeOperators() public view override returns (address[] memory _bridgeOperatorList) {
     _bridgeOperatorList = new address[](validatorCount);
     for (uint _i = 0; _i < _bridgeOperatorList.length; _i++) {
-      _bridgeOperatorList[_i] = _bridgeOperatorOf(_validators[_i]);
+      _bridgeOperatorList[_i] = bridgeOperatorOf(_validators[_i]);
     }
   }
 
@@ -94,7 +94,7 @@ abstract contract ValidatorInfoStorage is IValidatorInfo, HasRoninTrustedOrganiz
    */
   function isBridgeOperator(address _bridgeOperatorAddr) external view override returns (bool _result) {
     for (uint _i = 0; _i < validatorCount; _i++) {
-      if (_bridgeOperatorOf(_validators[_i]) == _bridgeOperatorAddr) {
+      if (bridgeOperatorOf(_validators[_i]) == _bridgeOperatorAddr) {
         _result = true;
         break;
       }
@@ -139,6 +139,11 @@ abstract contract ValidatorInfoStorage is IValidatorInfo, HasRoninTrustedOrganiz
   }
 
   /**
+   * @inheritdoc IValidatorInfo
+   */
+  function bridgeOperatorOf(address _consensusAddr) public view virtual returns (address);
+
+  /**
    * @dev See `IValidatorInfo-setMaxValidatorNumber`
    */
   function _setMaxValidatorNumber(uint256 _number) internal {
@@ -158,9 +163,4 @@ abstract contract ValidatorInfoStorage is IValidatorInfo, HasRoninTrustedOrganiz
     _maxPrioritizedValidatorNumber = _number;
     emit MaxPrioritizedValidatorNumberUpdated(_number);
   }
-
-  /**
-   * @dev Returns the bridge operator of a consensus address.
-   */
-  function _bridgeOperatorOf(address _consensusAddr) internal view virtual returns (address);
 }

--- a/contracts/ronin/validator/storage-fragments/ValidatorInfoStorage.sol
+++ b/contracts/ronin/validator/storage-fragments/ValidatorInfoStorage.sol
@@ -82,10 +82,17 @@ abstract contract ValidatorInfoStorage is IValidatorInfo, HasRoninTrustedOrganiz
   /**
    * @inheritdoc IValidatorInfo
    */
-  function getBridgeOperators() public view override returns (address[] memory _bridgeOperatorList) {
-    _bridgeOperatorList = new address[](validatorCount);
-    for (uint _i = 0; _i < _bridgeOperatorList.length; _i++) {
-      _bridgeOperatorList[_i] = _bridgeOperatorOf(_validators[_i]);
+  function getBridgeOperators() public view override returns (address[] memory _result) {
+    _result = new address[](validatorCount);
+    uint256 _count = 0;
+    for (uint _i = 0; _i < _result.length; _i++) {
+      if (isBlockProducer(_validators[_i])) {
+        _result[_count++] = _bridgeOperatorOf(_validators[_i]);
+      }
+    }
+
+    assembly {
+      mstore(_result, _count)
     }
   }
 
@@ -94,11 +101,18 @@ abstract contract ValidatorInfoStorage is IValidatorInfo, HasRoninTrustedOrganiz
    */
   function isBridgeOperator(address _bridgeOperatorAddr) external view override returns (bool _result) {
     for (uint _i = 0; _i < validatorCount; _i++) {
-      if (_bridgeOperatorOf(_validators[_i]) == _bridgeOperatorAddr) {
+      if (_bridgeOperatorOf(_validators[_i]) == _bridgeOperatorAddr && isOperatingBridge(_validators[_i])) {
         _result = true;
         break;
       }
     }
+  }
+
+  /**
+   * @inheritdoc IValidatorInfo
+   */
+  function isOperatingBridge(address _consensusAddr) public view override returns (bool) {
+    return _validatorMap[_consensusAddr].hasFlag(EnumFlags.ValidatorFlag.BridgeOperator);
   }
 
   /**
@@ -116,12 +130,14 @@ abstract contract ValidatorInfoStorage is IValidatorInfo, HasRoninTrustedOrganiz
   }
 
   /**
-   * Notice: A validator is always a bride operator
-   *
    * @inheritdoc IValidatorInfo
    */
-  function totalBridgeOperators() public view returns (uint256) {
-    return validatorCount;
+  function totalBridgeOperators() public view returns (uint256 _total) {
+    for (uint _i = 0; _i < validatorCount; _i++) {
+      if (isOperatingBridge(_validators[_i])) {
+        _total++;
+      }
+    }
   }
 
   /**

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -67,7 +67,7 @@ const compilerConfig: SolcUserConfig = {
   settings: {
     optimizer: {
       enabled: true,
-      runs: 200,
+      runs: 10,
     },
   },
 };

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -67,7 +67,7 @@ const compilerConfig: SolcUserConfig = {
   settings: {
     optimizer: {
       enabled: true,
-      runs: 10,
+      runs: 200,
     },
   },
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,8 +2,8 @@ import { BigNumber } from 'ethers';
 import { ethers } from 'hardhat';
 import {
   GeneralConfig,
-  GovernanceAdminArguments,
-  GovernanceAdminConfig,
+  RoninGovernanceAdminArguments,
+  RoninGovernanceAdminConfig,
   LiteralNetwork,
   MainchainGovernanceAdminArguments,
   MainchainGovernanceAdminConfig,
@@ -264,12 +264,12 @@ export const mainchainGovernanceAdminConf: MainchainGovernanceAdminConfig = {
   [Network.Ethereum]: undefined,
 };
 
-const defaultGovernanceAdminConf: GovernanceAdminArguments = {
+const defaultGovernanceAdminConf: RoninGovernanceAdminArguments = {
   proposalExpiryDuration: 60 * 60 * 24 * 14, // 14 days
 };
 
 // TODO: update config for goerli, ethereum
-export const governanceAdminConf: GovernanceAdminConfig = {
+export const roninGovernanceAdminConf: RoninGovernanceAdminConfig = {
   [Network.Local]: defaultGovernanceAdminConf,
   [Network.Devnet]: defaultGovernanceAdminConf,
   [Network.Goerli]: undefined,

--- a/src/config.ts
+++ b/src/config.ts
@@ -166,6 +166,8 @@ const defaultRoninValidatorSetConf: RoninValidatorSetArguments = {
   maxValidatorCandidate: 100,
   numberOfBlocksInEpoch: 600,
   minEffectiveDaysOnwards: 7,
+  emergencyExitLockedAmount: BigNumber.from(10).pow(18).mul(50_000), // 50.000 RON
+  emergencyExpiryDuration: 14 * 86400, // 14 days
 };
 
 // TODO: update config for testnet & mainnet

--- a/src/deploy/proxy/ronin-validator-proxy.ts
+++ b/src/deploy/proxy/ronin-validator-proxy.ts
@@ -26,6 +26,10 @@ const deploy = async ({ getNamedAccounts, deployments }: HardhatRuntimeEnvironme
     roninValidatorSetConf[network.name]!.maxPrioritizedValidatorNumber,
     roninValidatorSetConf[network.name]!.minEffectiveDaysOnwards,
     roninValidatorSetConf[network.name]!.numberOfBlocksInEpoch,
+    [
+      roninValidatorSetConf[network.name]!.emergencyExitLockedAmount,
+      roninValidatorSetConf[network.name]!.emergencyExpiryDuration,
+    ],
   ]);
 
   const deployment = await deploy('RoninValidatorSetProxy', {

--- a/src/deploy/ronin-governance-admin.ts
+++ b/src/deploy/ronin-governance-admin.ts
@@ -1,7 +1,7 @@
 import { network } from 'hardhat';
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 
-import { roninchainNetworks, generalRoninConf, governanceAdminConf } from '../config';
+import { roninchainNetworks, generalRoninConf, roninGovernanceAdminConf } from '../config';
 import { verifyAddress } from '../script/verify-address';
 
 const deploy = async ({ getNamedAccounts, deployments }: HardhatRuntimeEnvironment) => {
@@ -18,7 +18,8 @@ const deploy = async ({ getNamedAccounts, deployments }: HardhatRuntimeEnvironme
     args: [
       generalRoninConf[network.name].roninTrustedOrganizationContract?.address,
       generalRoninConf[network.name].bridgeContract,
-      governanceAdminConf[network.name]?.proposalExpiryDuration,
+      generalRoninConf[network.name].validatorContract?.address,
+      roninGovernanceAdminConf[network.name]?.proposalExpiryDuration,
     ],
     nonce: generalRoninConf[network.name].governanceAdmin?.nonce,
   });

--- a/src/script/governance-admin-interface.ts
+++ b/src/script/governance-admin-interface.ts
@@ -9,7 +9,7 @@ import { BallotTypes, getProposalHash, VoteType } from './proposal';
 import { RoninGovernanceAdmin, TransparentUpgradeableProxyV2__factory } from '../types';
 import { ProposalDetailStruct } from '../types/GovernanceAdmin';
 import { SignatureStruct } from '../types/MainchainGovernanceAdmin';
-import { GovernanceAdminArguments } from '../utils';
+import { RoninGovernanceAdminArguments } from '../utils';
 import { getLastBlockTimestamp } from '../../test/helpers/utils';
 import { defaultTestConfig } from '../../test/helpers/fixture';
 
@@ -31,10 +31,10 @@ export class GovernanceAdminInterface {
   contract!: RoninGovernanceAdmin;
   domain!: TypedDataDomain;
   interface!: Interface;
-  args!: GovernanceAdminArguments;
+  args!: RoninGovernanceAdminArguments;
   address = ethers.constants.AddressZero;
 
-  constructor(contract: RoninGovernanceAdmin, args?: GovernanceAdminArguments, ...signers: SignerWithAddress[]) {
+  constructor(contract: RoninGovernanceAdmin, args?: RoninGovernanceAdminArguments, ...signers: SignerWithAddress[]) {
     this.contract = contract;
     this.signers = signers;
     this.address = contract.address;

--- a/src/script/proposal.ts
+++ b/src/script/proposal.ts
@@ -10,8 +10,8 @@ const proposalTypeHash = '0xd051578048e6ff0bbc9fca3b65a42088dbde10f36ca841de5667
 const globalProposalTypeHash = '0x1463f426c05aff2c1a7a0957a71c9898bc8b47142540538e79ee25ee91141350';
 // keccak256("Ballot(bytes32 proposalHash,uint8 support)")
 const ballotTypeHash = '0xd900570327c4c0df8dd6bdd522b7da7e39145dd049d2fd4602276adcd511e3c2';
-// keccak256("BridgeOperatorsBallot(uint256 period,address[] operators)");
-const bridgeOperatorsBallotTypeHash = '0xeea5e3908ac28cbdbbce8853e49444c558a0a03597e98ef19e6ff86162ed9ae3';
+// keccak256("BridgeOperatorsBallot(uint256 period,uint256 epoch,address[] operators)");
+const bridgeOperatorsBallotTypeHash = '0xd679a49e9e099fa9ed83a5446aaec83e746b03ec6723d6f5efb29d37d7f0b78a';
 
 export enum VoteType {
   For = 0,
@@ -70,6 +70,7 @@ export const GlobalProposalTypes = {
 export const BridgeOperatorsBallotTypes = {
   BridgeOperatorsBallot: [
     { name: 'period', type: 'uint256' },
+    { name: 'epoch', type: 'uint256' },
     { name: 'operators', type: 'address[]' },
   ],
 };
@@ -152,14 +153,16 @@ export const getBallotDigest = (domainSeparator: string, proposalHash: string, s
 
 export interface BOsBallot {
   period: BigNumberish;
+  epoch: BigNumberish;
   operators: Address[];
 }
 
-export const getBOsBallotHash = (period: BigNumberish, operators: Address[]) =>
+export const getBOsBallotHash = (period: BigNumberish, epoch: BigNumberish, operators: Address[]) =>
   keccak256(
     AbiCoder.prototype.encode(bridgeOperatorsBallotParamTypes, [
       bridgeOperatorsBallotTypeHash,
       period,
+      epoch,
       keccak256(
         AbiCoder.prototype.encode(
           operators.map(() => 'address'),
@@ -169,8 +172,13 @@ export const getBOsBallotHash = (period: BigNumberish, operators: Address[]) =>
     ])
   );
 
-export const getBOsBallotDigest = (domainSeparator: string, period: BigNumberish, operators: Address[]): string =>
+export const getBOsBallotDigest = (
+  domainSeparator: string,
+  period: BigNumberish,
+  epoch: BigNumberish,
+  operators: Address[]
+): string =>
   solidityKeccak256(
     ['bytes1', 'bytes1', 'bytes32', 'bytes32'],
-    ['0x19', '0x01', domainSeparator, getBOsBallotHash(period, operators)]
+    ['0x19', '0x01', domainSeparator, getBOsBallotHash(period, epoch, operators)]
   );

--- a/src/script/proposal.ts
+++ b/src/script/proposal.ts
@@ -12,6 +12,8 @@ const globalProposalTypeHash = '0x1463f426c05aff2c1a7a0957a71c9898bc8b4714254053
 const ballotTypeHash = '0xd900570327c4c0df8dd6bdd522b7da7e39145dd049d2fd4602276adcd511e3c2';
 // keccak256("BridgeOperatorsBallot(uint256 period,uint256 epoch,address[] operators)");
 const bridgeOperatorsBallotTypeHash = '0xd679a49e9e099fa9ed83a5446aaec83e746b03ec6723d6f5efb29d37d7f0b78a';
+// keccak256("EmergencyExitBallot(address consensusAddress,address recipientAfterUnlockedFund,uint256 requestedAt,uint256 expiredAt)");
+const emergencyExitBallotTypehash = '0x697acba4deaf1a718d8c2d93e42860488cb7812696f28ca10eed17bac41e7027';
 
 export enum VoteType {
   For = 0,
@@ -38,6 +40,7 @@ export const proposalParamTypes = [
 ];
 export const globalProposalParamTypes = ['bytes32', 'uint256', 'uint256', 'bytes32', 'bytes32', 'bytes32', 'bytes32'];
 export const bridgeOperatorsBallotParamTypes = ['bytes32', 'uint256', 'bytes32'];
+export const emergencyExitBallotParamTypes = ['bytes32', 'address', 'address', 'uint256', 'uint256'];
 
 export const BallotTypes = {
   Ballot: [
@@ -72,6 +75,15 @@ export const BridgeOperatorsBallotTypes = {
     { name: 'period', type: 'uint256' },
     { name: 'epoch', type: 'uint256' },
     { name: 'operators', type: 'address[]' },
+  ],
+};
+
+export const EmergencyExitBallotTypes = {
+  EmergencyExitBallot: [
+    { name: 'consensusAddress', type: 'address' },
+    { name: 'recipientAfterUnlockedFund', type: 'address' },
+    { name: 'requestedAt', type: 'uint256' },
+    { name: 'expiredAt', type: 'uint256' },
   ],
 };
 
@@ -169,6 +181,22 @@ export const getBOsBallotHash = (period: BigNumberish, epoch: BigNumberish, oper
           operators
         )
       ),
+    ])
+  );
+
+export const getEmergencyExitBallotHash = (
+  consensusAddress: Address,
+  recipientAfterUnlockedFund: Address,
+  requestedAt: BigNumberish,
+  expiredAt: BigNumberish
+) =>
+  keccak256(
+    AbiCoder.prototype.encode(emergencyExitBallotParamTypes, [
+      emergencyExitBallotTypehash,
+      consensusAddress,
+      recipientAfterUnlockedFund,
+      requestedAt,
+      expiredAt,
     ])
   );
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -148,6 +148,8 @@ export interface RoninValidatorSetArguments {
   maxPrioritizedValidatorNumber?: BigNumberish;
   numberOfBlocksInEpoch?: BigNumberish;
   minEffectiveDaysOnwards?: BigNumberish;
+  emergencyExitLockedAmount?: BigNumberish;
+  emergencyExpiryDuration?: BigNumberish;
 }
 
 export interface RoninValidatorSetConfig {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -154,12 +154,12 @@ export interface RoninValidatorSetConfig {
   [network: LiteralNetwork]: RoninValidatorSetArguments | undefined;
 }
 
-export interface GovernanceAdminArguments {
+export interface RoninGovernanceAdminArguments {
   proposalExpiryDuration?: BigNumberish;
 }
 
-export interface GovernanceAdminConfig {
-  [network: LiteralNetwork]: GovernanceAdminArguments | undefined;
+export interface RoninGovernanceAdminConfig {
+  [network: LiteralNetwork]: RoninGovernanceAdminArguments | undefined;
 }
 
 export interface MainchainGovernanceAdminArguments {

--- a/test/bridge/BridgeTracking.test.ts
+++ b/test/bridge/BridgeTracking.test.ts
@@ -218,8 +218,6 @@ describe('Bridge Tracking test', () => {
       submitWithdrawalSignatures,
       submitWithdrawalSignatures.map(() => [])
     );
-    console.log('Period:', await roninValidatorSet.currentPeriod());
-    console.log('Epoch:', await roninValidatorSet.epochOf(await ethers.provider.getBlockNumber()));
   });
 
   it('Should not record the approved receipts once the epoch is not yet wrapped up', async () => {

--- a/test/helpers/fixture.ts
+++ b/test/helpers/fixture.ts
@@ -6,7 +6,7 @@ import { EpochController } from './ronin-validator-set';
 import {
   generalMainchainConf,
   generalRoninConf,
-  governanceAdminConf,
+  roninGovernanceAdminConf,
   mainchainGovernanceAdminConf,
   maintenanceConf,
   roninTrustedOrganizationConf,
@@ -16,7 +16,7 @@ import {
   stakingVestingConfig,
 } from '../../src/config';
 import {
-  GovernanceAdminArguments,
+  RoninGovernanceAdminArguments,
   MainchainGovernanceAdminArguments,
   MaintenanceArguments,
   Network,
@@ -50,7 +50,7 @@ export interface InitTestInput {
   roninValidatorSetArguments?: RoninValidatorSetArguments;
   roninTrustedOrganizationArguments?: RoninTrustedOrganizationArguments;
   mainchainGovernanceAdminArguments?: MainchainGovernanceAdminArguments;
-  governanceAdminArguments?: GovernanceAdminArguments;
+  governanceAdminArguments?: RoninGovernanceAdminArguments;
 }
 
 export const defaultTestConfig: InitTestInput = {
@@ -189,7 +189,7 @@ export const initTest = (id: string) =>
         ...defaultTestConfig?.mainchainGovernanceAdminArguments,
         ...options?.mainchainGovernanceAdminArguments,
       };
-      governanceAdminConf[network.name] = {
+      roninGovernanceAdminConf[network.name] = {
         ...defaultTestConfig?.governanceAdminArguments,
         ...options?.governanceAdminArguments,
       };

--- a/test/helpers/fixture.ts
+++ b/test/helpers/fixture.ts
@@ -112,6 +112,8 @@ export const defaultTestConfig: InitTestInput = {
     numberOfBlocksInEpoch: 600,
     maxValidatorCandidate: 10,
     minEffectiveDaysOnwards: 7,
+    emergencyExitLockedAmount: 500,
+    emergencyExpiryDuration: 14 * 86400, // 14 days
   },
 
   roninTrustedOrganizationArguments: {

--- a/test/helpers/ronin-validator-set.ts
+++ b/test/helpers/ronin-validator-set.ts
@@ -171,6 +171,25 @@ export const expects = {
     );
   },
 
+  emitBridgeOperatorSetUpdatedEvent: async function (
+    tx: ContractTransaction,
+    expectingPeriod?: BigNumberish,
+    expectingEpoch?: BigNumberish,
+    expectingBridgeOperators?: string[]
+  ) {
+    await expectEvent(
+      contractInterface,
+      'BridgeOperatorSetUpdated',
+      tx,
+      (event) => {
+        !!expectingPeriod && expect(event.args[0], 'invalid period').eq(expectingPeriod);
+        !!expectingEpoch && expect(event.args[1], 'invalid epoch').eq(expectingEpoch);
+        !!expectingBridgeOperators && expect(event.args[2], 'invalid bridge operators').eql(expectingBridgeOperators);
+      },
+      1
+    );
+  },
+
   emitBlockRewardDeprecatedEvent: async function (
     tx: ContractTransaction,
     expectingValidator: string,

--- a/test/helpers/ronin-validator-set.ts
+++ b/test/helpers/ronin-validator-set.ts
@@ -154,16 +154,18 @@ export const expects = {
 
   emitBlockProducerSetUpdatedEvent: async function (
     tx: ContractTransaction,
-    expectingPeriod: BigNumberish,
-    expectingBlockProducers: string[]
+    expectingPeriod?: BigNumberish,
+    expectingEpoch?: BigNumberish,
+    expectingBlockProducers?: string[]
   ) {
     await expectEvent(
       contractInterface,
       'BlockProducerSetUpdated',
       tx,
       (event) => {
-        expect(event.args[0], 'invalid period').eq(expectingPeriod);
-        expect(event.args[1], 'invalid validator set').eql(expectingBlockProducers);
+        !!expectingPeriod && expect(event.args[0], 'invalid period').eq(expectingPeriod);
+        !!expectingEpoch && expect(event.args[1], 'invalid epoch').eq(expectingEpoch);
+        !!expectingBlockProducers && expect(event.args[2], 'invalid block producers').eql(expectingBlockProducers);
       },
       1
     );

--- a/test/helpers/utils.ts
+++ b/test/helpers/utils.ts
@@ -26,11 +26,14 @@ export const expectEvent = async (
   expect(counter, 'invalid number of emitted events').eq(eventNumbers);
 };
 
+export const mineDummyBlock = () => network.provider.send('hardhat_mine', []);
+
 export const mineBatchTxs = async (fn: () => Promise<void>) => {
   await network.provider.send('evm_setAutomine', [false]);
   await fn();
   await network.provider.send('evm_mine');
   await network.provider.send('evm_setAutomine', [true]);
+  await mineDummyBlock();
 };
 
 export const getLastBlockTimestamp = async (): Promise<number> => {

--- a/test/integration/ActionSlashValidators.test.ts
+++ b/test/integration/ActionSlashValidators.test.ts
@@ -166,13 +166,11 @@ describe('[Integration] Slash validators', () => {
           slasheeInitStakingAmount
         );
 
-        console.log('----------');
         await EpochController.setTimestampToPeriodEnding();
         await mineBatchTxs(async () => {
           await validatorContract.connect(coinbase).endEpoch();
           wrapUpEpochTx = await validatorContract.connect(coinbase).wrapUpEpoch();
         });
-        console.log('----------');
 
         period = await validatorContract.currentPeriod();
         expectingValidatorSet.push(slashee.consensusAddr.address);

--- a/test/integration/ActionSlashValidators.test.ts
+++ b/test/integration/ActionSlashValidators.test.ts
@@ -225,15 +225,18 @@ describe('[Integration] Slash validators', () => {
       });
 
       it('Should the block producer set exclude the jailed validator in the next epoch', async () => {
+        console.log(await validatorContract.epochOf(await ethers.provider.getBlockNumber()));
         await mineBatchTxs(async () => {
           await validatorContract.connect(coinbase).endEpoch();
           wrapUpEpochTx = await validatorContract.connect(coinbase).wrapUpEpoch();
         });
+        console.log(await validatorContract.epochOf(await ethers.provider.getBlockNumber()));
         expectingBlockProducerSet.pop();
         expect(await validatorContract.getBlockProducers()).eql(expectingBlockProducerSet);
         await RoninValidatorSetExpects.emitBlockProducerSetUpdatedEvent(
           wrapUpEpochTx!,
           period,
+          await validatorContract.epochOf(await ethers.provider.getBlockNumber()),
           expectingBlockProducerSet
         );
         expect(wrapUpEpochTx).not.emit(validatorContract, 'ValidatorSetUpdated');
@@ -269,6 +272,7 @@ describe('[Integration] Slash validators', () => {
         await RoninValidatorSetExpects.emitBlockProducerSetUpdatedEvent(
           wrapUpEpochTx!,
           period,
+          await validatorContract.epochOf(await ethers.provider.getBlockNumber()),
           expectingBlockProducerSet
         );
         expect(wrapUpEpochTx).not.emit(validatorContract, 'ValidatorSetUpdated');
@@ -389,6 +393,7 @@ describe('[Integration] Slash validators', () => {
           await RoninValidatorSetExpects.emitBlockProducerSetUpdatedEvent(
             wrapUpEpochTx!,
             period,
+            await validatorContract.epochOf(await ethers.provider.getBlockNumber()),
             expectingBlockProducerSet
           );
         });
@@ -424,6 +429,7 @@ describe('[Integration] Slash validators', () => {
           await RoninValidatorSetExpects.emitBlockProducerSetUpdatedEvent(
             wrapUpEpochTx!,
             period,
+            await validatorContract.epochOf(await ethers.provider.getBlockNumber()),
             expectingBlockProducerSet
           );
           expect(wrapUpEpochTx).not.emit(validatorContract, 'ValidatorSetUpdated');

--- a/test/integration/ActionSubmitReward.test.ts
+++ b/test/integration/ActionSubmitReward.test.ts
@@ -95,6 +95,7 @@ describe('[Integration] Submit Block Reward', () => {
     const mockValidatorLogic = await new MockRoninValidatorSetExtended__factory(deployer).deploy();
     await mockValidatorLogic.deployed();
     await governanceAdminInterface.upgrade(validatorContract.address, mockValidatorLogic.address);
+    await validatorContract.initEpoch();
   });
 
   describe('Configuration check', async () => {

--- a/test/integration/ActionWrapUpEpoch.test.ts
+++ b/test/integration/ActionWrapUpEpoch.test.ts
@@ -94,6 +94,7 @@ describe('[Integration] Wrap up epoch', () => {
     const mockValidatorLogic = await new MockRoninValidatorSetExtended__factory(deployer).deploy();
     await mockValidatorLogic.deployed();
     await governanceAdminInterface.upgrade(validatorContract.address, mockValidatorLogic.address);
+    await validatorContract.initEpoch();
   });
 
   after(async () => {
@@ -290,7 +291,7 @@ describe('[Integration] Wrap up epoch', () => {
 
       it('Should the block producer set get updated (excluding the slashed validator)', async () => {
         const lastPeriod = await validatorContract.currentPeriod();
-        const epoch = (await validatorContract.epochOf(await ethers.provider.getBlockNumber())).add(1);
+        const epoch = await validatorContract.epochOf(await ethers.provider.getBlockNumber());
         await mineBatchTxs(async () => {
           await validatorContract.endEpoch();
           wrapUpTx = await validatorContract.wrapUpEpoch();
@@ -302,7 +303,7 @@ describe('[Integration] Wrap up epoch', () => {
         await ValidatorSetExpects.emitBlockProducerSetUpdatedEvent(
           wrapUpTx!,
           lastPeriod,
-          await validatorContract.epochOf(await ethers.provider.getBlockNumber()),
+          await validatorContract.epochOf((await ethers.provider.getBlockNumber()) + 1),
           expectingBlockProducerSet
         );
 

--- a/test/integration/ActionWrapUpEpoch.test.ts
+++ b/test/integration/ActionWrapUpEpoch.test.ts
@@ -299,7 +299,12 @@ describe('[Integration] Wrap up epoch', () => {
         let expectingBlockProducerSet = [validators[2], validators[3]].map((_) => _.consensusAddr.address).reverse();
 
         await expect(wrapUpTx!).emit(validatorContract, 'WrappedUpEpoch').withArgs(lastPeriod, epoch, false);
-        await ValidatorSetExpects.emitBlockProducerSetUpdatedEvent(wrapUpTx!, lastPeriod, expectingBlockProducerSet);
+        await ValidatorSetExpects.emitBlockProducerSetUpdatedEvent(
+          wrapUpTx!,
+          lastPeriod,
+          await validatorContract.epochOf(await ethers.provider.getBlockNumber()),
+          expectingBlockProducerSet
+        );
 
         expect(await validatorContract.getValidators()).eql(
           [validators[1], validators[2], validators[3]].map((_) => _.consensusAddr.address).reverse()

--- a/test/maintainance/Maintenance.test.ts
+++ b/test/maintainance/Maintenance.test.ts
@@ -307,6 +307,7 @@ describe('Maintenance test', () => {
       await ValidatorSetExpects.emitBlockProducerSetUpdatedEvent(
         tx!,
         await validatorContract.currentPeriod(),
+        await validatorContract.epochOf(await ethers.provider.getBlockNumber()),
         expectingBlockProducerSet
       );
       expect(await validatorContract.getBlockProducers()).eql(
@@ -328,6 +329,7 @@ describe('Maintenance test', () => {
       await ValidatorSetExpects.emitBlockProducerSetUpdatedEvent(
         tx!,
         await validatorContract.currentPeriod(),
+        await validatorContract.epochOf(await ethers.provider.getBlockNumber()),
         expectingBlockProducerSet
       );
       expect(await validatorContract.getBlockProducers()).eql(expectingBlockProducerSet);

--- a/test/maintainance/Maintenance.test.ts
+++ b/test/maintainance/Maintenance.test.ts
@@ -307,7 +307,7 @@ describe('Maintenance test', () => {
       await ValidatorSetExpects.emitBlockProducerSetUpdatedEvent(
         tx!,
         await validatorContract.currentPeriod(),
-        await validatorContract.epochOf(await ethers.provider.getBlockNumber()),
+        await validatorContract.epochOf((await ethers.provider.getBlockNumber()) + 1),
         expectingBlockProducerSet
       );
       expect(await validatorContract.getBlockProducers()).eql(
@@ -329,7 +329,7 @@ describe('Maintenance test', () => {
       await ValidatorSetExpects.emitBlockProducerSetUpdatedEvent(
         tx!,
         await validatorContract.currentPeriod(),
-        await validatorContract.epochOf(await ethers.provider.getBlockNumber()),
+        await validatorContract.epochOf((await ethers.provider.getBlockNumber()) + 1),
         expectingBlockProducerSet
       );
       expect(await validatorContract.getBlockProducers()).eql(expectingBlockProducerSet);

--- a/test/validator/ArrangeValidators.test.ts
+++ b/test/validator/ArrangeValidators.test.ts
@@ -133,6 +133,7 @@ describe('Arrange validators', () => {
     const mockValidatorLogic = await new MockRoninValidatorSetExtended__factory(deployer).deploy();
     await mockValidatorLogic.deployed();
     await governanceAdminInterface.upgrade(validatorContract.address, mockValidatorLogic.address);
+    await validatorContract.initEpoch();
 
     const mockSlashIndicator = await new MockSlashIndicatorExtended__factory(deployer).deploy();
     await mockSlashIndicator.deployed();

--- a/test/validator/EmergencyExit.test.ts
+++ b/test/validator/EmergencyExit.test.ts
@@ -265,6 +265,10 @@ describe('Emergency Exit test', () => {
         .voteEmergencyExit(voteHash, consensusAddr, recipientAfterUnlockedFund, requestedAt, expiredAt);
     });
 
+    it('Should the vote tx emit event EmergencyExitPollApproved', async () => {
+      await expect(tx).emit(governanceAdmin, 'EmergencyExitPollApproved').withArgs(voteHash);
+    });
+
     it('Should the vote tx emit event EmergencyExitFundUnlocked', async () => {
       await expect(tx)
         .emit(roninValidatorSet, 'EmergencyExitFundUnlocked')

--- a/test/validator/EmergencyExit.test.ts
+++ b/test/validator/EmergencyExit.test.ts
@@ -192,9 +192,9 @@ describe('Emergency Exit test', () => {
       .withArgs(compromisedValidator.consensusAddr.address, requestBlock.timestamp + waitingSecsToRevoke);
   });
 
-  it('Should the request tx emit event EmergencyExitFundLocked', async () => {
+  it('Should the request tx emit event EmergencyExitRequested', async () => {
     await expect(tx)
-      .emit(roninValidatorSet, 'EmergencyExitFundLocked')
+      .emit(roninValidatorSet, 'EmergencyExitRequested')
       .withArgs(compromisedValidator.consensusAddr.address, emergencyExitLockedAmount);
   });
 
@@ -269,9 +269,9 @@ describe('Emergency Exit test', () => {
       await expect(tx).emit(governanceAdmin, 'EmergencyExitPollApproved').withArgs(voteHash);
     });
 
-    it('Should the vote tx emit event EmergencyExitFundUnlocked', async () => {
+    it('Should the vote tx emit event EmergencyExitLockedFundReleased', async () => {
       await expect(tx)
-        .emit(roninValidatorSet, 'EmergencyExitFundUnlocked')
+        .emit(roninValidatorSet, 'EmergencyExitLockedFundReleased')
         .withArgs(
           compromisedValidator.consensusAddr.address,
           compromisedValidator.treasuryAddr.address,
@@ -288,7 +288,7 @@ describe('Emergency Exit test', () => {
       tx = await governanceAdmin
         .connect(trustedOrgs[1].governor)
         .voteEmergencyExit(voteHash, consensusAddr, recipientAfterUnlockedFund, requestedAt, expiredAt);
-      await expect(tx).not.emit(roninValidatorSet, 'EmergencyExitFundUnlocked');
+      await expect(tx).not.emit(roninValidatorSet, 'EmergencyExitLockedFundReleased');
     });
 
     it('Should the requester not receive the unlocked fund again', async () => {

--- a/test/validator/EmergencyExit.test.ts
+++ b/test/validator/EmergencyExit.test.ts
@@ -16,11 +16,9 @@ import {
   StakingVesting,
 } from '../../src/types';
 import * as RoninValidatorSet from '../helpers/ronin-validator-set';
-import { expects as StakingVestingExpects } from '../helpers/staking-vesting';
 import { mineBatchTxs } from '../helpers/utils';
 import { initTest } from '../helpers/fixture';
 import { GovernanceAdminInterface } from '../../src/script/governance-admin-interface';
-import { BlockRewardDeprecatedType } from '../../src/script/ronin-validator-set';
 import { Address } from 'hardhat-deploy/dist/types';
 import {
   createManyTrustedOrganizationAddressSets,
@@ -28,7 +26,6 @@ import {
   TrustedOrganizationAddressSet,
   ValidatorCandidateAddressSet,
 } from '../helpers/address-set-types';
-import { SlashType } from '../../src/script/slash-indicator';
 import { getEmergencyExitBallotHash } from '../../src/script/proposal';
 
 let roninValidatorSet: MockRoninValidatorSetExtended;
@@ -83,7 +80,7 @@ describe('Emergency Exit test', () => {
       stakingContractAddress,
       roninGovernanceAdminAddress,
       stakingVestingContractAddress,
-    } = await initTest('RoninValidatorSet')({
+    } = await initTest('EmergencyExit')({
       slashIndicatorArguments: {
         doubleSignSlashing: {
           slashDoubleSignAmount,

--- a/test/validator/EmergencyExit.test.ts
+++ b/test/validator/EmergencyExit.test.ts
@@ -1,0 +1,370 @@
+import { expect } from 'chai';
+import { BigNumber, BigNumberish, ContractTransaction, ethers as EthersType } from 'ethers';
+import { ethers, network } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+
+import {
+  Staking,
+  MockRoninValidatorSetExtended,
+  MockRoninValidatorSetExtended__factory,
+  Staking__factory,
+  MockSlashIndicatorExtended__factory,
+  MockSlashIndicatorExtended,
+  RoninGovernanceAdmin__factory,
+  RoninGovernanceAdmin,
+  StakingVesting__factory,
+  StakingVesting,
+} from '../../src/types';
+import * as RoninValidatorSet from '../helpers/ronin-validator-set';
+import { expects as StakingVestingExpects } from '../helpers/staking-vesting';
+import { mineBatchTxs } from '../helpers/utils';
+import { initTest } from '../helpers/fixture';
+import { GovernanceAdminInterface } from '../../src/script/governance-admin-interface';
+import { BlockRewardDeprecatedType } from '../../src/script/ronin-validator-set';
+import { Address } from 'hardhat-deploy/dist/types';
+import {
+  createManyTrustedOrganizationAddressSets,
+  createManyValidatorCandidateAddressSets,
+  TrustedOrganizationAddressSet,
+  ValidatorCandidateAddressSet,
+} from '../helpers/address-set-types';
+import { SlashType } from '../../src/script/slash-indicator';
+import { getEmergencyExitBallotHash } from '../../src/script/proposal';
+
+let roninValidatorSet: MockRoninValidatorSetExtended;
+let stakingVesting: StakingVesting;
+let stakingContract: Staking;
+let slashIndicator: MockSlashIndicatorExtended;
+let governanceAdmin: RoninGovernanceAdmin;
+let governanceAdminInterface: GovernanceAdminInterface;
+
+let poolAdmin: SignerWithAddress;
+let coinbase: SignerWithAddress;
+let bridgeOperator: SignerWithAddress;
+let deployer: SignerWithAddress;
+let signers: SignerWithAddress[];
+let trustedOrgs: TrustedOrganizationAddressSet[];
+let validatorCandidates: ValidatorCandidateAddressSet[];
+let compromisedValidator: ValidatorCandidateAddressSet;
+
+const localValidatorCandidatesLength = 5;
+const slashAmountForUnavailabilityTier2Threshold = 100;
+const maxValidatorNumber = 5;
+const maxValidatorCandidate = 100;
+const minValidatorStakingAmount = BigNumber.from(20000);
+const slashDoubleSignAmount = BigNumber.from(2000);
+const emergencyExitLockedAmount = BigNumber.from(500);
+const waitingSecsToRevoke = 7 * 86400; // 7 days
+const emergencyExpiryDuration = 14 * 86400; // 14 days
+
+let consensusAddr: Address;
+let recipientAfterUnlockedFund: Address;
+let requestedAt: BigNumberish;
+let expiredAt: BigNumberish;
+let voteHash: string;
+let snapshotId: string;
+let totalStakedAmount: BigNumber;
+
+describe('Emergency Exit test', () => {
+  let tx: ContractTransaction;
+  let requestBlock: EthersType.providers.Block;
+
+  before(async () => {
+    [poolAdmin, coinbase, bridgeOperator, deployer, ...signers] = await ethers.getSigners();
+
+    trustedOrgs = createManyTrustedOrganizationAddressSets(signers.splice(0, 6));
+    validatorCandidates = createManyValidatorCandidateAddressSets(signers.slice(0, localValidatorCandidatesLength * 3));
+
+    await network.provider.send('hardhat_setCoinbase', [coinbase.address]);
+
+    const {
+      slashContractAddress,
+      validatorContractAddress,
+      stakingContractAddress,
+      roninGovernanceAdminAddress,
+      stakingVestingContractAddress,
+    } = await initTest('RoninValidatorSet')({
+      slashIndicatorArguments: {
+        doubleSignSlashing: {
+          slashDoubleSignAmount,
+        },
+        unavailabilitySlashing: {
+          slashAmountForUnavailabilityTier2Threshold,
+        },
+      },
+      stakingArguments: {
+        minValidatorStakingAmount,
+        waitingSecsToRevoke,
+      },
+      roninValidatorSetArguments: {
+        maxValidatorNumber,
+        maxValidatorCandidate,
+        emergencyExitLockedAmount,
+        emergencyExpiryDuration,
+      },
+      roninTrustedOrganizationArguments: {
+        trustedOrganizations: trustedOrgs.map((v) => ({
+          consensusAddr: v.consensusAddr.address,
+          governor: v.governor.address,
+          bridgeVoter: v.bridgeVoter.address,
+          weight: 100,
+          addedBlock: 0,
+        })),
+      },
+    });
+
+    roninValidatorSet = MockRoninValidatorSetExtended__factory.connect(validatorContractAddress, deployer);
+    stakingVesting = StakingVesting__factory.connect(stakingVestingContractAddress, deployer);
+    slashIndicator = MockSlashIndicatorExtended__factory.connect(slashContractAddress, deployer);
+    stakingContract = Staking__factory.connect(stakingContractAddress, deployer);
+    governanceAdmin = RoninGovernanceAdmin__factory.connect(roninGovernanceAdminAddress, deployer);
+    governanceAdminInterface = new GovernanceAdminInterface(
+      governanceAdmin,
+      undefined,
+      ...trustedOrgs.map((_) => _.governor)
+    );
+
+    const mockValidatorLogic = await new MockRoninValidatorSetExtended__factory(deployer).deploy();
+    await mockValidatorLogic.deployed();
+    await governanceAdminInterface.upgrade(roninValidatorSet.address, mockValidatorLogic.address);
+    await roninValidatorSet.initEpoch();
+
+    const mockSlashIndicator = await new MockSlashIndicatorExtended__factory(deployer).deploy();
+    await mockSlashIndicator.deployed();
+    await governanceAdminInterface.upgrade(slashIndicator.address, mockSlashIndicator.address);
+
+    const stakedAmount = validatorCandidates.map((_, i) =>
+      minValidatorStakingAmount.mul(2).add(validatorCandidates.length - i)
+    );
+    for (let i = 0; i < validatorCandidates.length; i++) {
+      await stakingContract
+        .connect(validatorCandidates[i].poolAdmin)
+        .applyValidatorCandidate(
+          validatorCandidates[i].candidateAdmin.address,
+          validatorCandidates[i].consensusAddr.address,
+          validatorCandidates[i].treasuryAddr.address,
+          validatorCandidates[i].bridgeOperator.address,
+          2_00,
+          {
+            value: stakedAmount[i],
+          }
+        );
+    }
+
+    await RoninValidatorSet.EpochController.setTimestampToPeriodEnding();
+    await mineBatchTxs(async () => {
+      await roninValidatorSet.endEpoch();
+      await roninValidatorSet.connect(coinbase).wrapUpEpoch();
+    });
+    compromisedValidator = validatorCandidates[validatorCandidates.length - 1];
+    totalStakedAmount = stakedAmount[validatorCandidates.length - 1];
+  });
+
+  after(async () => {
+    await network.provider.send('hardhat_setCoinbase', [ethers.constants.AddressZero]);
+  });
+
+  it('Should be able to get list of the validator candidates', async () => {
+    expect(validatorCandidates.map((v) => v.consensusAddr.address)).eql(await roninValidatorSet.getBlockProducers());
+  });
+
+  it('Should not be able to request emergency exit using unauthorized accounts', async () => {
+    await expect(stakingContract.requestEmergencyExit(compromisedValidator.consensusAddr.address)).revertedWith(
+      'BaseStaking: requester must be the pool admin'
+    );
+  });
+
+  it('Should be able to request emergency exit', async () => {
+    tx = await stakingContract
+      .connect(compromisedValidator.poolAdmin)
+      .requestEmergencyExit(compromisedValidator.consensusAddr.address);
+  });
+
+  it('Should not be able to request emergency exit again', async () => {
+    await expect(
+      stakingContract
+        .connect(compromisedValidator.poolAdmin)
+        .requestEmergencyExit(compromisedValidator.consensusAddr.address)
+    ).revertedWith('EmergencyExit: already requested');
+  });
+
+  it('Should the request tx emit event CandidateRevokingTimestampUpdated', async () => {
+    requestBlock = await ethers.provider.getBlock(tx.blockNumber!);
+    await expect(tx)
+      .emit(roninValidatorSet, 'CandidateRevokingTimestampUpdated')
+      .withArgs(compromisedValidator.consensusAddr.address, requestBlock.timestamp + waitingSecsToRevoke);
+  });
+
+  it('Should the request tx emit event EmergencyExitFundLocked', async () => {
+    await expect(tx)
+      .emit(roninValidatorSet, 'EmergencyExitFundLocked')
+      .withArgs(compromisedValidator.consensusAddr.address, emergencyExitLockedAmount);
+  });
+
+  it('Should the request tx emit event EmergencyExitVoteCreated', async () => {
+    consensusAddr = compromisedValidator.consensusAddr.address;
+    recipientAfterUnlockedFund = compromisedValidator.treasuryAddr.address;
+    requestedAt = requestBlock.timestamp;
+    expiredAt = requestBlock.timestamp + emergencyExpiryDuration;
+    voteHash = getEmergencyExitBallotHash(consensusAddr, recipientAfterUnlockedFund, requestedAt, expiredAt);
+
+    await expect(tx)
+      .emit(governanceAdmin, 'EmergencyExitVoteCreated')
+      .withArgs(voteHash, consensusAddr, recipientAfterUnlockedFund, requestedAt, expiredAt);
+  });
+
+  it("Should the emergency exit's requester be still in the validator list", async () => {
+    expect(validatorCandidates.map((v) => v.consensusAddr.address)).eql(await roninValidatorSet.getBlockProducers());
+    expect(await roninValidatorSet.isValidator(compromisedValidator.consensusAddr.address)).to.true;
+    expect(await roninValidatorSet.isBlockProducer(compromisedValidator.consensusAddr.address)).to.true;
+    expect(await roninValidatorSet.isOperatingBridge(compromisedValidator.consensusAddr.address)).to.true;
+    expect(await roninValidatorSet.isBridgeOperator(compromisedValidator.bridgeOperator.address)).to.true;
+  });
+
+  it("Should the exit's requester be removed in block producer and bridge operator list in next epoch", async () => {
+    await mineBatchTxs(async () => {
+      await roninValidatorSet.endEpoch();
+      tx = await roninValidatorSet.connect(coinbase).wrapUpEpoch();
+    });
+
+    expect(await roninValidatorSet.isValidatorCandidate(compromisedValidator.consensusAddr.address)).to.true;
+    expect(await roninValidatorSet.isValidator(compromisedValidator.consensusAddr.address)).to.false;
+    expect(await roninValidatorSet.isBlockProducer(compromisedValidator.consensusAddr.address)).to.false;
+    expect(await roninValidatorSet.isOperatingBridge(compromisedValidator.consensusAddr.address)).to.false;
+    expect(await roninValidatorSet.isBridgeOperator(compromisedValidator.bridgeOperator.address)).to.false;
+    await RoninValidatorSet.expects.emitBlockProducerSetUpdatedEvent(
+      tx,
+      undefined,
+      undefined,
+      validatorCandidates
+        .map((v) => v.consensusAddr.address)
+        .filter((v) => v != compromisedValidator.consensusAddr.address)
+    );
+    await RoninValidatorSet.expects.emitBridgeOperatorSetUpdatedEvent(
+      tx,
+      undefined,
+      undefined,
+      validatorCandidates
+        .map((v) => v.bridgeOperator.address)
+        .filter((v) => v != compromisedValidator.bridgeOperator.address)
+    );
+  });
+
+  describe('Valid emergency exit', () => {
+    let balance: BigNumberish;
+
+    before(async () => {
+      snapshotId = await network.provider.send('evm_snapshot');
+      balance = await ethers.provider.getBalance(compromisedValidator.treasuryAddr.address);
+    });
+
+    after(async () => {
+      await network.provider.send('evm_revert', [snapshotId]);
+    });
+
+    it('Should the governor vote for an emergency exit', async () => {
+      tx = await governanceAdmin
+        .connect(trustedOrgs[0].governor)
+        .voteEmergencyExit(voteHash, consensusAddr, recipientAfterUnlockedFund, requestedAt, expiredAt);
+    });
+
+    it('Should the vote tx emit event EmergencyExitFundUnlocked', async () => {
+      await expect(tx)
+        .emit(roninValidatorSet, 'EmergencyExitFundUnlocked')
+        .withArgs(
+          compromisedValidator.consensusAddr.address,
+          compromisedValidator.treasuryAddr.address,
+          emergencyExitLockedAmount
+        );
+    });
+
+    it('Should the requester receive the unlocked fund', async () => {
+      const currentBalance = await ethers.provider.getBalance(compromisedValidator.treasuryAddr.address);
+      expect(currentBalance.sub(balance)).eq(emergencyExitLockedAmount);
+    });
+
+    it('Should the governor still able to vote', async () => {
+      tx = await governanceAdmin
+        .connect(trustedOrgs[1].governor)
+        .voteEmergencyExit(voteHash, consensusAddr, recipientAfterUnlockedFund, requestedAt, expiredAt);
+      await expect(tx).not.emit(roninValidatorSet, 'EmergencyExitFundUnlocked');
+    });
+
+    it('Should the requester not receive the unlocked fund again', async () => {
+      const currentBalance = await ethers.provider.getBalance(compromisedValidator.treasuryAddr.address);
+      expect(currentBalance.sub(balance)).eq(emergencyExitLockedAmount);
+    });
+
+    it('Should the requester receive the total staked amount at the next period ending', async () => {
+      await RoninValidatorSet.EpochController.setTimestampToPeriodEnding();
+      await mineBatchTxs(async () => {
+        await roninValidatorSet.endEpoch();
+        tx = await roninValidatorSet.connect(coinbase).wrapUpEpoch();
+      });
+
+      const currentBalance = await ethers.provider.getBalance(compromisedValidator.treasuryAddr.address);
+      expect(currentBalance.sub(balance)).eq(totalStakedAmount);
+      expect(await roninValidatorSet.isValidatorCandidate(compromisedValidator.consensusAddr.address)).to.false;
+    });
+
+    it('Should the requester not receive again in the next period ending', async () => {
+      await RoninValidatorSet.EpochController.setTimestampToPeriodEnding();
+      await mineBatchTxs(async () => {
+        await roninValidatorSet.endEpoch();
+        tx = await roninValidatorSet.connect(coinbase).wrapUpEpoch();
+      });
+
+      const currentBalance = await ethers.provider.getBalance(compromisedValidator.treasuryAddr.address);
+      expect(currentBalance.sub(balance)).eq(totalStakedAmount);
+    });
+  });
+
+  describe('Expiry emergency exit', () => {
+    let treasuryBalance: BigNumberish;
+    let stakingVestingBalance: BigNumberish;
+
+    before(async () => {
+      snapshotId = await network.provider.send('evm_snapshot');
+      treasuryBalance = await ethers.provider.getBalance(compromisedValidator.treasuryAddr.address);
+      stakingVestingBalance = await ethers.provider.getBalance(stakingVesting.address);
+      await network.provider.send('evm_increaseTime', [emergencyExpiryDuration * 2]);
+    });
+
+    after(async () => {
+      await network.provider.send('evm_revert', [snapshotId]);
+    });
+
+    it('Should the governor not be able to vote for an expiry emergency exit', async () => {
+      await expect(
+        governanceAdmin
+          .connect(trustedOrgs[0].governor)
+          .voteEmergencyExit(voteHash, consensusAddr, recipientAfterUnlockedFund, requestedAt, expiredAt)
+      ).revertedWith('RoninGovernanceAdmin: query for expired vote');
+    });
+
+    it('Should be able to recycle the locked fund and transfer back the amount left', async () => {
+      await RoninValidatorSet.EpochController.setTimestampToPeriodEnding();
+      await mineBatchTxs(async () => {
+        await roninValidatorSet.endEpoch();
+        tx = await roninValidatorSet.connect(coinbase).wrapUpEpoch();
+      });
+      const currentTreasuryBalance = await ethers.provider.getBalance(compromisedValidator.treasuryAddr.address);
+      const currentStakingVestingBalance = await ethers.provider.getBalance(stakingVesting.address);
+      expect(currentTreasuryBalance.sub(treasuryBalance)).eq(totalStakedAmount.sub(emergencyExitLockedAmount));
+      expect(currentStakingVestingBalance.sub(stakingVestingBalance)).eq(emergencyExitLockedAmount);
+      expect(await roninValidatorSet.isValidatorCandidate(compromisedValidator.consensusAddr.address)).to.false;
+    });
+
+    it('Should not be able to receive fund again', async () => {
+      await RoninValidatorSet.EpochController.setTimestampToPeriodEnding();
+      await mineBatchTxs(async () => {
+        await roninValidatorSet.endEpoch();
+        tx = await roninValidatorSet.connect(coinbase).wrapUpEpoch();
+      });
+      const currentTreasuryBalance = await ethers.provider.getBalance(compromisedValidator.treasuryAddr.address);
+      const currentStakingVestingBalance = await ethers.provider.getBalance(stakingVesting.address);
+      expect(currentTreasuryBalance.sub(treasuryBalance)).eq(totalStakedAmount.sub(emergencyExitLockedAmount));
+      expect(currentStakingVestingBalance.sub(stakingVestingBalance)).eq(emergencyExitLockedAmount);
+    });
+  });
+});

--- a/test/validator/EmergencyExit.test.ts
+++ b/test/validator/EmergencyExit.test.ts
@@ -198,7 +198,7 @@ describe('Emergency Exit test', () => {
       .withArgs(compromisedValidator.consensusAddr.address, emergencyExitLockedAmount);
   });
 
-  it('Should the request tx emit event EmergencyExitVoteCreated', async () => {
+  it('Should the request tx emit event EmergencyExitPollCreated', async () => {
     consensusAddr = compromisedValidator.consensusAddr.address;
     recipientAfterUnlockedFund = compromisedValidator.treasuryAddr.address;
     requestedAt = requestBlock.timestamp;
@@ -206,7 +206,7 @@ describe('Emergency Exit test', () => {
     voteHash = getEmergencyExitBallotHash(consensusAddr, recipientAfterUnlockedFund, requestedAt, expiredAt);
 
     await expect(tx)
-      .emit(governanceAdmin, 'EmergencyExitVoteCreated')
+      .emit(governanceAdmin, 'EmergencyExitPollCreated')
       .withArgs(voteHash, consensusAddr, recipientAfterUnlockedFund, requestedAt, expiredAt);
   });
 
@@ -316,7 +316,7 @@ describe('Emergency Exit test', () => {
     });
   });
 
-  describe('Expiry emergency exit', () => {
+  describe('Expired emergency exit', () => {
     let treasuryBalance: BigNumberish;
     let stakingVestingBalance: BigNumberish;
 
@@ -332,9 +332,13 @@ describe('Emergency Exit test', () => {
     });
 
     it('Should the governor not be able to vote for an expiry emergency exit', async () => {
+      tx = await governanceAdmin
+        .connect(trustedOrgs[0].governor)
+        .voteEmergencyExit(voteHash, consensusAddr, recipientAfterUnlockedFund, requestedAt, expiredAt);
+      await expect(tx).emit(governanceAdmin, 'EmergencyExitPollExpired').withArgs(voteHash);
       await expect(
         governanceAdmin
-          .connect(trustedOrgs[0].governor)
+          .connect(trustedOrgs[1].governor)
           .voteEmergencyExit(voteHash, consensusAddr, recipientAfterUnlockedFund, requestedAt, expiredAt)
       ).revertedWith('RoninGovernanceAdmin: query for expired vote');
     });

--- a/test/validator/RoninValidatorSet.test.ts
+++ b/test/validator/RoninValidatorSet.test.ts
@@ -159,7 +159,7 @@ describe('Ronin Validator Set test', () => {
       });
       expect(tx!).emit(roninValidatorSet, 'WrappedUpEpoch').withArgs(lastPeriod, epoch, true);
       lastPeriod = await roninValidatorSet.currentPeriod();
-      await RoninValidatorSet.expects.emitBlockProducerSetUpdatedEvent(tx!, lastPeriod, []);
+      await RoninValidatorSet.expects.emitBlockProducerSetUpdatedEvent(tx!, lastPeriod, epoch, []);
       expect(await roninValidatorSet.getValidators()).eql([]);
     });
   });

--- a/test/validator/RoninValidatorSet.test.ts
+++ b/test/validator/RoninValidatorSet.test.ts
@@ -126,6 +126,7 @@ describe('Ronin Validator Set test', () => {
     const mockValidatorLogic = await new MockRoninValidatorSetExtended__factory(deployer).deploy();
     await mockValidatorLogic.deployed();
     await governanceAdminInterface.upgrade(roninValidatorSet.address, mockValidatorLogic.address);
+    await roninValidatorSet.initEpoch();
 
     const mockSlashIndicator = await new MockSlashIndicatorExtended__factory(deployer).deploy();
     await mockSlashIndicator.deployed();
@@ -182,7 +183,7 @@ describe('Ronin Validator Set test', () => {
       }
 
       let tx: ContractTransaction;
-      epoch = (await roninValidatorSet.epochOf(await ethers.provider.getBlockNumber())).add(1);
+      epoch = await roninValidatorSet.epochOf(await ethers.provider.getBlockNumber());
       await mineBatchTxs(async () => {
         await roninValidatorSet.endEpoch();
         tx = await roninValidatorSet.connect(consensusAddr).wrapUpEpoch();
@@ -271,7 +272,7 @@ describe('Ronin Validator Set test', () => {
     it('Should be able to wrap up epoch at end of period and sync validator set from staking contract', async () => {
       let tx: ContractTransaction;
       await RoninValidatorSet.EpochController.setTimestampToPeriodEnding();
-      epoch = (await roninValidatorSet.epochOf(await ethers.provider.getBlockNumber())).add(1);
+      epoch = await roninValidatorSet.epochOf(await ethers.provider.getBlockNumber());
       lastPeriod = await roninValidatorSet.currentPeriod();
       await mineBatchTxs(async () => {
         await roninValidatorSet.endEpoch();
@@ -331,7 +332,7 @@ describe('Ronin Validator Set test', () => {
 
       let tx: ContractTransaction;
       await RoninValidatorSet.EpochController.setTimestampToPeriodEnding();
-      epoch = (await roninValidatorSet.epochOf(await ethers.provider.getBlockNumber())).add(1);
+      epoch = await roninValidatorSet.epochOf(await ethers.provider.getBlockNumber());
       lastPeriod = await roninValidatorSet.currentPeriod();
       await mineBatchTxs(async () => {
         await roninValidatorSet.endEpoch();
@@ -365,7 +366,7 @@ describe('Ronin Validator Set test', () => {
       it('Should be able to submit block reward using coinbase account and not receive bonuses', async () => {
         const tx = await roninValidatorSet.connect(consensusAddr).submitBlockReward({ value: 100 });
 
-        epoch = (await roninValidatorSet.epochOf(await ethers.provider.getBlockNumber())).add(1);
+        epoch = await roninValidatorSet.epochOf(await ethers.provider.getBlockNumber());
         lastPeriod = await roninValidatorSet.currentPeriod();
         await RoninValidatorSet.expects.emitBlockRewardSubmittedEvent(tx, consensusAddr.address, 100, 0);
 
@@ -415,7 +416,7 @@ describe('Ronin Validator Set test', () => {
         await RoninValidatorSet.EpochController.setTimestampToPeriodEnding();
 
         lastPeriod = await roninValidatorSet.currentPeriod();
-        epoch = (await roninValidatorSet.epochOf(await ethers.provider.getBlockNumber())).add(1);
+        epoch = await roninValidatorSet.epochOf(await ethers.provider.getBlockNumber());
         await mineBatchTxs(async () => {
           await roninValidatorSet.endEpoch();
           tx = await roninValidatorSet.connect(consensusAddr).wrapUpEpoch();
@@ -458,7 +459,7 @@ describe('Ronin Validator Set test', () => {
 
           expect(await roninValidatorSet.totalDeprecatedReward()).equal(5100); // = 0 + (5000 + 100)
 
-          epoch = (await roninValidatorSet.epochOf(await ethers.provider.getBlockNumber())).add(1);
+          epoch = await roninValidatorSet.epochOf(await ethers.provider.getBlockNumber());
           lastPeriod = await roninValidatorSet.currentPeriod();
           await mineBatchTxs(async () => {
             await roninValidatorSet.endEpoch();
@@ -478,7 +479,7 @@ describe('Ronin Validator Set test', () => {
           await roninValidatorSet.connect(consensusAddr).submitBlockReward({ value: 100 });
           await RoninValidatorSet.EpochController.setTimestampToPeriodEnding();
 
-          epoch = (await roninValidatorSet.epochOf(await ethers.provider.getBlockNumber())).add(1);
+          epoch = await roninValidatorSet.epochOf(await ethers.provider.getBlockNumber());
           lastPeriod = await roninValidatorSet.currentPeriod();
           await mineBatchTxs(async () => {
             await roninValidatorSet.endEpoch();
@@ -505,7 +506,7 @@ describe('Ronin Validator Set test', () => {
         await roninValidatorSet.connect(consensusAddr).submitBlockReward({ value: 100 });
         await RoninValidatorSet.EpochController.setTimestampToPeriodEnding();
 
-        epoch = (await roninValidatorSet.epochOf(await ethers.provider.getBlockNumber())).add(1);
+        epoch = await roninValidatorSet.epochOf(await ethers.provider.getBlockNumber());
         lastPeriod = await roninValidatorSet.currentPeriod();
         await mineBatchTxs(async () => {
           await roninValidatorSet.endEpoch();
@@ -542,10 +543,10 @@ describe('Ronin Validator Set test', () => {
         await expect(tx)
           .to.emit(roninValidatorSet, 'BlockRewardDeprecated')
           .withArgs(consensusAddr.address, 100, BlockRewardDeprecatedType.UNAVAILABILITY);
-        await expect(await roninValidatorSet.totalDeprecatedReward()).equal(100);
+        expect(await roninValidatorSet.totalDeprecatedReward()).equal(100);
         await RoninValidatorSet.EpochController.setTimestampToPeriodEnding();
 
-        epoch = (await roninValidatorSet.epochOf(await ethers.provider.getBlockNumber())).add(1);
+        epoch = await roninValidatorSet.epochOf(await ethers.provider.getBlockNumber());
         lastPeriod = await roninValidatorSet.currentPeriod();
         await mineBatchTxs(async () => {
           await roninValidatorSet.endEpoch();
@@ -603,7 +604,7 @@ describe('Ronin Validator Set test', () => {
       currentValidatorSet.splice(-1, 1, validatorCandidates[1].consensusAddr.address);
 
       await RoninValidatorSet.EpochController.setTimestampToPeriodEnding();
-      epoch = (await roninValidatorSet.epochOf(await ethers.provider.getBlockNumber())).add(1);
+      epoch = await roninValidatorSet.epochOf(await ethers.provider.getBlockNumber());
       lastPeriod = await roninValidatorSet.currentPeriod();
       await mineBatchTxs(async () => {
         await roninValidatorSet.endEpoch();


### PR DESCRIPTION
### Description
Mainly implement function emergency exit for Validators:
1. Events changed: `BlockProducerSetUpdated` & `BridgeOperatorSetUpdated` add `epoch` field → Bridge operator set voting in `RoninGovernanceAdmin` is changed.
2. Callback to `RoninGovernanceAdmin` contract to create new voting for an emergency exit request → Add new ballot & voting round
3. Add cronjob at epoch ending: recycle the expired locked funds.

### ABI Changes

**Ronin Validator Set**
- Event changed: _**BlockProducerSetUpdated**_ + _**BridgeOperatorSetUpdated**_
- New ABI: See `IEmergencyExit.sol` + `ICommonInfo.sol`

**GovernanceAdmin**
- Function changed: `getBridgeOperatorVotingSignatures` + `bridgeOperatorsVoted` + `voteBridgeOperatorsBySignatures`
- New ABI: `createEmergencyExitVote` + `voteEmergencyExit`


### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
