### PR TITLE
[RoninGovernanceAdmin] Expose function & store bridge operator set

### DIFF
--- a/contracts/extensions/isolated-governance/bridge-operator-governance/BOsGovernanceProposal.sol
+++ b/contracts/extensions/isolated-governance/bridge-operator-governance/BOsGovernanceProposal.sol
@@ -7,10 +7,8 @@ import "../../../libraries/BridgeOperatorsBallot.sol";
 import "../../../interfaces/IRoninGovernanceAdmin.sol";
 
 abstract contract BOsGovernanceProposal is SignatureConsumer, IsolatedGovernance, IRoninGovernanceAdmin {
-  /// @dev The last period that the brige operators synced.
-  uint256 internal _lastSyncedPeriod;
-  /// @dev The last epoch that the brige operators synced.
-  uint256 internal _lastSyncedEpoch;
+  /// @dev The last the brige operator set info.
+  BridgeOperatorsBallot.BridgeOperatorSet internal _lastSyncedBridgeOperatorSetInfo;
   /// @dev Mapping from period index => epoch index => bridge operators vote
   mapping(uint256 => mapping(uint256 => IsolatedVote)) internal _vote;
 
@@ -29,8 +27,8 @@ abstract contract BOsGovernanceProposal is SignatureConsumer, IsolatedGovernance
   /**
    * @inheritdoc IRoninGovernanceAdmin
    */
-  function lastBridgeOperatorSetSynced() external view returns (uint256 _period, uint256 _epoch) {
-    return (_lastSyncedPeriod, _lastSyncedEpoch);
+  function lastSyncedBridgeOperatorSetInfo() external view returns (BridgeOperatorsBallot.BridgeOperatorSet memory) {
+    return _lastSyncedBridgeOperatorSetInfo;
   }
 
   /**
@@ -43,38 +41,41 @@ abstract contract BOsGovernanceProposal is SignatureConsumer, IsolatedGovernance
    *
    */
   function _castVotesBySignatures(
-    address[] calldata _operators,
+    BridgeOperatorsBallot.BridgeOperatorSet calldata _ballot,
     Signature[] calldata _signatures,
-    uint256 _period,
-    uint256 _epoch,
     uint256 _minimumVoteWeight,
     bytes32 _domainSeperator
   ) internal {
     require(
-      _period >= _lastSyncedPeriod && _epoch >= _lastSyncedEpoch,
+      _ballot.period >= _lastSyncedBridgeOperatorSetInfo.period &&
+        _ballot.epoch >= _lastSyncedBridgeOperatorSetInfo.epoch,
       "BOsGovernanceProposal: query for outdated bridge operator set"
     );
-    require(_operators.length > 0 && _signatures.length > 0, "BOsGovernanceProposal: invalid array length");
+    BridgeOperatorsBallot.verifyBallot(_ballot, _lastSyncedBridgeOperatorSetInfo);
+    require(_signatures.length > 0, "BOsGovernanceProposal: invalid array length");
 
-    Signature memory _sig;
     address _signer;
     address _lastSigner;
-    bytes32 _hash = BridgeOperatorsBallot.hash(_period, _epoch, _operators);
+    bytes32 _hash = BridgeOperatorsBallot.hash(_ballot);
     bytes32 _digest = ECDSA.toTypedDataHash(_domainSeperator, _hash);
-    IsolatedVote storage _v = _vote[_period][_epoch];
+    IsolatedVote storage _v = _vote[_ballot.period][_ballot.epoch];
+    mapping(address => Signature) storage _signatureOf = _votingSig[_ballot.period][_ballot.epoch];
     bool _hasValidVotes;
 
     for (uint256 _i = 0; _i < _signatures.length; _i++) {
-      _sig = _signatures[_i];
-      _signer = ECDSA.recover(_digest, _sig.v, _sig.r, _sig.s);
-      require(_lastSigner < _signer, "BOsGovernanceProposal: invalid order");
-      _lastSigner = _signer;
+      // Avoids stack too deeps
+      {
+        Signature calldata _sig = _signatures[_i];
+        _signer = ECDSA.recover(_digest, _sig.v, _sig.r, _sig.s);
+        require(_lastSigner < _signer, "BOsGovernanceProposal: invalid order");
+        _lastSigner = _signer;
+      }
 
       uint256 _weight = _getBridgeVoterWeight(_signer);
       if (_weight > 0) {
         _hasValidVotes = true;
         _lastVotedBlock[_signer] = block.number;
-        _votingSig[_period][_epoch][_signer] = _sig;
+        _signatureOf[_signer] = _signatures[_i];
         if (_castVote(_v, _signer, _weight, _minimumVoteWeight, _hash) == VoteStatus.Approved) {
           return;
         }

--- a/contracts/extensions/isolated-governance/bridge-operator-governance/BOsGovernanceProposal.sol
+++ b/contracts/extensions/isolated-governance/bridge-operator-governance/BOsGovernanceProposal.sol
@@ -67,7 +67,7 @@ abstract contract BOsGovernanceProposal is SignatureConsumer, IsolatedGovernance
       {
         Signature calldata _sig = _signatures[_i];
         _signer = ECDSA.recover(_digest, _sig.v, _sig.r, _sig.s);
-        require(_lastSigner < _signer, "BOsGovernanceProposal: invalid order");
+        require(_lastSigner < _signer, "BOsGovernanceProposal: invalid signer order");
         _lastSigner = _signer;
       }
 

--- a/contracts/extensions/isolated-governance/bridge-operator-governance/BOsGovernanceProposal.sol
+++ b/contracts/extensions/isolated-governance/bridge-operator-governance/BOsGovernanceProposal.sol
@@ -27,6 +27,13 @@ abstract contract BOsGovernanceProposal is SignatureConsumer, IsolatedGovernance
   }
 
   /**
+   * @inheritdoc IRoninGovernanceAdmin
+   */
+  function lastBridgeOperatorSetSynced() external view returns (uint256 _period, uint256 _epoch) {
+    return (_lastSyncedPeriod, _lastSyncedEpoch);
+  }
+
+  /**
    * @dev Votes for a set of bridge operators by signatures.
    *
    * Requirements:

--- a/contracts/extensions/sequential-governance/GovernanceProposal.sol
+++ b/contracts/extensions/sequential-governance/GovernanceProposal.sol
@@ -26,7 +26,7 @@ abstract contract GovernanceProposal is CoreGovernance {
 
     address _lastSigner;
     address _signer;
-    Signature memory _sig;
+    Signature calldata _sig;
     bool _hasValidVotes;
     for (uint256 _i; _i < _signatures.length; _i++) {
       _sig = _signatures[_i];

--- a/contracts/extensions/sequential-governance/GovernanceRelay.sol
+++ b/contracts/extensions/sequential-governance/GovernanceRelay.sol
@@ -30,7 +30,7 @@ abstract contract GovernanceRelay is CoreGovernance {
       address _signer;
       address _lastSigner;
       Ballot.VoteType _support;
-      Signature memory _sig;
+      Signature calldata _sig;
 
       for (uint256 _i; _i < _signatures.length; _i++) {
         _sig = _signatures[_i];

--- a/contracts/interfaces/IRoninGovernanceAdmin.sol
+++ b/contracts/interfaces/IRoninGovernanceAdmin.sol
@@ -23,6 +23,11 @@ interface IRoninGovernanceAdmin {
   function lastVotedBlock(address _bridgeVoter) external view returns (uint256);
 
   /**
+   * @dev Returns the last period and epoch that the bridge operator set is synced.
+   */
+  function lastBridgeOperatorSetSynced() external view returns (uint256 _period, uint256 _epoch);
+
+  /**
    * @dev Create a vote to agree that an emergency exit is valid and should return the locked funds back.a
    *
    * Requirements:

--- a/contracts/interfaces/IRoninGovernanceAdmin.sol
+++ b/contracts/interfaces/IRoninGovernanceAdmin.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import "../libraries/BridgeOperatorsBallot.sol";
+
 interface IRoninGovernanceAdmin {
   /// @dev Emitted when the bridge operators are approved.
   event BridgeOperatorsApproved(uint256 _period, uint256 _epoch, address[] _operators);
@@ -23,9 +25,12 @@ interface IRoninGovernanceAdmin {
   function lastVotedBlock(address _bridgeVoter) external view returns (uint256);
 
   /**
-   * @dev Returns the last period and epoch that the bridge operator set is synced.
+   * @dev Returns the synced bridge operator set info.
    */
-  function lastBridgeOperatorSetSynced() external view returns (uint256 _period, uint256 _epoch);
+  function lastSyncedBridgeOperatorSetInfo()
+    external
+    view
+    returns (BridgeOperatorsBallot.BridgeOperatorSet memory _bridgeOperatorSetInfo);
 
   /**
    * @dev Create a vote to agree that an emergency exit is valid and should return the locked funds back.a

--- a/contracts/libraries/BridgeOperatorsBallot.sol
+++ b/contracts/libraries/BridgeOperatorsBallot.sol
@@ -4,23 +4,62 @@ pragma solidity ^0.8.0;
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 
 library BridgeOperatorsBallot {
+  struct BridgeOperatorSet {
+    uint256 period;
+    uint256 epoch;
+    address[] operators;
+  }
+
   // keccak256("BridgeOperatorsBallot(uint256 period,uint256 epoch,address[] operators)");
   bytes32 public constant BRIDGE_OPERATORS_BALLOT_TYPEHASH =
     0xd679a49e9e099fa9ed83a5446aaec83e746b03ec6723d6f5efb29d37d7f0b78a;
 
   /**
+   * @dev Verifies whether the ballot is valid or not.
+   *
+   * Requirements:
+   * - The ballot is not for an empty operator set.
+   * - The epoch and period are not older than the current ones.
+   * - The bridge operator set is changed compared with the latest one.
+   * - The operator address list is in order.
+   *
+   */
+  function verifyBallot(BridgeOperatorSet calldata _ballot, BridgeOperatorSet storage _latest) internal view {
+    require(_ballot.operators.length > 0, "BridgeOperatorsBallot: invalid array length");
+
+    bytes32 _ballotOperatorsHash;
+    bytes32 _latestOperatorsHash;
+    address[] memory _ballotOperators = _ballot.operators;
+    address[] memory _latestOperators = _latest.operators;
+
+    assembly {
+      _ballotOperatorsHash := keccak256(add(_ballotOperators, 32), mul(mload(_ballotOperators), 32))
+      _latestOperatorsHash := keccak256(add(_latestOperators, 32), mul(mload(_latestOperators), 32))
+    }
+
+    require(
+      _ballotOperatorsHash != _latestOperatorsHash,
+      "BOsGovernanceProposal: bridge operator set is already voted"
+    );
+
+    address _addr = _ballotOperators[0];
+    for (uint _i = 1; _i < _ballotOperators.length; _i++) {
+      require(_addr < _ballotOperators[_i], "BOsGovernanceProposal: invalid order of bridge operators");
+      _addr = _ballotOperators[_i];
+    }
+  }
+
+  /**
    * @dev Returns hash of the ballot.
    */
-  function hash(
-    uint256 _period,
-    uint256 _epoch,
-    address[] memory _operators
-  ) internal pure returns (bytes32) {
+  function hash(BridgeOperatorSet calldata _ballot) internal pure returns (bytes32) {
     bytes32 _operatorsHash;
+    address[] memory _operators = _ballot.operators;
+
     assembly {
       _operatorsHash := keccak256(add(_operators, 32), mul(mload(_operators), 32))
     }
 
-    return keccak256(abi.encode(BRIDGE_OPERATORS_BALLOT_TYPEHASH, _period, _epoch, _operatorsHash));
+    return keccak256(abi.encode(BRIDGE_OPERATORS_BALLOT_TYPEHASH, _ballot.period, _ballot.epoch, _operatorsHash));
   }
 }

--- a/contracts/libraries/BridgeOperatorsBallot.sol
+++ b/contracts/libraries/BridgeOperatorsBallot.sol
@@ -39,12 +39,12 @@ library BridgeOperatorsBallot {
 
     require(
       _ballotOperatorsHash != _latestOperatorsHash,
-      "BOsGovernanceProposal: bridge operator set is already voted"
+      "BridgeOperatorsBallot: bridge operator set is already voted"
     );
 
     address _addr = _ballotOperators[0];
     for (uint _i = 1; _i < _ballotOperators.length; _i++) {
-      require(_addr < _ballotOperators[_i], "BOsGovernanceProposal: invalid order of bridge operators");
+      require(_addr < _ballotOperators[_i], "BridgeOperatorsBallot: invalid order of bridge operators");
       _addr = _ballotOperators[_i];
     }
   }

--- a/contracts/mainchain/MainchainGovernanceAdmin.sol
+++ b/contracts/mainchain/MainchainGovernanceAdmin.sol
@@ -84,14 +84,12 @@ contract MainchainGovernanceAdmin is AccessControlEnumerable, GovernanceRelay, G
    *
    */
   function relayBridgeOperators(
-    uint256 _period,
-    uint256 _epoch,
-    address[] calldata _operators,
+    BridgeOperatorsBallot.BridgeOperatorSet calldata _ballot,
     Signature[] calldata _signatures
   ) external onlyRole(RELAYER_ROLE) {
-    _relayVotesBySignatures(_operators, _signatures, _period, _epoch, _getMinimumVoteWeight(), DOMAIN_SEPARATOR);
+    _relayVotesBySignatures(_ballot, _signatures, _getMinimumVoteWeight(), DOMAIN_SEPARATOR);
     TransparentUpgradeableProxyV2(payable(bridgeContract())).functionDelegateCall(
-      abi.encodeWithSelector(_bridgeContract.replaceBridgeOperators.selector, _operators)
+      abi.encodeWithSelector(_bridgeContract.replaceBridgeOperators.selector, _ballot.operators)
     );
   }
 

--- a/contracts/ronin/RoninGovernanceAdmin.sol
+++ b/contracts/ronin/RoninGovernanceAdmin.sol
@@ -237,17 +237,14 @@ contract RoninGovernanceAdmin is
    * @dev See `BOsGovernanceProposal-_castVotesBySignatures`.
    */
   function voteBridgeOperatorsBySignatures(
-    uint256 _period,
-    uint256 _epoch,
-    address[] calldata _operators,
+    BridgeOperatorsBallot.BridgeOperatorSet calldata _ballot,
     Signature[] calldata _signatures
   ) external {
-    _castVotesBySignatures(_operators, _signatures, _period, _epoch, _getMinimumVoteWeight(), DOMAIN_SEPARATOR);
-    IsolatedVote storage _v = _vote[_period][_epoch];
+    _castVotesBySignatures(_ballot, _signatures, _getMinimumVoteWeight(), DOMAIN_SEPARATOR);
+    IsolatedVote storage _v = _vote[_ballot.period][_ballot.epoch];
     if (_v.status == VoteStatus.Approved) {
-      _lastSyncedPeriod = _period;
-      _lastSyncedEpoch = _epoch;
-      emit BridgeOperatorsApproved(_period, _epoch, _operators);
+      _lastSyncedBridgeOperatorSetInfo = _ballot;
+      emit BridgeOperatorsApproved(_ballot.period, _ballot.epoch, _ballot.operators);
       _v.status = VoteStatus.Executed;
     }
   }

--- a/test/governance-admin/GovernanceAdmin.test.ts
+++ b/test/governance-admin/GovernanceAdmin.test.ts
@@ -27,7 +27,7 @@ import { SignatureStruct } from '../../src/types/RoninGovernanceAdmin';
 import { randomAddress, ZERO_BYTES32 } from '../../src/utils';
 import { createManyTrustedOrganizationAddressSets, TrustedOrganizationAddressSet } from '../helpers/address-set-types';
 import { initTest } from '../helpers/fixture';
-import { getLastBlockTimestamp } from '../helpers/utils';
+import { getLastBlockTimestamp, compareAddrs } from '../helpers/utils';
 
 let deployer: SignerWithAddress;
 let relayer: SignerWithAddress;
@@ -63,7 +63,7 @@ describe('Governance Admin test', () => {
     bridgeContract = MockBridge__factory.connect(proxy.address, deployer);
 
     const { roninGovernanceAdminAddress, mainchainGovernanceAdminAddress, stakingContractAddress } = await initTest(
-      'RoninGovernanceAdmin.test'
+      'RoninGovernanceAdminTest'
     )({
       bridgeContract: bridgeContract.address,
       roninTrustedOrganizationArguments: {
@@ -100,141 +100,194 @@ describe('Governance Admin test', () => {
   });
 
   describe('General case of governance admin', async () => {
-    it('Should be able to propose to change staking config', async () => {
-      const newMinValidatorStakingAmount = 555;
-      const latestTimestamp = await getLastBlockTimestamp();
-      proposal = await governanceAdminInterface.createProposal(
-        latestTimestamp + proposalExpiryDuration,
-        stakingContract.address,
-        0,
-        governanceAdminInterface.interface.encodeFunctionData('functionDelegateCall', [
-          stakingContract.interface.encodeFunctionData('setMinValidatorStakingAmount', [newMinValidatorStakingAmount]),
-        ]),
-        500_000
-      );
-      signatures = await governanceAdminInterface.generateSignatures(proposal);
-      supports = signatures.map(() => VoteType.For);
+    describe('Proposals', () => {
+      it('Should be able to propose to change staking config', async () => {
+        const newMinValidatorStakingAmount = 555;
+        const latestTimestamp = await getLastBlockTimestamp();
+        proposal = await governanceAdminInterface.createProposal(
+          latestTimestamp + proposalExpiryDuration,
+          stakingContract.address,
+          0,
+          governanceAdminInterface.interface.encodeFunctionData('functionDelegateCall', [
+            stakingContract.interface.encodeFunctionData('setMinValidatorStakingAmount', [
+              newMinValidatorStakingAmount,
+            ]),
+          ]),
+          500_000
+        );
+        signatures = await governanceAdminInterface.generateSignatures(proposal);
+        supports = signatures.map(() => VoteType.For);
 
-      expect(await governanceAdmin.proposalVoted(proposal.chainId, proposal.nonce, trustedOrgs[0].governor.address)).to
-        .false;
-      await governanceAdmin
-        .connect(trustedOrgs[0].governor)
-        .proposeProposalStructAndCastVotes(proposal, supports, signatures);
-      expect(await governanceAdmin.proposalVoted(proposal.chainId, proposal.nonce, trustedOrgs[0].governor.address)).to
-        .true;
-      expect(await stakingContract.minValidatorStakingAmount()).eq(newMinValidatorStakingAmount);
-    });
-
-    it('Should not be able to reuse already voted signatures or proposals', async () => {
-      await expect(
-        governanceAdmin
+        expect(await governanceAdmin.proposalVoted(proposal.chainId, proposal.nonce, trustedOrgs[0].governor.address))
+          .to.false;
+        await governanceAdmin
           .connect(trustedOrgs[0].governor)
-          .proposeProposalStructAndCastVotes(proposal, supports, signatures)
-      ).revertedWith('CoreGovernance: invalid proposal nonce');
+          .proposeProposalStructAndCastVotes(proposal, supports, signatures);
+        expect(await governanceAdmin.proposalVoted(proposal.chainId, proposal.nonce, trustedOrgs[0].governor.address))
+          .to.true;
+        expect(await stakingContract.minValidatorStakingAmount()).eq(newMinValidatorStakingAmount);
+      });
+
+      it('Should not be able to reuse already voted signatures or proposals', async () => {
+        await expect(
+          governanceAdmin
+            .connect(trustedOrgs[0].governor)
+            .proposeProposalStructAndCastVotes(proposal, supports, signatures)
+        ).revertedWith('CoreGovernance: invalid proposal nonce');
+      });
+
+      it('Should be able to relay to mainchain governance admin contract', async () => {
+        expect(await mainchainGovernanceAdmin.proposalRelayed(proposal.chainId, proposal.nonce)).to.false;
+        await mainchainGovernanceAdmin.connect(relayer).relayProposal(proposal, supports, signatures);
+        expect(await mainchainGovernanceAdmin.proposalRelayed(proposal.chainId, proposal.nonce)).to.true;
+      });
+
+      it('Should not be able to relay again', async () => {
+        await expect(
+          mainchainGovernanceAdmin.connect(relayer).relayProposal(proposal, supports, signatures)
+        ).revertedWith('CoreGovernance: invalid proposal nonce');
+      });
     });
 
-    it('Should be able to relay to mainchain governance admin contract', async () => {
-      expect(await mainchainGovernanceAdmin.proposalRelayed(proposal.chainId, proposal.nonce)).to.false;
-      await mainchainGovernanceAdmin.connect(relayer).relayProposal(proposal, supports, signatures);
-      expect(await mainchainGovernanceAdmin.proposalRelayed(proposal.chainId, proposal.nonce)).to.true;
-    });
+    describe('Bridge Operator Set Voting', () => {
+      before(async () => {
+        const latestBOset = await governanceAdmin.lastSyncedBridgeOperatorSetInfo();
+        expect(latestBOset.period).eq(0);
+        expect(latestBOset.epoch).eq(0);
+        expect(latestBOset.operators).eql([]);
+      });
 
-    it('Should not be able to relay again', async () => {
-      await expect(
-        mainchainGovernanceAdmin.connect(relayer).relayProposal(proposal, supports, signatures)
-      ).revertedWith('CoreGovernance: invalid proposal nonce');
-    });
+      it('Should be able to vote bridge operators', async () => {
+        ballot = {
+          period: 10,
+          epoch: 10_000,
+          operators: trustedOrgs
+            .slice(0, 2)
+            .map((v) => v.bridgeVoter.address)
+            .sort(compareAddrs),
+        };
+        signatures = await Promise.all(
+          trustedOrgs.map((g) =>
+            g.bridgeVoter
+              ._signTypedData(governanceAdminInterface.domain, BridgeOperatorsBallotTypes, ballot)
+              .then(mapByteSigToSigStruct)
+          )
+        );
+        expect(
+          await governanceAdmin.bridgeOperatorsVoted(ballot.period, ballot.epoch, trustedOrgs[0].bridgeVoter.address)
+        ).to.false;
+        await governanceAdmin.voteBridgeOperatorsBySignatures(ballot, signatures);
+        expect(
+          await governanceAdmin.bridgeOperatorsVoted(ballot.period, ballot.epoch, trustedOrgs[0].bridgeVoter.address)
+        ).to.true;
 
-    it('Should be able to vote bridge operators', async () => {
-      ballot = {
-        period: 10,
-        epoch: 10_000,
-        operators: trustedOrgs.map((v) => v.bridgeVoter.address),
-      };
-      signatures = await Promise.all(
-        trustedOrgs.map((g) =>
-          g.bridgeVoter
-            ._signTypedData(governanceAdminInterface.domain, BridgeOperatorsBallotTypes, ballot)
-            .then(mapByteSigToSigStruct)
-        )
-      );
-      expect(
-        await governanceAdmin.bridgeOperatorsVoted(ballot.period, ballot.epoch, trustedOrgs[0].bridgeVoter.address)
-      ).to.false;
-      await governanceAdmin.voteBridgeOperatorsBySignatures(ballot.period, ballot.epoch, ballot.operators, signatures);
-      expect(
-        await governanceAdmin.bridgeOperatorsVoted(ballot.period, ballot.epoch, trustedOrgs[0].bridgeVoter.address)
-      ).to.true;
-    });
+        const latestBOset = await governanceAdmin.lastSyncedBridgeOperatorSetInfo();
+        expect(latestBOset.period).eq(ballot.period);
+        expect(latestBOset.epoch).eq(ballot.epoch);
+        expect(latestBOset.operators).eql(ballot.operators);
+      });
 
-    it('Should be able relay vote bridge operators', async () => {
-      expect(await mainchainGovernanceAdmin.bridgeOperatorsRelayed(ballot.period, ballot.epoch)).to.false;
-      await mainchainGovernanceAdmin
-        .connect(relayer)
-        .relayBridgeOperators(ballot.period, ballot.epoch, ballot.operators, signatures);
-      expect(await mainchainGovernanceAdmin.bridgeOperatorsRelayed(ballot.period, ballot.epoch)).to.true;
-      expect(await bridgeContract.getBridgeOperators()).eql(trustedOrgs.map((v) => v.bridgeVoter.address));
-    });
+      it('Should be able relay vote bridge operators', async () => {
+        expect(await mainchainGovernanceAdmin.bridgeOperatorsRelayed(ballot.period, ballot.epoch)).to.false;
+        await mainchainGovernanceAdmin.connect(relayer).relayBridgeOperators(ballot, signatures);
+        expect(await mainchainGovernanceAdmin.bridgeOperatorsRelayed(ballot.period, ballot.epoch)).to.true;
+        const bridgeOperators = await bridgeContract.getBridgeOperators();
+        expect([...bridgeOperators].sort(compareAddrs)).eql(ballot.operators);
+        const latestBOset = await mainchainGovernanceAdmin.lastSyncedBridgeOperatorSetInfo();
+        expect(latestBOset.period).eq(ballot.period);
+        expect(latestBOset.epoch).eq(ballot.epoch);
+        expect(latestBOset.operators).eql(ballot.operators);
+      });
 
-    it('Should not able to relay again', async () => {
-      await expect(
-        mainchainGovernanceAdmin
-          .connect(relayer)
-          .relayBridgeOperators(ballot.period, ballot.epoch, ballot.operators, signatures)
-      ).revertedWith('BOsGovernanceRelay: query for outdated bridge operator set');
-    });
+      it('Should not able to relay again', async () => {
+        await expect(mainchainGovernanceAdmin.connect(relayer).relayBridgeOperators(ballot, signatures)).revertedWith(
+          'BOsGovernanceRelay: query for outdated bridge operator set'
+        );
+      });
 
-    it('Should not be able to use the signatures for another period', async () => {
-      ballot = {
-        period: 100,
-        epoch: 10_000,
-        operators: trustedOrgs.map((v) => v.bridgeVoter.address),
-      };
-      await expect(
-        governanceAdmin.voteBridgeOperatorsBySignatures(ballot.period, ballot.epoch, ballot.operators, signatures)
-      ).revertedWith('BOsGovernanceProposal: invalid order');
-    });
+      it('Should not be able to use the signatures for another period', async () => {
+        const ballot = {
+          period: 100,
+          epoch: 10_000,
+          operators: trustedOrgs.slice(0, 1).map((v) => v.bridgeVoter.address),
+        };
+        await expect(governanceAdmin.voteBridgeOperatorsBySignatures(ballot, signatures)).revertedWith(
+          'BOsGovernanceProposal: invalid order'
+        );
+      });
 
-    it('Should not be able to vote bridge operators with a smaller period', async () => {
-      ballot = {
-        period: 100,
-        epoch: 100,
-        operators: trustedOrgs.map((v) => v.bridgeVoter.address),
-      };
-      signatures = await Promise.all(
-        trustedOrgs.map((g) =>
-          g.bridgeVoter
-            ._signTypedData(governanceAdminInterface.domain, BridgeOperatorsBallotTypes, ballot)
-            .then(mapByteSigToSigStruct)
-        )
-      );
-      await expect(
-        governanceAdmin.voteBridgeOperatorsBySignatures(ballot.period, ballot.epoch, ballot.operators, signatures)
-      ).revertedWith('BOsGovernanceProposal: query for outdated bridge operator set');
-    });
+      it('Should not be able to vote for the same operator set again', async () => {
+        ballot = {
+          ...ballot,
+          epoch: BigNumber.from(ballot.epoch).add(1),
+        };
+        await expect(governanceAdmin.voteBridgeOperatorsBySignatures(ballot, signatures)).revertedWith(
+          'BOsGovernanceProposal: bridge operator set is already voted'
+        );
+      });
 
-    it('Should be able to vote bridge operators with a larger epoch', async () => {
-      const duplicatedNumber = 11;
-      ballot = {
-        period: 100,
-        epoch: 10_001,
-        operators: trustedOrgs.map((v, i) => (i < duplicatedNumber ? v.bridgeVoter.address : randomAddress())),
-      };
-      signatures = await Promise.all(
-        trustedOrgs.map((g) =>
-          g.bridgeVoter
-            ._signTypedData(governanceAdminInterface.domain, BridgeOperatorsBallotTypes, ballot)
-            .then(mapByteSigToSigStruct)
-        )
-      );
-      await governanceAdmin.voteBridgeOperatorsBySignatures(ballot.period, ballot.epoch, ballot.operators, signatures);
-    });
+      it('Should not be able to vote bridge operators with a smaller period', async () => {
+        ballot = {
+          period: 100,
+          epoch: 100,
+          operators: trustedOrgs.map((v) => v.bridgeVoter.address),
+        };
+        signatures = await Promise.all(
+          trustedOrgs.map((g) =>
+            g.bridgeVoter
+              ._signTypedData(governanceAdminInterface.domain, BridgeOperatorsBallotTypes, ballot)
+              .then(mapByteSigToSigStruct)
+          )
+        );
+        await expect(governanceAdmin.voteBridgeOperatorsBySignatures(ballot, signatures)).revertedWith(
+          'BOsGovernanceProposal: query for outdated bridge operator set'
+        );
+      });
 
-    it('Should be able relay vote bridge operators', async () => {
-      await mainchainGovernanceAdmin
-        .connect(relayer)
-        .relayBridgeOperators(ballot.period, ballot.epoch, ballot.operators, signatures);
-      expect(await bridgeContract.getBridgeOperators()).have.same.members(ballot.operators);
+      it('Should not be able to vote invalid order of bridge operators', async () => {
+        const duplicatedNumber = 11;
+        ballot = {
+          period: 100,
+          epoch: 10_001,
+          operators: [
+            ...trustedOrgs.map((v, i) => (i < duplicatedNumber ? v.bridgeVoter.address : randomAddress())),
+            ethers.constants.AddressZero,
+          ],
+        };
+        await expect(governanceAdmin.voteBridgeOperatorsBySignatures(ballot, signatures)).revertedWith(
+          'BOsGovernanceProposal: invalid order of bridge operators'
+        );
+      });
+
+      it('Should be able to vote bridge operators', async () => {
+        ballot.operators.pop();
+        ballot = {
+          ...ballot,
+          operators: [ethers.constants.AddressZero, ...ballot.operators.sort(compareAddrs)],
+        };
+        signatures = await Promise.all(
+          trustedOrgs.map((g) =>
+            g.bridgeVoter
+              ._signTypedData(governanceAdminInterface.domain, BridgeOperatorsBallotTypes, ballot)
+              .then(mapByteSigToSigStruct)
+          )
+        );
+        await governanceAdmin.voteBridgeOperatorsBySignatures(ballot, signatures);
+        const latestBOset = await governanceAdmin.lastSyncedBridgeOperatorSetInfo();
+        expect(latestBOset.period).eq(ballot.period);
+        expect(latestBOset.epoch).eq(ballot.epoch);
+        expect(latestBOset.operators).eql(ballot.operators);
+      });
+
+      it('Should be able relay vote bridge operators', async () => {
+        await mainchainGovernanceAdmin.connect(relayer).relayBridgeOperators(ballot, signatures);
+        const bridgeOperators = await bridgeContract.getBridgeOperators();
+        expect([...bridgeOperators].sort(compareAddrs)).eql(ballot.operators);
+        const latestBOset = await mainchainGovernanceAdmin.lastSyncedBridgeOperatorSetInfo();
+        expect(latestBOset.period).eq(ballot.period);
+        expect(latestBOset.epoch).eq(ballot.epoch);
+        expect(latestBOset.operators).eql(ballot.operators);
+      });
     });
   });
 

--- a/test/helpers/utils.ts
+++ b/test/helpers/utils.ts
@@ -41,3 +41,6 @@ export const getLastBlockTimestamp = async (): Promise<number> => {
   let blockBefore = await ethers.provider.getBlock(blockNumBefore);
   return blockBefore.timestamp;
 };
+
+export const compareAddrs = (firstStr: string, secondStr: string) =>
+  firstStr.toLowerCase().localeCompare(secondStr.toLowerCase());


### PR DESCRIPTION
### Description
-  Expose function for period and epoch that the bridge operator set is synced

### ABI Changes
- `contracts/mainchain/MainchainGovernanceAdmin.sol`: `relayBridgeOperators`
- `contracts/ronin/RoninGovernanceAdmin.sol`: `voteBridgeOperatorsBySignatures`

### New ABI
- `lastSyncedBridgeOperatorSetInfo`

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
