### PR TITLE
[ValidatorSet] Replace error messages by custom erorrs

### DIFF
--- a/contracts/extensions/RONTransferHelper.sol
+++ b/contracts/extensions/RONTransferHelper.sol
@@ -3,12 +3,17 @@
 pragma solidity ^0.8.9;
 
 abstract contract RONTransferHelper {
+  /// @dev Error of recipient not accepting RON when transfer RON.
+  error ErrRecipientRevert();
+  /// @dev Error of sender has insufficient balance.
+  error ErrInsufficientBalance();
+
   /**
    * @dev See `_sendRON`.
    * Reverts if the recipient does not receive RON.
    */
   function _transferRON(address payable _recipient, uint256 _amount) internal {
-    require(_sendRON(_recipient, _amount), "RONTransfer: unable to transfer value, recipient may have reverted");
+    if (!_sendRON(_recipient, _amount)) revert ErrRecipientRevert();
   }
 
   /**
@@ -20,7 +25,7 @@ abstract contract RONTransferHelper {
    *
    */
   function _sendRON(address payable _recipient, uint256 _amount) internal returns (bool _success) {
-    require(address(this).balance >= _amount, "RONTransfer: insufficient balance");
+    if (address(this).balance < _amount) revert ErrInsufficientBalance();
     return _unsafeSendRON(_recipient, _amount);
   }
 

--- a/contracts/extensions/collections/HasBridgeContract.sol
+++ b/contracts/extensions/collections/HasBridgeContract.sol
@@ -24,7 +24,7 @@ contract HasBridgeContract is IHasBridgeContract, HasProxyAdmin {
    * @inheritdoc IHasBridgeContract
    */
   function setBridgeContract(address _addr) external virtual override onlyAdmin {
-    if (_addr.code.length <= 0) revert ErrZeroCodeBridgeContract();
+    if (_addr.code.length <= 0) revert ErrZeroCodeContract();
     _setBridgeContract(_addr);
   }
 

--- a/contracts/extensions/collections/HasBridgeContract.sol
+++ b/contracts/extensions/collections/HasBridgeContract.sol
@@ -9,7 +9,7 @@ contract HasBridgeContract is IHasBridgeContract, HasProxyAdmin {
   IBridge internal _bridgeContract;
 
   modifier onlyBridgeContract() {
-    require(bridgeContract() == msg.sender, "HasBridgeContract: method caller must be bridge contract");
+    if (bridgeContract() != msg.sender) revert ErrCallerMustBeBridgeContract();
     _;
   }
 
@@ -24,7 +24,7 @@ contract HasBridgeContract is IHasBridgeContract, HasProxyAdmin {
    * @inheritdoc IHasBridgeContract
    */
   function setBridgeContract(address _addr) external virtual override onlyAdmin {
-    require(_addr.code.length > 0, "HasBridgeContract: set to non-contract");
+    if (_addr.code.length <= 0) revert ErrZeroCodeBridgeContract();
     _setBridgeContract(_addr);
   }
 

--- a/contracts/extensions/collections/HasBridgeTrackingContract.sol
+++ b/contracts/extensions/collections/HasBridgeTrackingContract.sol
@@ -9,10 +9,7 @@ contract HasBridgeTrackingContract is IHasBridgeTrackingContract, HasProxyAdmin 
   IBridgeTracking internal _bridgeTrackingContract;
 
   modifier onlyBridgeTrackingContract() {
-    require(
-      bridgeTrackingContract() == msg.sender,
-      "HasBridgeTrackingContract: method caller must be bridge tracking contract"
-    );
+    if (bridgeTrackingContract() != msg.sender) revert ErrCallerMustBeBridgeTrackingContract();
     _;
   }
 
@@ -27,7 +24,7 @@ contract HasBridgeTrackingContract is IHasBridgeTrackingContract, HasProxyAdmin 
    * @inheritdoc IHasBridgeTrackingContract
    */
   function setBridgeTrackingContract(address _addr) external virtual override onlyAdmin {
-    require(_addr.code.length > 0, "HasBridgeTrackingContract: set to non-contract");
+    if (_addr.code.length == 0) revert ErrZeroCodeBridgeTrackingContract();
     _setBridgeTrackingContract(_addr);
   }
 

--- a/contracts/extensions/collections/HasBridgeTrackingContract.sol
+++ b/contracts/extensions/collections/HasBridgeTrackingContract.sol
@@ -24,7 +24,7 @@ contract HasBridgeTrackingContract is IHasBridgeTrackingContract, HasProxyAdmin 
    * @inheritdoc IHasBridgeTrackingContract
    */
   function setBridgeTrackingContract(address _addr) external virtual override onlyAdmin {
-    if (_addr.code.length == 0) revert ErrZeroCodeBridgeTrackingContract();
+    if (_addr.code.length == 0) revert ErrZeroCodeContract();
     _setBridgeTrackingContract(_addr);
   }
 

--- a/contracts/extensions/collections/HasMaintenanceContract.sol
+++ b/contracts/extensions/collections/HasMaintenanceContract.sol
@@ -9,10 +9,7 @@ contract HasMaintenanceContract is IHasMaintenanceContract, HasProxyAdmin {
   IMaintenance internal _maintenanceContract;
 
   modifier onlyMaintenanceContract() {
-    require(
-      maintenanceContract() == msg.sender,
-      "HasMaintenanceContract: method caller must be scheduled maintenance contract"
-    );
+    if (maintenanceContract() != msg.sender) revert ErrCallerMustBeMaintenanceContract();
     _;
   }
 
@@ -27,7 +24,7 @@ contract HasMaintenanceContract is IHasMaintenanceContract, HasProxyAdmin {
    * @inheritdoc IHasMaintenanceContract
    */
   function setMaintenanceContract(address _addr) external override onlyAdmin {
-    require(_addr.code.length > 0, "HasMaintenanceContract: set to non-contract");
+    if (_addr.code.length == 0) revert ErrZeroCodeMaintenanceContract();
     _setMaintenanceContract(_addr);
   }
 

--- a/contracts/extensions/collections/HasMaintenanceContract.sol
+++ b/contracts/extensions/collections/HasMaintenanceContract.sol
@@ -24,7 +24,7 @@ contract HasMaintenanceContract is IHasMaintenanceContract, HasProxyAdmin {
    * @inheritdoc IHasMaintenanceContract
    */
   function setMaintenanceContract(address _addr) external override onlyAdmin {
-    if (_addr.code.length == 0) revert ErrZeroCodeMaintenanceContract();
+    if (_addr.code.length == 0) revert ErrZeroCodeContract();
     _setMaintenanceContract(_addr);
   }
 

--- a/contracts/extensions/collections/HasRoninGovernanceAdminContract.sol
+++ b/contracts/extensions/collections/HasRoninGovernanceAdminContract.sol
@@ -9,10 +9,7 @@ contract HasRoninGovernanceAdminContract is IHasRoninGovernanceAdminContract, Ha
   IRoninGovernanceAdmin internal _roninGovernanceAdminContract;
 
   modifier onlyRoninGovernanceAdminContract() {
-    require(
-      roninGovernanceAdminContract() == msg.sender,
-      "HasRoninGovernanceAdminContract: method caller must be ronin governance admin contract"
-    );
+    if (roninGovernanceAdminContract() != msg.sender) revert ErrCallerMustBeGovernanceAdminContract();
     _;
   }
 
@@ -27,7 +24,7 @@ contract HasRoninGovernanceAdminContract is IHasRoninGovernanceAdminContract, Ha
    * @inheritdoc IHasRoninGovernanceAdminContract
    */
   function setRoninGovernanceAdminContract(address _addr) external override onlyAdmin {
-    require(_addr.code.length > 0, "HasRoninGovernanceAdminContract: set to non-contract");
+    if (_addr.code.length == 0) revert ErrZeroCodeGovernanceAdminContract();
     _setRoninGovernanceAdminContract(_addr);
   }
 

--- a/contracts/extensions/collections/HasRoninGovernanceAdminContract.sol
+++ b/contracts/extensions/collections/HasRoninGovernanceAdminContract.sol
@@ -24,7 +24,7 @@ contract HasRoninGovernanceAdminContract is IHasRoninGovernanceAdminContract, Ha
    * @inheritdoc IHasRoninGovernanceAdminContract
    */
   function setRoninGovernanceAdminContract(address _addr) external override onlyAdmin {
-    if (_addr.code.length == 0) revert ErrZeroCodeGovernanceAdminContract();
+    if (_addr.code.length == 0) revert ErrZeroCodeContract();
     _setRoninGovernanceAdminContract(_addr);
   }
 

--- a/contracts/extensions/collections/HasRoninTrustedOrganizationContract.sol
+++ b/contracts/extensions/collections/HasRoninTrustedOrganizationContract.sol
@@ -9,10 +9,7 @@ contract HasRoninTrustedOrganizationContract is IHasRoninTrustedOrganizationCont
   IRoninTrustedOrganization internal _roninTrustedOrganizationContract;
 
   modifier onlyRoninTrustedOrganizationContract() {
-    require(
-      roninTrustedOrganizationContract() == msg.sender,
-      "HasRoninTrustedOrganizationContract: method caller must be ronin trusted organization contract"
-    );
+    if (roninTrustedOrganizationContract() != msg.sender) revert ErrCallerMustBeRoninTrustedOrgContract();
     _;
   }
 
@@ -27,7 +24,7 @@ contract HasRoninTrustedOrganizationContract is IHasRoninTrustedOrganizationCont
    * @inheritdoc IHasRoninTrustedOrganizationContract
    */
   function setRoninTrustedOrganizationContract(address _addr) external virtual override onlyAdmin {
-    require(_addr.code.length > 0, "HasRoninTrustedOrganizationContract: set to non-contract");
+    if (_addr.code.length == 0) revert ErrZeroCodeRoninTrustedOrgContract();
     _setRoninTrustedOrganizationContract(_addr);
   }
 

--- a/contracts/extensions/collections/HasRoninTrustedOrganizationContract.sol
+++ b/contracts/extensions/collections/HasRoninTrustedOrganizationContract.sol
@@ -24,7 +24,7 @@ contract HasRoninTrustedOrganizationContract is IHasRoninTrustedOrganizationCont
    * @inheritdoc IHasRoninTrustedOrganizationContract
    */
   function setRoninTrustedOrganizationContract(address _addr) external virtual override onlyAdmin {
-    if (_addr.code.length == 0) revert ErrZeroCodeRoninTrustedOrgContract();
+    if (_addr.code.length == 0) revert ErrZeroCodeContract();
     _setRoninTrustedOrganizationContract(_addr);
   }
 

--- a/contracts/extensions/collections/HasSlashIndicatorContract.sol
+++ b/contracts/extensions/collections/HasSlashIndicatorContract.sol
@@ -24,7 +24,7 @@ contract HasSlashIndicatorContract is IHasSlashIndicatorContract, HasProxyAdmin 
    * @inheritdoc IHasSlashIndicatorContract
    */
   function setSlashIndicatorContract(address _addr) external override onlyAdmin {
-    if (_addr.code.length == 0) revert ErrZeroCodeSlashIndicatorContract();
+    if (_addr.code.length == 0) revert ErrZeroCodeContract();
     _setSlashIndicatorContract(_addr);
   }
 

--- a/contracts/extensions/collections/HasSlashIndicatorContract.sol
+++ b/contracts/extensions/collections/HasSlashIndicatorContract.sol
@@ -9,10 +9,7 @@ contract HasSlashIndicatorContract is IHasSlashIndicatorContract, HasProxyAdmin 
   ISlashIndicator internal _slashIndicatorContract;
 
   modifier onlySlashIndicatorContract() {
-    require(
-      slashIndicatorContract() == msg.sender,
-      "HasSlashIndicatorContract: method caller must be slash indicator contract"
-    );
+    if (slashIndicatorContract() != msg.sender) revert ErrCallerMustBeSlashIndicatorContract();
     _;
   }
 
@@ -27,7 +24,7 @@ contract HasSlashIndicatorContract is IHasSlashIndicatorContract, HasProxyAdmin 
    * @inheritdoc IHasSlashIndicatorContract
    */
   function setSlashIndicatorContract(address _addr) external override onlyAdmin {
-    require(_addr.code.length > 0, "HasSlashIndicatorContract: set to non-contract");
+    if (_addr.code.length == 0) revert ErrZeroCodeSlashIndicatorContract();
     _setSlashIndicatorContract(_addr);
   }
 

--- a/contracts/extensions/collections/HasStakingContract.sol
+++ b/contracts/extensions/collections/HasStakingContract.sol
@@ -9,7 +9,7 @@ contract HasStakingContract is IHasStakingContract, HasProxyAdmin {
   IStaking internal _stakingContract;
 
   modifier onlyStakingContract() {
-    require(stakingContract() == msg.sender, "HasStakingContract: method caller must be staking contract");
+    if (stakingContract() != msg.sender) revert ErrCallerMustBeStakingContract();
     _;
   }
 
@@ -24,7 +24,7 @@ contract HasStakingContract is IHasStakingContract, HasProxyAdmin {
    * @inheritdoc IHasStakingContract
    */
   function setStakingContract(address _addr) external override onlyAdmin {
-    require(_addr.code.length > 0, "HasStakingContract: set to non-contract");
+    if (_addr.code.length == 0) revert ErrZeroCodeStakingContract();
     _setStakingContract(_addr);
   }
 

--- a/contracts/extensions/collections/HasStakingContract.sol
+++ b/contracts/extensions/collections/HasStakingContract.sol
@@ -24,7 +24,7 @@ contract HasStakingContract is IHasStakingContract, HasProxyAdmin {
    * @inheritdoc IHasStakingContract
    */
   function setStakingContract(address _addr) external override onlyAdmin {
-    if (_addr.code.length == 0) revert ErrZeroCodeStakingContract();
+    if (_addr.code.length == 0) revert ErrZeroCodeContract();
     _setStakingContract(_addr);
   }
 

--- a/contracts/extensions/collections/HasStakingVestingContract.sol
+++ b/contracts/extensions/collections/HasStakingVestingContract.sol
@@ -9,10 +9,7 @@ contract HasStakingVestingContract is IHasStakingVestingContract, HasProxyAdmin 
   IStakingVesting internal _stakingVestingContract;
 
   modifier onlyStakingVestingContract() {
-    require(
-      stakingVestingContract() == msg.sender,
-      "HasStakingVestingContract: method caller must be staking vesting contract"
-    );
+    if (stakingVestingContract() != msg.sender) revert ErrCallerMustBeStakingVestingContract();
     _;
   }
 
@@ -27,7 +24,7 @@ contract HasStakingVestingContract is IHasStakingVestingContract, HasProxyAdmin 
    * @inheritdoc IHasStakingVestingContract
    */
   function setStakingVestingContract(address _addr) external override onlyAdmin {
-    require(_addr.code.length > 0, "HasStakingVestingContract: set to non-contract");
+    if (_addr.code.length == 0) revert ErrZeroCodeStakingVestingContract();
     _setStakingVestingContract(_addr);
   }
 

--- a/contracts/extensions/collections/HasStakingVestingContract.sol
+++ b/contracts/extensions/collections/HasStakingVestingContract.sol
@@ -24,7 +24,7 @@ contract HasStakingVestingContract is IHasStakingVestingContract, HasProxyAdmin 
    * @inheritdoc IHasStakingVestingContract
    */
   function setStakingVestingContract(address _addr) external override onlyAdmin {
-    if (_addr.code.length == 0) revert ErrZeroCodeStakingVestingContract();
+    if (_addr.code.length == 0) revert ErrZeroCodeContract();
     _setStakingVestingContract(_addr);
   }
 

--- a/contracts/extensions/collections/HasValidatorContract.sol
+++ b/contracts/extensions/collections/HasValidatorContract.sol
@@ -9,7 +9,7 @@ contract HasValidatorContract is IHasValidatorContract, HasProxyAdmin {
   IRoninValidatorSet internal _validatorContract;
 
   modifier onlyValidatorContract() {
-    require(validatorContract() == msg.sender, "HasValidatorContract: method caller must be validator contract");
+    if (validatorContract() != msg.sender) revert ErrCallerMustBeValidatorContract();
     _;
   }
 
@@ -24,7 +24,7 @@ contract HasValidatorContract is IHasValidatorContract, HasProxyAdmin {
    * @inheritdoc IHasValidatorContract
    */
   function setValidatorContract(address _addr) external virtual override onlyAdmin {
-    require(_addr.code.length > 0, "HasValidatorContract: set to non-contract");
+    if (_addr.code.length == 0) revert ErrZeroCodeValidatorContract();
     _setValidatorContract(_addr);
   }
 

--- a/contracts/extensions/collections/HasValidatorContract.sol
+++ b/contracts/extensions/collections/HasValidatorContract.sol
@@ -24,7 +24,7 @@ contract HasValidatorContract is IHasValidatorContract, HasProxyAdmin {
    * @inheritdoc IHasValidatorContract
    */
   function setValidatorContract(address _addr) external virtual override onlyAdmin {
-    if (_addr.code.length == 0) revert ErrZeroCodeValidatorContract();
+    if (_addr.code.length == 0) revert ErrZeroCodeContract();
     _setValidatorContract(_addr);
   }
 

--- a/contracts/interfaces/collections/IHasBridgeContract.sol
+++ b/contracts/interfaces/collections/IHasBridgeContract.sol
@@ -6,6 +6,11 @@ interface IHasBridgeContract {
   /// @dev Emitted when the bridge contract is updated.
   event BridgeContractUpdated(address);
 
+  /// @dev Error of method caller must be bridge contract.
+  error ErrCallerMustBeBridgeContract();
+  /// @dev Error of set to non-contract.
+  error ErrZeroCodeBridgeContract();
+
   /**
    * @dev Returns the bridge contract.
    */

--- a/contracts/interfaces/collections/IHasBridgeContract.sol
+++ b/contracts/interfaces/collections/IHasBridgeContract.sol
@@ -2,14 +2,14 @@
 
 pragma solidity ^0.8.9;
 
-interface IHasBridgeContract {
+import "./IHasContract.sol";
+
+interface IHasBridgeContract is IHasContract {
   /// @dev Emitted when the bridge contract is updated.
   event BridgeContractUpdated(address);
 
   /// @dev Error of method caller must be bridge contract.
   error ErrCallerMustBeBridgeContract();
-  /// @dev Error of set to non-contract.
-  error ErrZeroCodeBridgeContract();
 
   /**
    * @dev Returns the bridge contract.

--- a/contracts/interfaces/collections/IHasBridgeTrackingContract.sol
+++ b/contracts/interfaces/collections/IHasBridgeTrackingContract.sol
@@ -2,14 +2,14 @@
 
 pragma solidity ^0.8.9;
 
-interface IHasBridgeTrackingContract {
+import "./IHasContract.sol";
+
+interface IHasBridgeTrackingContract is IHasContract {
   /// @dev Emitted when the bridge tracking contract is updated.
   event BridgeTrackingContractUpdated(address);
 
   /// @dev Error of method caller must be bridge tracking contract.
   error ErrCallerMustBeBridgeTrackingContract();
-  /// @dev Error of set to non-contract.
-  error ErrZeroCodeBridgeTrackingContract();
 
   /**
    * @dev Returns the bridge tracking contract.

--- a/contracts/interfaces/collections/IHasBridgeTrackingContract.sol
+++ b/contracts/interfaces/collections/IHasBridgeTrackingContract.sol
@@ -6,6 +6,11 @@ interface IHasBridgeTrackingContract {
   /// @dev Emitted when the bridge tracking contract is updated.
   event BridgeTrackingContractUpdated(address);
 
+  /// @dev Error of method caller must be bridge tracking contract.
+  error ErrCallerMustBeBridgeTrackingContract();
+  /// @dev Error of set to non-contract.
+  error ErrZeroCodeBridgeTrackingContract();
+
   /**
    * @dev Returns the bridge tracking contract.
    */

--- a/contracts/interfaces/collections/IHasContract.sol
+++ b/contracts/interfaces/collections/IHasContract.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.9;
+
+interface IHasContract {
+  /// @dev Error of set to non-contract.
+  error ErrZeroCodeContract();
+}

--- a/contracts/interfaces/collections/IHasMaintenanceContract.sol
+++ b/contracts/interfaces/collections/IHasMaintenanceContract.sol
@@ -6,6 +6,11 @@ interface IHasMaintenanceContract {
   /// @dev Emitted when the maintenance contract is updated.
   event MaintenanceContractUpdated(address);
 
+  /// @dev Error of method caller must be maintenance contract.
+  error ErrCallerMustBeMaintenanceContract();
+  /// @dev Error of set to non-contract.
+  error ErrZeroCodeMaintenanceContract();
+
   /**
    * @dev Returns the maintenance contract.
    */

--- a/contracts/interfaces/collections/IHasMaintenanceContract.sol
+++ b/contracts/interfaces/collections/IHasMaintenanceContract.sol
@@ -2,14 +2,14 @@
 
 pragma solidity ^0.8.9;
 
-interface IHasMaintenanceContract {
+import "./IHasContract.sol";
+
+interface IHasMaintenanceContract is IHasContract {
   /// @dev Emitted when the maintenance contract is updated.
   event MaintenanceContractUpdated(address);
 
   /// @dev Error of method caller must be maintenance contract.
   error ErrCallerMustBeMaintenanceContract();
-  /// @dev Error of set to non-contract.
-  error ErrZeroCodeMaintenanceContract();
 
   /**
    * @dev Returns the maintenance contract.

--- a/contracts/interfaces/collections/IHasRoninGovernanceAdminContract.sol
+++ b/contracts/interfaces/collections/IHasRoninGovernanceAdminContract.sol
@@ -6,6 +6,11 @@ interface IHasRoninGovernanceAdminContract {
   /// @dev Emitted when the ronin governance admin contract is updated.
   event RoninGovernanceAdminContractUpdated(address);
 
+  /// @dev Error of method caller must be goverance admin contract.
+  error ErrCallerMustBeGovernanceAdminContract();
+  /// @dev Error of set to non-contract.
+  error ErrZeroCodeGovernanceAdminContract();
+
   /**
    * @dev Returns the ronin governance admin contract.
    */

--- a/contracts/interfaces/collections/IHasRoninGovernanceAdminContract.sol
+++ b/contracts/interfaces/collections/IHasRoninGovernanceAdminContract.sol
@@ -2,14 +2,14 @@
 
 pragma solidity ^0.8.9;
 
-interface IHasRoninGovernanceAdminContract {
+import "./IHasContract.sol";
+
+interface IHasRoninGovernanceAdminContract is IHasContract {
   /// @dev Emitted when the ronin governance admin contract is updated.
   event RoninGovernanceAdminContractUpdated(address);
 
   /// @dev Error of method caller must be goverance admin contract.
   error ErrCallerMustBeGovernanceAdminContract();
-  /// @dev Error of set to non-contract.
-  error ErrZeroCodeGovernanceAdminContract();
 
   /**
    * @dev Returns the ronin governance admin contract.

--- a/contracts/interfaces/collections/IHasRoninTrustedOrganizationContract.sol
+++ b/contracts/interfaces/collections/IHasRoninTrustedOrganizationContract.sol
@@ -2,14 +2,14 @@
 
 pragma solidity ^0.8.9;
 
-interface IHasRoninTrustedOrganizationContract {
+import "./IHasContract.sol";
+
+interface IHasRoninTrustedOrganizationContract is IHasContract {
   /// @dev Emitted when the ronin trusted organization contract is updated.
   event RoninTrustedOrganizationContractUpdated(address);
 
   /// @dev Error of method caller must be Ronin trusted org contract.
   error ErrCallerMustBeRoninTrustedOrgContract();
-  /// @dev Error of set to non-contract.
-  error ErrZeroCodeRoninTrustedOrgContract();
 
   /**
    * @dev Returns the ronin trusted organization contract.

--- a/contracts/interfaces/collections/IHasRoninTrustedOrganizationContract.sol
+++ b/contracts/interfaces/collections/IHasRoninTrustedOrganizationContract.sol
@@ -6,6 +6,11 @@ interface IHasRoninTrustedOrganizationContract {
   /// @dev Emitted when the ronin trusted organization contract is updated.
   event RoninTrustedOrganizationContractUpdated(address);
 
+  /// @dev Error of method caller must be Ronin trusted org contract.
+  error ErrCallerMustBeRoninTrustedOrgContract();
+  /// @dev Error of set to non-contract.
+  error ErrZeroCodeRoninTrustedOrgContract();
+
   /**
    * @dev Returns the ronin trusted organization contract.
    */

--- a/contracts/interfaces/collections/IHasSlashIndicatorContract.sol
+++ b/contracts/interfaces/collections/IHasSlashIndicatorContract.sol
@@ -2,14 +2,14 @@
 
 pragma solidity ^0.8.9;
 
-interface IHasSlashIndicatorContract {
+import "./IHasContract.sol";
+
+interface IHasSlashIndicatorContract is IHasContract {
   /// @dev Emitted when the slash indicator contract is updated.
   event SlashIndicatorContractUpdated(address);
 
   /// @dev Error of method caller must be slash indicator contract.
   error ErrCallerMustBeSlashIndicatorContract();
-  /// @dev Error of set to non-contract.
-  error ErrZeroCodeSlashIndicatorContract();
 
   /**
    * @dev Returns the slash indicator contract.

--- a/contracts/interfaces/collections/IHasSlashIndicatorContract.sol
+++ b/contracts/interfaces/collections/IHasSlashIndicatorContract.sol
@@ -6,6 +6,11 @@ interface IHasSlashIndicatorContract {
   /// @dev Emitted when the slash indicator contract is updated.
   event SlashIndicatorContractUpdated(address);
 
+  /// @dev Error of method caller must be slash indicator contract.
+  error ErrCallerMustBeSlashIndicatorContract();
+  /// @dev Error of set to non-contract.
+  error ErrZeroCodeSlashIndicatorContract();
+
   /**
    * @dev Returns the slash indicator contract.
    */

--- a/contracts/interfaces/collections/IHasStakingContract.sol
+++ b/contracts/interfaces/collections/IHasStakingContract.sol
@@ -6,6 +6,11 @@ interface IHasStakingContract {
   /// @dev Emitted when the staking contract is updated.
   event StakingContractUpdated(address);
 
+  /// @dev Error of method caller must be staking contract.
+  error ErrCallerMustBeStakingContract();
+  /// @dev Error of set to non-contract.
+  error ErrZeroCodeStakingContract();
+
   /**
    * @dev Returns the staking contract.
    */

--- a/contracts/interfaces/collections/IHasStakingContract.sol
+++ b/contracts/interfaces/collections/IHasStakingContract.sol
@@ -2,14 +2,14 @@
 
 pragma solidity ^0.8.9;
 
-interface IHasStakingContract {
+import "./IHasContract.sol";
+
+interface IHasStakingContract is IHasContract {
   /// @dev Emitted when the staking contract is updated.
   event StakingContractUpdated(address);
 
   /// @dev Error of method caller must be staking contract.
   error ErrCallerMustBeStakingContract();
-  /// @dev Error of set to non-contract.
-  error ErrZeroCodeStakingContract();
 
   /**
    * @dev Returns the staking contract.

--- a/contracts/interfaces/collections/IHasStakingVestingContract.sol
+++ b/contracts/interfaces/collections/IHasStakingVestingContract.sol
@@ -2,14 +2,14 @@
 
 pragma solidity ^0.8.9;
 
-interface IHasStakingVestingContract {
+import "./IHasContract.sol";
+
+interface IHasStakingVestingContract is IHasContract {
   /// @dev Emitted when the staking vesting contract is updated.
   event StakingVestingContractUpdated(address);
 
   /// @dev Error of method caller must be staking vesting contract.
   error ErrCallerMustBeStakingVestingContract();
-  /// @dev Error of set to non-contract.
-  error ErrZeroCodeStakingVestingContract();
 
   /**
    * @dev Returns the staking vesting contract.

--- a/contracts/interfaces/collections/IHasStakingVestingContract.sol
+++ b/contracts/interfaces/collections/IHasStakingVestingContract.sol
@@ -6,6 +6,11 @@ interface IHasStakingVestingContract {
   /// @dev Emitted when the staking vesting contract is updated.
   event StakingVestingContractUpdated(address);
 
+  /// @dev Error of method caller must be staking vesting contract.
+  error ErrCallerMustBeStakingVestingContract();
+  /// @dev Error of set to non-contract.
+  error ErrZeroCodeStakingVestingContract();
+
   /**
    * @dev Returns the staking vesting contract.
    */

--- a/contracts/interfaces/collections/IHasValidatorContract.sol
+++ b/contracts/interfaces/collections/IHasValidatorContract.sol
@@ -6,6 +6,11 @@ interface IHasValidatorContract {
   /// @dev Emitted when the validator contract is updated.
   event ValidatorContractUpdated(address);
 
+  /// @dev Error of method caller must be validator contract.
+  error ErrCallerMustBeValidatorContract();
+  /// @dev Error of set to non-contract.
+  error ErrZeroCodeValidatorContract();
+
   /**
    * @dev Returns the validator contract.
    */

--- a/contracts/interfaces/collections/IHasValidatorContract.sol
+++ b/contracts/interfaces/collections/IHasValidatorContract.sol
@@ -2,14 +2,14 @@
 
 pragma solidity ^0.8.9;
 
-interface IHasValidatorContract {
+import "./IHasContract.sol";
+
+interface IHasValidatorContract is IHasContract {
   /// @dev Emitted when the validator contract is updated.
   event ValidatorContractUpdated(address);
 
   /// @dev Error of method caller must be validator contract.
   error ErrCallerMustBeValidatorContract();
-  /// @dev Error of set to non-contract.
-  error ErrZeroCodeValidatorContract();
 
   /**
    * @dev Returns the validator contract.

--- a/contracts/interfaces/validator/ICandidateManager.sol
+++ b/contracts/interfaces/validator/ICandidateManager.sol
@@ -51,6 +51,29 @@ interface ICandidateManager {
   /// @dev Emitted when the commission rate of a validator is updated.
   event CommissionRateUpdated(address indexed consensusAddr, uint256 rate);
 
+  /// @dev Error of exceeding maximum number of candidates.
+  error ErrExceedsMaxNumberOfCandidate();
+  /// @dev Error of querying for already existent candidate.
+  error ErrExistentCandidate();
+  /// @dev Error of querying for non-existent candidate.
+  error ErrNonExistentCandidate();
+  /// @dev Error of candidate admin already exists.
+  error ErrExistentCandidateAdmin(address _candidateAdminAddr);
+  /// @dev Error of treasury already exists.
+  error ErrExistentTreasury(address _treasuryAddr);
+  /// @dev Error of bridge operator already exists.
+  error ErrExistentBridgeOperator(address _bridgeOperatorAddr);
+  /// @dev Error of invalid commission rate.
+  error ErrInvalidCommissionRate();
+  /// @dev Error of invalid effective days onwards.
+  error ErrInvalidEffectiveDaysOnwards();
+  /// @dev Error of invalid min effective days onwards.
+  error ErrInvalidMinEffectiveDaysOnwards();
+  /// @dev Error of already requested revoking candidate before
+  error ErrAlreadyRequestedRevokingCandidate();
+  /// @dev Error of commission change schedule exists
+  error ErrAlreadyRequestedUpdatingCommissionRate();
+
   /**
    * @dev Returns the maximum number of validator candidate.
    */

--- a/contracts/interfaces/validator/ICoinbaseExecution.sol
+++ b/contracts/interfaces/validator/ICoinbaseExecution.sol
@@ -61,6 +61,13 @@ interface ICoinbaseExecution is ISlashingExecution {
   /// @dev Emitted when the epoch is wrapped up.
   event WrappedUpEpoch(uint256 indexed periodNumber, uint256 indexed epochNumber, bool periodEnding);
 
+  /// @dev Error of method caller must be coinbase
+  error ErrCallerMustBeCoinbase();
+  /// @dev Error of only allowed at the end of epoch
+  error ErrAtEndOfEpochOnly();
+  /// @dev Error of query for already wrapped up epoch
+  error ErrAlreadyWrappedEpoch();
+
   /**
    * @dev Submits reward of the current block.
    *

--- a/contracts/interfaces/validator/IEmergencyExit.sol
+++ b/contracts/interfaces/validator/IEmergencyExit.sol
@@ -24,6 +24,9 @@ interface IEmergencyExit {
   /// @dev Emitted when the emergency expiry duration is updated.
   event EmergencyExpiryDurationUpdated(uint256 amount);
 
+  /// @dev Error of already requested emergency exit before.
+  error ErrAlreadyRequestedEmergencyExit();
+
   /**
    * @dev Returns the amount of RON to lock from a consensus address.
    */

--- a/contracts/interfaces/validator/info-fragments/ICommonInfo.sol
+++ b/contracts/interfaces/validator/info-fragments/ICommonInfo.sol
@@ -18,6 +18,9 @@ interface ICommonInfo is ITimingInfo, IJailingInfo, IValidatorInfo {
   /// @dev Emitted when the deprecated reward withdrawal is failed
   event DeprecatedRewardRecycleFailed(address indexed recipientAddr, uint256 amount, uint256 balance);
 
+  // Error thrown when receives RON from neither staking vesting contract nor staking contract"
+  error UnauthorizedReceiveRON();
+
   /**
    * @dev Returns the total deprecated reward, which includes reward that is not sent for slashed validators and unsastified bridge operators
    */

--- a/contracts/interfaces/validator/info-fragments/IValidatorInfo.sol
+++ b/contracts/interfaces/validator/info-fragments/IValidatorInfo.sol
@@ -3,18 +3,21 @@
 pragma solidity ^0.8.9;
 
 interface IValidatorInfo {
-  /// @dev Emitted when the number of max validator is updated
+  /// @dev Emitted when the number of max validator is updated.
   event MaxValidatorNumberUpdated(uint256);
-  /// @dev Emitted when the number of reserved slots for prioritized validators is updated
+  /// @dev Emitted when the number of reserved slots for prioritized validators is updated.
   event MaxPrioritizedValidatorNumberUpdated(uint256);
 
+  /// @dev Error of number of prioritized greater than number of max validators.
+  error InvalidMaxPrioitizedValidatorNumber();
+
   /**
-   * @dev Returns the maximum number of validators in the epoch
+   * @dev Returns the maximum number of validators in the epoch.
    */
   function maxValidatorNumber() external view returns (uint256 _maximumValidatorNumber);
 
   /**
-   * @dev Returns the number of reserved slots for prioritized validators
+   * @dev Returns the number of reserved slots for prioritized validators.
    */
   function maxPrioritizedValidatorNumber() external view returns (uint256 _maximumPrioritizedValidatorNumber);
 

--- a/contracts/mocks/precompile-usages/MockPCUPickValidatorSet.sol
+++ b/contracts/mocks/precompile-usages/MockPCUPickValidatorSet.sol
@@ -2,9 +2,9 @@
 
 pragma solidity ^0.8.9;
 
-import "../../precompile-usages/PrecompileUsagePickValidatorSet.sol";
+import "../../precompile-usages/PCUPickValidatorSet.sol";
 
-contract MockPrecompileUsagePickValidatorSet is PrecompileUsagePickValidatorSet {
+contract MockPCUPickValidatorSet is PCUPickValidatorSet {
   address internal _precompileSortValidatorAddress;
 
   constructor(address _precompile) {

--- a/contracts/mocks/precompile-usages/MockPCUSortValidators.sol
+++ b/contracts/mocks/precompile-usages/MockPCUSortValidators.sol
@@ -2,9 +2,9 @@
 
 pragma solidity ^0.8.9;
 
-import "../../precompile-usages/PrecompileUsageSortValidators.sol";
+import "../../precompile-usages/PCUSortValidators.sol";
 
-contract MockPrecompileUsageSortValidators is PrecompileUsageSortValidators {
+contract MockPCUSortValidators is PCUSortValidators {
   address internal _precompileSortValidatorAddress;
 
   constructor(address _precompile) {

--- a/contracts/mocks/precompile-usages/MockPCUValidateDoubleSign.sol
+++ b/contracts/mocks/precompile-usages/MockPCUValidateDoubleSign.sol
@@ -2,9 +2,9 @@
 
 pragma solidity ^0.8.9;
 
-import "../../precompile-usages/PrecompileUsageValidateDoubleSign.sol";
+import "../../precompile-usages/PCUValidateDoubleSign.sol";
 
-contract MockPrecompileUsageValidateDoubleSign is PrecompileUsageValidateDoubleSign {
+contract MockPCUValidateDoubleSign is PCUValidateDoubleSign {
   address internal _precompileValidateDoubleSignAddress;
 
   constructor(address _precompile) {

--- a/contracts/precompile-usages/PCUPickValidatorSet.sol
+++ b/contracts/precompile-usages/PCUPickValidatorSet.sol
@@ -2,7 +2,9 @@
 
 pragma solidity ^0.8.9;
 
-abstract contract PrecompileUsagePickValidatorSet {
+import "./PrecompiledUsage.sol";
+
+abstract contract PCUPickValidatorSet is PrecompiledUsage {
   /// @dev Gets the address of the precompile of picking validator set
   function precompilePickValidatorSetAddress() public view virtual returns (address) {
     return address(0x68);
@@ -49,7 +51,7 @@ abstract contract PrecompileUsagePickValidatorSet {
       _result := add(_result, 0x20)
     }
 
-    require(_success, "PrecompileUsagePickValidatorSet: call to precompile fails");
+    if (!_success) revert ErrCallPrecompiled();
 
     _newValidatorCount = _result.length;
   }

--- a/contracts/precompile-usages/PCUSortValidators.sol
+++ b/contracts/precompile-usages/PCUSortValidators.sol
@@ -2,7 +2,9 @@
 
 pragma solidity ^0.8.9;
 
-abstract contract PrecompileUsageSortValidators {
+import "./PrecompiledUsage.sol";
+
+abstract contract PCUSortValidators is PrecompiledUsage {
   /// @dev Gets the address of the precompile of sorting validators
   function precompileSortValidatorsAddress() public view virtual returns (address) {
     return address(0x66);
@@ -40,6 +42,6 @@ abstract contract PrecompileUsageSortValidators {
       _result := add(_result, 0x20)
     }
 
-    require(_success, "PrecompileUsageSortValidators: call to precompile fails");
+    if (!_success) revert ErrCallPrecompiled();
   }
 }

--- a/contracts/precompile-usages/PCUValidateDoubleSign.sol
+++ b/contracts/precompile-usages/PCUValidateDoubleSign.sol
@@ -2,7 +2,9 @@
 
 pragma solidity ^0.8.9;
 
-abstract contract PrecompileUsageValidateDoubleSign {
+import "./PrecompiledUsage.sol";
+
+abstract contract PCUValidateDoubleSign is PrecompiledUsage {
   /// @dev Gets the address of the precompile of validating double sign evidence
   function precompileValidateDoubleSignAddress() public view virtual returns (address) {
     return address(0x67);
@@ -38,7 +40,7 @@ abstract contract PrecompileUsageValidateDoubleSign {
       }
     }
 
-    require(_success, "PrecompileUsageValidateDoubleSign: call to precompile fails");
+    if (!_success) revert ErrCallPrecompiled();
     return (_output[0] != 0);
   }
 }

--- a/contracts/precompile-usages/PrecompiledUsage.sol
+++ b/contracts/precompile-usages/PrecompiledUsage.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.9;
+
+import "./PrecompiledUsage.sol";
+
+abstract contract PrecompiledUsage {
+  /// @dev Error of call to precompile fails.
+  error ErrCallPrecompiled();
+}

--- a/contracts/ronin/slash-indicator/SlashDoubleSign.sol
+++ b/contracts/ronin/slash-indicator/SlashDoubleSign.sol
@@ -3,10 +3,10 @@
 pragma solidity ^0.8.9;
 
 import "../../interfaces/slash-indicator/ISlashDoubleSign.sol";
-import "../../precompile-usages/PrecompileUsageValidateDoubleSign.sol";
+import "../../precompile-usages/PCUValidateDoubleSign.sol";
 import "../../extensions/collections/HasValidatorContract.sol";
 
-abstract contract SlashDoubleSign is ISlashDoubleSign, HasValidatorContract, PrecompileUsageValidateDoubleSign {
+abstract contract SlashDoubleSign is ISlashDoubleSign, HasValidatorContract, PCUValidateDoubleSign {
   /// @dev The amount of RON to slash double sign.
   uint256 internal _slashDoubleSignAmount;
   /// @dev The block number that the punished validator will be jailed until, due to double signing.

--- a/contracts/ronin/validator/EmergencyExit.sol
+++ b/contracts/ronin/validator/EmergencyExit.sol
@@ -5,8 +5,6 @@ pragma solidity ^0.8.9;
 import "../../extensions/RONTransferHelper.sol";
 import "../../interfaces/IRoninGovernanceAdmin.sol";
 import "../../interfaces/validator/IEmergencyExit.sol";
-import "../../precompile-usages/PrecompileUsageSortValidators.sol";
-import "../../precompile-usages/PrecompileUsagePickValidatorSet.sol";
 import "./storage-fragments/CommonStorage.sol";
 import "./CandidateManager.sol";
 

--- a/contracts/ronin/validator/EmergencyExit.sol
+++ b/contracts/ronin/validator/EmergencyExit.sol
@@ -28,7 +28,7 @@ abstract contract EmergencyExit is IEmergencyExit, RONTransferHelper, CandidateM
    */
   function execEmergencyExit(address _consensusAddr, uint256 _secLeftToRevoke) external onlyStakingContract {
     EmergencyExitInfo storage _info = _exitInfo[_consensusAddr];
-    require(_info.recyclingAt == 0, "EmergencyExit: already requested");
+    if (_info.recyclingAt != 0) revert ErrAlreadyRequestedEmergencyExit();
 
     uint256 _revokingTimestamp = block.timestamp + _secLeftToRevoke;
     _setRevokingTimestamp(_candidateInfo[_consensusAddr], _revokingTimestamp);

--- a/contracts/ronin/validator/RoninValidatorSet.sol
+++ b/contracts/ronin/validator/RoninValidatorSet.sol
@@ -59,10 +59,7 @@ contract RoninValidatorSet is Initializable, CoinbaseExecution, SlashingExecutio
    * deducting amount on slashing).
    */
   function _fallback() internal view {
-    require(
-      msg.sender == stakingVestingContract() || msg.sender == stakingContract(),
-      "RoninValidatorSet: only receives RON from staking vesting contract or staking contract"
-    );
+    if (msg.sender != stakingVestingContract() && msg.sender != stakingContract()) revert UnauthorizedReceiveRON();
   }
 
   /**

--- a/contracts/ronin/validator/storage-fragments/ValidatorInfoStorage.sol
+++ b/contracts/ronin/validator/storage-fragments/ValidatorInfoStorage.sol
@@ -171,11 +171,7 @@ abstract contract ValidatorInfoStorage is IValidatorInfo, HasRoninTrustedOrganiz
    * @dev See `IValidatorInfo-setMaxPrioritizedValidatorNumber`
    */
   function _setMaxPrioritizedValidatorNumber(uint256 _number) internal {
-    require(
-      _number <= _maxValidatorNumber,
-      "RoninValidatorSet: cannot set number of prioritized greater than number of max validators"
-    );
-
+    if (_number > _maxValidatorNumber) revert InvalidMaxPrioitizedValidatorNumber();
     _maxPrioritizedValidatorNumber = _number;
     emit MaxPrioritizedValidatorNumberUpdated(_number);
   }

--- a/test/integration/ActionWrapUpEpoch.test.ts
+++ b/test/integration/ActionWrapUpEpoch.test.ts
@@ -173,7 +173,7 @@ describe('[Integration] Wrap up epoch', () => {
           await validatorContract.endEpoch();
           await validatorContract.wrapUpEpoch();
           let duplicatedWrapUpTx = validatorContract.wrapUpEpoch();
-          await expect(duplicatedWrapUpTx).to.be.revertedWith('RoninValidatorSet: query for already wrapped up epoch');
+          await expect(duplicatedWrapUpTx).to.be.revertedWithCustomError(validatorContract, 'ErrAlreadyWrappedEpoch');
         });
       });
 

--- a/test/precompile-usages/PrecompileUsageSortValidators.test.ts
+++ b/test/precompile-usages/PrecompileUsageSortValidators.test.ts
@@ -5,22 +5,22 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import {
   MockPrecompile,
   MockPrecompile__factory,
-  MockPrecompileUsageSortValidators,
-  MockPrecompileUsageSortValidators__factory,
+  MockPCUSortValidators,
+  MockPCUSortValidators__factory,
 } from '../../src/types';
 import { randomInt } from 'crypto';
 
 let deployer: SignerWithAddress;
 let validatorCandidates: SignerWithAddress[];
 let precompileSorting: MockPrecompile;
-let usageSorting: MockPrecompileUsageSortValidators;
+let usageSorting: MockPCUSortValidators;
 
 describe('[Precompile] Sorting validators test', () => {
   before(async () => {
     [deployer, ...validatorCandidates] = await ethers.getSigners();
 
     precompileSorting = await new MockPrecompile__factory(deployer).deploy();
-    usageSorting = await new MockPrecompileUsageSortValidators__factory(deployer).deploy(precompileSorting.address);
+    usageSorting = await new MockPCUSortValidators__factory(deployer).deploy(precompileSorting.address);
   });
 
   it('Should the usage contract correctly configs the precompile address', async () => {
@@ -50,8 +50,9 @@ describe('[Precompile] Sorting validators test', () => {
 
   it('Should the usage contract revert with proper message on calling the precompile contract fails', async () => {
     await usageSorting.setPrecompileSortValidatorAddress(ethers.constants.AddressZero);
-    await expect(usageSorting.callPrecompile([validatorCandidates[0].address], [1])).revertedWith(
-      'PrecompileUsageSortValidators: call to precompile fails'
+    await expect(usageSorting.callPrecompile([validatorCandidates[0].address], [1])).revertedWithCustomError(
+      usageSorting,
+      'ErrCallPrecompiled'
     );
   });
 });

--- a/test/precompile-usages/PrecompileUsageValidateDoubleSign.test.ts
+++ b/test/precompile-usages/PrecompileUsageValidateDoubleSign.test.ts
@@ -5,23 +5,21 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import {
   MockPrecompile,
   MockPrecompile__factory,
-  MockPrecompileUsageValidateDoubleSign,
-  MockPrecompileUsageValidateDoubleSign__factory,
+  MockPCUValidateDoubleSign,
+  MockPCUValidateDoubleSign__factory,
 } from '../../src/types';
 
 let deployer: SignerWithAddress;
 let signers: SignerWithAddress[];
 let precompileValidating: MockPrecompile;
-let usageValidating: MockPrecompileUsageValidateDoubleSign;
+let usageValidating: MockPCUValidateDoubleSign;
 
 describe('[Precompile] Validate double sign test', () => {
   before(async () => {
     [deployer, ...signers] = await ethers.getSigners();
 
     precompileValidating = await new MockPrecompile__factory(deployer).deploy();
-    usageValidating = await new MockPrecompileUsageValidateDoubleSign__factory(deployer).deploy(
-      precompileValidating.address
-    );
+    usageValidating = await new MockPCUValidateDoubleSign__factory(deployer).deploy(precompileValidating.address);
   });
 
   let header1 = ethers.utils.toUtf8Bytes('sampleHeader1');
@@ -38,8 +36,9 @@ describe('[Precompile] Validate double sign test', () => {
 
   it('Should the usage contract revert with proper message on calling the precompile contract fails', async () => {
     await usageValidating.setPrecompileValidateDoubleSignAddress(ethers.constants.AddressZero);
-    await expect(usageValidating.callPrecompile(header1, header2)).revertedWith(
-      'PrecompileUsageValidateDoubleSign: call to precompile fails'
+    await expect(usageValidating.callPrecompile(header1, header2)).revertedWithCustomError(
+      usageValidating,
+      'ErrCallPrecompiled'
     );
   });
 });

--- a/test/staking/Staking.test.ts
+++ b/test/staking/Staking.test.ts
@@ -132,7 +132,7 @@ describe('Staking test', () => {
               value: minValidatorStakingAmount,
             }
           )
-      ).revertedWith('CandidateManager: query for already existent candidate');
+      ).revertedWithCustomError(validatorContract, 'ErrExistentCandidate');
     });
 
     it('Should not be able to stake with empty value', async () => {
@@ -218,7 +218,7 @@ describe('Staking test', () => {
           minEffectiveDaysOnwards - 1,
           20_00 // 20%
         )
-      ).revertedWith('CandidateManager: invalid effective date');
+      ).revertedWithCustomError(validatorContract, 'ErrInvalidEffectiveDaysOnwards');
     });
 
     it('Should the pool admin be able to request updating the commission rate', async () => {
@@ -261,7 +261,7 @@ describe('Staking test', () => {
     it('Should not be able to request renounce again', async () => {
       await expect(
         stakingContract.connect(poolAddrSet.poolAdmin).requestRenounce(poolAddrSet.consensusAddr.address)
-      ).revertedWith('CandidateManager: already requested before');
+      ).revertedWithCustomError(validatorContract, 'ErrAlreadyRequestedRevokingCandidate');
     });
 
     it('Should the consensus account is no longer be a candidate, and the staked amount is transferred back to the pool admin', async () => {

--- a/test/validator/EmergencyExit.test.ts
+++ b/test/validator/EmergencyExit.test.ts
@@ -182,7 +182,7 @@ describe('Emergency Exit test', () => {
       stakingContract
         .connect(compromisedValidator.poolAdmin)
         .requestEmergencyExit(compromisedValidator.consensusAddr.address)
-    ).revertedWith('EmergencyExit: already requested');
+    ).revertedWithCustomError(roninValidatorSet, 'ErrAlreadyRequestedEmergencyExit');
   });
 
   it('Should the request tx emit event CandidateRevokingTimestampUpdated', async () => {

--- a/test/validator/RoninValidatorSet.test.ts
+++ b/test/validator/RoninValidatorSet.test.ts
@@ -139,14 +139,16 @@ describe('Ronin Validator Set test', () => {
 
   describe('Wrapping up epoch sanity check', async () => {
     it('Should not be able to wrap up epoch using unauthorized account', async () => {
-      await expect(roninValidatorSet.connect(deployer).wrapUpEpoch()).revertedWith(
-        'RoninValidatorSet: method caller must be coinbase'
+      await expect(roninValidatorSet.connect(deployer).wrapUpEpoch()).revertedWithCustomError(
+        roninValidatorSet,
+        'ErrCallerMustBeCoinbase'
       );
     });
 
     it('Should not be able to wrap up epoch when the epoch is not ending', async () => {
-      await expect(roninValidatorSet.connect(consensusAddr).wrapUpEpoch()).revertedWith(
-        'RoninValidatorSet: only allowed at the end of epoch'
+      await expect(roninValidatorSet.connect(consensusAddr).wrapUpEpoch()).revertedWithCustomError(
+        roninValidatorSet,
+        'ErrAtEndOfEpochOnly'
       );
     });
 
@@ -356,8 +358,9 @@ describe('Ronin Validator Set test', () => {
   describe('Recording and distributing rewards', async () => {
     describe('Sanity check', async () => {
       it('Should not be able to submit block reward using unauthorized account', async () => {
-        await expect(roninValidatorSet.submitBlockReward()).revertedWith(
-          'RoninValidatorSet: method caller must be coinbase'
+        await expect(roninValidatorSet.submitBlockReward()).revertedWithCustomError(
+          roninValidatorSet,
+          'ErrCallerMustBeCoinbase'
         );
       });
     });

--- a/test/validator/RoninValidatorSet.test.ts
+++ b/test/validator/RoninValidatorSet.test.ts
@@ -263,9 +263,9 @@ describe('Ronin Validator Set test', () => {
           }
         );
 
-      await expect(tx).revertedWith(
-        `CandidateManager: bridge operator address ${validatorCandidates[0].bridgeOperator.address.toLocaleLowerCase()} is already exist`
-      );
+      await expect(tx)
+        .revertedWithCustomError(roninValidatorSet, 'ErrExistentBridgeOperator')
+        .withArgs(validatorCandidates[0].bridgeOperator.address);
     });
   });
 


### PR DESCRIPTION
### Description
Changes `require(A, "message")` to `if (~A) revert CustomError` to reduce contract size.

### Size of contracts

#### After emergency exit #126 

```
 ·-------------------------------------------|--------------|----------------·
 |  Contract Name                            ·  Size (KiB)  ·  Change (KiB)  │
 ············································|··············|·················
 |  HasBridgeTrackingContract                ·       0.477  ·        -0.069  │
 ············································|··············|·················
 |  HasBridgeContract                        ·       0.477  ·        -0.062  │
 ············································|··············|·················
 |  HasSlashIndicatorContract                ·       0.477  ·        -0.069  │
 ············································|··············|·················
 |  HasMaintenanceContract                   ·       0.477  ·        -0.066  │
 ············································|··············|·················
 |  HasRoninTrustedOrganizationContract      ·       0.477  ·        -0.084  │
 ············································|··············|·················
 |  HasRoninGovernanceAdminContract          ·       0.477  ·        -0.075  │
 ············································|··············|·················
 |  HasStakingContract                       ·       0.477  ·        -0.063  │
 ············································|··············|·················
 |  HasStakingVestingContract                ·       0.477  ·        -0.069  │
 ············································|··············|·················
 |  HasValidatorContract                     ·       0.477  ·        -0.064  │
 ············································|··············|·················
 |  StakingVesting                           ·       2.106  ·        -0.146  │
 ············································|··············|·················
 |  BridgeTracking                           ·       4.271  ·        -0.213  │
 ············································|··············|·················
 |  Maintenance                              ·       5.061  ·        -0.063  │
 ············································|··············|·················
 |  MockValidatorSet                         ·       7.847  ·        -1.596  │
 ············································|··············|·················
 |  SlashIndicator                           ·      10.343  ·        -0.452  │
 ············································|··············|·················
 |  MockSlashIndicatorExtended               ·      13.534  ·        -0.369  │
 ············································|··············|·················
 |  Staking                                  ·      15.405  ·        -0.304  │
 ············································|··············|·················
 |  RoninGovernanceAdmin                     ·      20.888  ·        -0.083  │
 ············································|··············|·················
 |  RoninValidatorSet                        ·      22.722  ·        -2.615  │
 ············································|··············|·················
 |  MockRoninValidatorSetOverridePrecompile  ·      26.004  ·        -2.532  │
 ············································|··············|·················
 |  MockRoninValidatorSetExtended            ·      26.807  ·        -2.532  │
 ·-------------------------------------------|--------------|----------------·
```

#### Before emergency exit #126 

```
 ·-------------------------------------------|--------------|----------------·
 |  Contract Name                            ·  Size (KiB)  ·  Change (KiB)  │
 ············································|··············|·················
 |  HasRoninGovernanceAdminContract          ·       0.477  ·        -0.075  │
 ············································|··············|·················
 |  HasBridgeTrackingContract                ·       0.477  ·        -0.069  │
 ············································|··············|·················
 |  HasMaintenanceContract                   ·       0.477  ·        -0.066  │
 ············································|··············|·················
 |  HasBridgeContract                        ·       0.477  ·        -0.062  │
 ············································|··············|·················
 |  HasSlashIndicatorContract                ·       0.477  ·        -0.069  │
 ············································|··············|·················
 |  HasStakingVestingContract                ·       0.477  ·        -0.069  │
 ············································|··············|·················
 |  HasRoninTrustedOrganizationContract      ·       0.477  ·        -0.084  │
 ············································|··············|·················
 |  HasValidatorContract                     ·       0.477  ·        -0.064  │
 ············································|··············|·················
 |  HasStakingContract                       ·       0.477  ·        -0.063  │
 ············································|··············|·················
 |  StakingVesting                           ·       2.106  ·        -0.146  │
 ············································|··············|·················
 |  BridgeTracking                           ·       4.271  ·        -0.213  │
 ············································|··············|·················
 |  Maintenance                              ·       5.061  ·        -0.063  │
 ············································|··············|·················
 |  MockValidatorSet                         ·       7.546  ·        -1.596  │
 ············································|··············|·················
 |  SlashIndicator                           ·      10.343  ·        -0.452  │
 ············································|··············|·················
 |  MockSlashIndicatorExtended               ·      13.534  ·        -0.369  │
 ············································|··············|·················
 |  Staking                                  ·      15.105  ·        -0.304  │
 ············································|··············|·················
 |  RoninValidatorSet                        ·      19.763  ·        -2.574  │
 ············································|··············|·················
 |  MockRoninValidatorSetOverridePrecompile  ·      23.028  ·        -2.491  │
 ············································|··············|·················
 |  MockRoninValidatorSetExtended            ·      23.713  ·        -2.491  │
 ·-------------------------------------------|--------------|----------------·
```



### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
