### PR TITLE
Limit gas to 3500

### DIFF
--- a/contracts/extensions/RONTransferHelper.sol
+++ b/contracts/extensions/RONTransferHelper.sol
@@ -37,4 +37,15 @@ abstract contract RONTransferHelper {
   function _unsafeSendRON(address payable _recipient, uint256 _amount) internal returns (bool _success) {
     (_success, ) = _recipient.call{ value: _amount }("");
   }
+
+  /**
+   * @dev Same purpose with {_unsafeSendRON(address,uin256)} but containing gas limit stipend forwarded in the call.
+   */
+  function _unsafeSendRON(
+    address payable _recipient,
+    uint256 _amount,
+    uint256 _gas
+  ) internal returns (bool _success) {
+    (_success, ) = _recipient.call{ value: _amount, gas: _gas }("");
+  }
 }

--- a/contracts/ronin/staking/CandidateStaking.sol
+++ b/contracts/ronin/staking/CandidateStaking.sol
@@ -92,7 +92,7 @@ abstract contract CandidateStaking is BaseStaking, ICandidateStaking {
       _amount = _pool.stakingAmount;
       if (_amount > 0) {
         _deductStakingAmount(_pool, _amount);
-        if (!_unsafeSendRON(payable(_pool.admin), _amount)) {
+        if (!_unsafeSendRON(payable(_pool.admin), _amount, 3500)) {
           emit StakingAmountTransferFailed(_pool.addr, _pool.admin, _amount, address(this).balance);
         }
       }

--- a/contracts/ronin/staking/Staking.sol
+++ b/contracts/ronin/staking/Staking.sol
@@ -80,7 +80,7 @@ contract Staking is IStaking, CandidateStaking, DelegatorStaking, Initializable 
   {
     _actualDeductingAmount = _deductStakingAmount(_stakingPool[_consensusAddr], _amount);
     address payable _recipientAddr = payable(validatorContract());
-    if (!_unsafeSendRON(_recipientAddr, _actualDeductingAmount)) {
+    if (!_unsafeSendRON(_recipientAddr, _actualDeductingAmount, 3500)) {
       emit StakingAmountDeductFailed(_consensusAddr, _recipientAddr, _actualDeductingAmount, address(this).balance);
     }
   }

--- a/contracts/ronin/validator/CoinbaseExecution.sol
+++ b/contracts/ronin/validator/CoinbaseExecution.sol
@@ -252,7 +252,7 @@ abstract contract CoinbaseExecution is
   function _distributeMiningReward(address _consensusAddr, address payable _treasury) private {
     uint256 _amount = _miningReward[_consensusAddr];
     if (_amount > 0) {
-      if (_unsafeSendRON(_treasury, _amount)) {
+      if (_unsafeSendRON(_treasury, _amount, 3500)) {
         emit MiningRewardDistributed(_consensusAddr, _treasury, _amount);
         return;
       }
@@ -277,7 +277,7 @@ abstract contract CoinbaseExecution is
   ) private {
     uint256 _amount = _bridgeOperatingReward[_consensusAddr];
     if (_amount > 0) {
-      if (_unsafeSendRON(_treasury, _amount)) {
+      if (_unsafeSendRON(_treasury, _amount, 3500)) {
         emit BridgeOperatorRewardDistributed(_consensusAddr, _bridgeOperator, _treasury, _amount);
         return;
       }


### PR DESCRIPTION
### Description
- On RON transfer to unknown addresses, the gas forwarded is limited to `3500`. This follows these recommendations: [Link 1](https://github.com/ethereum/EIPs/issues/1285), [Link 2](https://ethereum.stackexchange.com/questions/59197/transfer-function-gas-limit-why-2-300), [Link 3](https://consensys.net/diligence/blog/2019/09/stop-using-soliditys-transfer-now/)

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
