### PR TITLE
[ValidatorSet] Add details for `StakingRewardDistributed` event

### DIFF
--- a/contracts/interfaces/validator/ICoinbaseExecution.sol
+++ b/contracts/interfaces/validator/ICoinbaseExecution.sol
@@ -54,9 +54,14 @@ interface ICoinbaseExecution is ISlashingExecution {
   );
 
   /// @dev Emitted when the amount of RON reward is distributed to staking contract.
-  event StakingRewardDistributed(uint256 amount);
+  event StakingRewardDistributed(uint256 totalAmount, address[] consensusAddrs, uint256[] amounts);
   /// @dev Emitted when the contracts fails when distributing the amount of RON to the staking contract.
-  event StakingRewardDistributionFailed(uint256 amount, uint256 contractBalance);
+  event StakingRewardDistributionFailed(
+    uint256 totalAmount,
+    address[] consensusAddrs,
+    uint256[] amounts,
+    uint256 contractBalance
+  );
 
   /// @dev Emitted when the epoch is wrapped up.
   event WrappedUpEpoch(uint256 indexed periodNumber, uint256 indexed epochNumber, bool periodEnding);

--- a/contracts/ronin/validator/CoinbaseExecution.sol
+++ b/contracts/ronin/validator/CoinbaseExecution.sol
@@ -314,11 +314,16 @@ abstract contract CoinbaseExecution is
     if (_totalDelegatingReward > 0) {
       if (_unsafeSendRON(payable(address(_staking)), _totalDelegatingReward)) {
         _staking.recordRewards(_currentValidators, _delegatingRewards, _period);
-        emit StakingRewardDistributed(_totalDelegatingReward);
+        emit StakingRewardDistributed(_totalDelegatingReward, _currentValidators, _delegatingRewards);
         return;
       }
 
-      emit StakingRewardDistributionFailed(_totalDelegatingReward, address(this).balance);
+      emit StakingRewardDistributionFailed(
+        _totalDelegatingReward,
+        _currentValidators,
+        _delegatingRewards,
+        address(this).balance
+      );
     }
   }
 

--- a/test/helpers/ronin-validator-set.ts
+++ b/test/helpers/ronin-validator-set.ts
@@ -123,13 +123,24 @@ export const expects = {
     );
   },
 
-  emitStakingRewardDistributedEvent: async function (tx: ContractTransaction, expectingAmount: BigNumberish) {
+  emitStakingRewardDistributedEvent: async function (
+    tx: ContractTransaction,
+    expectingTotalAmount: BigNumberish,
+    expectingValidators: string[] | undefined,
+    expectingAmounts: BigNumberish[] | undefined
+  ) {
     await expectEvent(
       contractInterface,
       'StakingRewardDistributed',
       tx,
       (event) => {
-        expect(event.args[0], 'invalid distributing reward').eq(expectingAmount);
+        expect(event.args[0], 'invalid total distributing reward').eq(expectingTotalAmount);
+        if (expectingValidators) {
+          expect(event.args[1], 'invalid validator list').eql(expectingValidators);
+        }
+        if (expectingAmounts) {
+          expect(event.args[2], 'invalid amount list').eql(expectingAmounts);
+        }
       },
       1
     );

--- a/test/validator/RoninValidatorSet.test.ts
+++ b/test/validator/RoninValidatorSet.test.ts
@@ -428,7 +428,12 @@ describe('Ronin Validator Set test', () => {
         await expect(tx!).emit(roninValidatorSet, 'WrappedUpEpoch').withArgs(lastPeriod, epoch, true);
         lastPeriod = await roninValidatorSet.currentPeriod();
         await RoninValidatorSet.expects.emitValidatorSetUpdatedEvent(tx!, lastPeriod, currentValidatorSet);
-        await RoninValidatorSet.expects.emitStakingRewardDistributedEvent(tx!, 5148); // (5000 + 100 + 100) * 99%
+        await RoninValidatorSet.expects.emitStakingRewardDistributedEvent(
+          tx!,
+          5148,
+          currentValidatorSet,
+          [5148, 0, 0, 0].map((_) => BigNumber.from(_))
+        ); // (5000 + 100 + 100) * 99%
         await RoninValidatorSet.expects.emitMiningRewardDistributedEvent(
           tx!,
           consensusAddr.address,
@@ -521,7 +526,9 @@ describe('Ronin Validator Set test', () => {
         await RoninValidatorSet.expects.emitValidatorSetUpdatedEvent(tx!, lastPeriod, currentValidatorSet);
         await RoninValidatorSet.expects.emitStakingRewardDistributedEvent(
           tx!,
-          blockProducerBonusPerBlock.add(100).div(100).mul(99)
+          blockProducerBonusPerBlock.add(100).div(100).mul(99),
+          currentValidatorSet,
+          [blockProducerBonusPerBlock.add(100).div(100).mul(99), 0, 0, 0].map((_) => BigNumber.from(_))
         );
 
         const balanceDiff = (await treasury.getBalance()).sub(balance);


### PR DESCRIPTION
### Description

Emits list of validators and their corresponding amount of reward in `StakingRewardDistributed`.

### ABI changes

| Old | New |
| --- | --- |
|  event StakingRewardDistributed(uint256 amount) | event StakingRewardDistributed(uint256 totalAmount, address[] consensusAddrs, uint256[] amounts) |
| event StakingRewardDistributionFailed(uint256 amount) | event StakingRewardDistributionFailed(uint256 totalAmount, address[] consensusAddrs, uint256[] amounts, uint256 contractBalance)|

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
