### PR TITLE
[Staking] Rename for clarity between pools and active pools

### DIFF
--- a/contracts/interfaces/staking/IBaseStaking.sol
+++ b/contracts/interfaces/staking/IBaseStaking.sol
@@ -34,6 +34,23 @@ interface IBaseStaking {
   function getPoolAddressOf(address _poolAdminAddr) external view returns (address);
 
   /**
+   * @dev Returns the staking pool detail.
+   */
+  function getPoolDetail(address)
+    external
+    view
+    returns (
+      address _admin,
+      uint256 _stakingAmount,
+      uint256 _stakingTotal
+    );
+
+  /**
+   * @dev Returns the self-staking amounts of the pools.
+   */
+  function getManySelfStakings(address[] calldata) external view returns (uint256[] memory);
+
+  /**
    * @dev Returns The cooldown time in seconds to undelegate from the last timestamp (s)he delegated.
    */
   function cooldownSecsToUndelegate() external view returns (uint256);

--- a/contracts/interfaces/staking/IBaseStaking.sol
+++ b/contracts/interfaces/staking/IBaseStaking.sol
@@ -23,21 +23,25 @@ interface IBaseStaking {
   /// @dev Emitted when the number of seconds that a candidate must wait to be revoked.
   event WaitingSecsToRevokeUpdated(uint256 secs);
 
+  /// @dev Error of cannot transfer RON.
+  error ErrCannotTransferRON();
   /// @dev Error of receiving zero message value.
   error ErrZeroMessageValue();
   /// @dev Error of pool admin is not allowed to call.
   error ErrPoolAdminForbidden();
   /// @dev Error of no one is allowed to call but the pool's admin.
   error ErrOnlyPoolAdminAllowed();
+  /// @dev Error of admin of any active pool cannot delegate.
+  error ErrAdminOfAnyActivePoolForbidden(address admin);
   /// @dev Error of querying inactive pool.
   error ErrInactivePool(address poolAddr);
-  /// @dev Error of arrays' length are not of the same.
+  /// @dev Error of length of input arrays are not of the same.
   error ErrInvalidArrays();
 
   /**
    * @dev Returns whether the `_poolAdminAddr` is currently active.
    */
-  function isActivePoolAdmin(address _poolAdminAddr) external view returns (bool);
+  function isAdminOfActivePool(address _poolAdminAddr) external view returns (bool);
 
   /**
    * @dev Returns the consensus address corresponding to the pool admin.

--- a/contracts/interfaces/staking/IBaseStaking.sol
+++ b/contracts/interfaces/staking/IBaseStaking.sol
@@ -26,7 +26,7 @@ interface IBaseStaking {
   /// @dev Error of cannot transfer RON.
   error ErrCannotTransferRON();
   /// @dev Error of receiving zero message value.
-  error ErrZeroMessageValue();
+  error ErrZeroValue();
   /// @dev Error of pool admin is not allowed to call.
   error ErrPoolAdminForbidden();
   /// @dev Error of no one is allowed to call but the pool's admin.

--- a/contracts/interfaces/staking/IBaseStaking.sol
+++ b/contracts/interfaces/staking/IBaseStaking.sol
@@ -23,6 +23,17 @@ interface IBaseStaking {
   /// @dev Emitted when the number of seconds that a candidate must wait to be revoked.
   event WaitingSecsToRevokeUpdated(uint256 secs);
 
+  /// @dev Error of receiving zero message value.
+  error ErrZeroMessageValue();
+  /// @dev Error of pool admin is not allowed to call.
+  error ErrPoolAdminForbidden();
+  /// @dev Error of no one is allowed to call but the pool's admin.
+  error ErrOnlyPoolAdminAllowed();
+  /// @dev Error of querying inactive pool.
+  error ErrInactivePool(address poolAddr);
+  /// @dev Error of arrays' length are not of the same.
+  error ErrInvalidArrays();
+
   /**
    * @dev Returns whether the `_poolAdminAddr` is currently active.
    */

--- a/contracts/interfaces/staking/ICandidateStaking.sol
+++ b/contracts/interfaces/staking/ICandidateStaking.sol
@@ -37,7 +37,7 @@ interface ICandidateStaking is IRewardPool {
   /// @dev Error of three interaction addresses must be of the same in applying for validator candidate.
   error ErrThreeInteractionAddrsNotEqual();
   /// @dev Error of three operation addresses must be distinct in applying for validator candidate.
-  error ErrThreeOperationAddrNotDistinct();
+  error ErrThreeOperationAddrsNotDistinct();
   /// @dev Error of unstaking zero amount.
   error ErrUnstakeZeroAmount();
   /// @dev Error of invalid staking amount left after deducted.

--- a/contracts/interfaces/staking/ICandidateStaking.sol
+++ b/contracts/interfaces/staking/ICandidateStaking.sol
@@ -32,6 +32,21 @@ interface ICandidateStaking is IRewardPool {
     uint256 contractBalance
   );
 
+  /// @dev Error of cannot transfer RON to specified target.
+  error ErrCannotInitTransferRON(address addr, string extraInfo);
+  /// @dev Error of three interaction addresses must be of the same in applying for validator candidate.
+  error ErrThreeInteractionAddrsNotEqual();
+  /// @dev Error of three operation addresses must be distinct in applying for validator candidate.
+  error ErrThreeOperationAddrNotDistinct();
+  /// @dev Error of unstaking zero amount.
+  error ErrUnstakeZeroAmount();
+  /// @dev Error of invalid staking amount left after deducted.
+  error ErrStakingAmountLeft();
+  /// @dev Error of insufficient staking amount for unstaking.
+  error ErrInsufficientStakingAmount();
+  /// @dev Error of unstaking too early.
+  error ErrUnstakeTooEarly();
+
   /**
    * @dev Returns the minimum threshold for being a validator candidate.
    */

--- a/contracts/interfaces/staking/IDelegatorStaking.sol
+++ b/contracts/interfaces/staking/IDelegatorStaking.sol
@@ -10,14 +10,10 @@ interface IDelegatorStaking is IRewardPool {
   /// @dev Emitted when the delegator unstaked from a validator candidate.
   event Undelegated(address indexed delegator, address indexed consensuAddr, uint256 amount);
 
-  /// @dev Error of admin of any active pool cannot delegate.
-  error ErrAdminOfAnyActivePoolForbidden(address admin);
-  /// @dev Error of cannot transfer RON.
-  error ErrCannotTransferRON();
   /// @dev Error of undelegating zero amount.
   error ErrUndelegateZeroAmount();
   /// @dev Error of undelegating insufficient amount.
-  error ErrInsufficientUndelegateAmount();
+  error ErrInsufficientDelegatingAmount();
   /// @dev Error of undelegating too early.
   error ErrUndelegateTooEarly();
 

--- a/contracts/interfaces/staking/IDelegatorStaking.sol
+++ b/contracts/interfaces/staking/IDelegatorStaking.sol
@@ -10,6 +10,17 @@ interface IDelegatorStaking is IRewardPool {
   /// @dev Emitted when the delegator unstaked from a validator candidate.
   event Undelegated(address indexed delegator, address indexed consensuAddr, uint256 amount);
 
+  /// @dev Error of admin of any active pool cannot delegate.
+  error ErrAdminOfAnyActivePoolForbidden(address admin);
+  /// @dev Error of cannot transfer RON.
+  error ErrCannotTransferRON();
+  /// @dev Error of undelegating zero amount.
+  error ErrUndelegateZeroAmount();
+  /// @dev Error of undelegating insufficient amount.
+  error ErrInsufficientUndelegateAmount();
+  /// @dev Error of undelegating too early.
+  error ErrUndelegateTooEarly();
+
   /**
    * @dev Stakes for a validator candidate `_consensusAddr`.
    *

--- a/contracts/interfaces/staking/IRewardPool.sol
+++ b/contracts/interfaces/staking/IRewardPool.sol
@@ -37,6 +37,9 @@ interface IRewardPool is PeriodWrapperConsumer {
   /// @dev Emitted when the contract fails when updating the pools that already set
   event PoolsUpdateConflicted(uint256 indexed period, address[] poolAddrs);
 
+  /// @dev Error of invalid pool share.
+  error ErrInvalidPoolShare();
+
   /**
    * @dev Returns the reward amount that user claimable.
    */

--- a/contracts/interfaces/staking/IStaking.sol
+++ b/contracts/interfaces/staking/IStaking.sol
@@ -38,21 +38,4 @@ interface IStaking is IRewardPool, IBaseStaking, ICandidateStaking, IDelegatorSt
   function deductStakingAmount(address _consensusAddr, uint256 _amount)
     external
     returns (uint256 _actualDeductingAmount);
-
-  /**
-   * @dev Returns the staking pool detail.
-   */
-  function getStakingPool(address)
-    external
-    view
-    returns (
-      address _admin,
-      uint256 _stakingAmount,
-      uint256 _stakingTotal
-    );
-
-  /**
-   * @dev Returns the self-staking amounts of the pools.
-   */
-  function getManySelfStakings(address[] calldata) external view returns (uint256[] memory);
 }

--- a/contracts/interfaces/staking/IStaking.sol
+++ b/contracts/interfaces/staking/IStaking.sol
@@ -11,7 +11,7 @@ interface IStaking is IRewardPool, IBaseStaking, ICandidateStaking, IDelegatorSt
    * @dev Records the amount of rewards `_rewards` for the pools `_consensusAddrs`.
    *
    * Requirements:
-   * - The method caller is validator contract.
+   * - The method caller must be validator contract.
    *
    * Emits the event `PoolsUpdated` once the contract recorded the rewards successfully.
    * Emits the event `PoolsUpdateFailed` once the input array lengths are not equal.
@@ -20,7 +20,7 @@ interface IStaking is IRewardPool, IBaseStaking, ICandidateStaking, IDelegatorSt
    * Note: This method should be called once at the period ending.
    *
    */
-  function recordRewards(
+  function execRecordRewards(
     address[] calldata _consensusAddrs,
     uint256[] calldata _rewards,
     uint256 _period
@@ -30,12 +30,12 @@ interface IStaking is IRewardPool, IBaseStaking, ICandidateStaking, IDelegatorSt
    * @dev Deducts from staking amount of the validator `_consensusAddr` for `_amount`.
    *
    * Requirements:
-   * - The method caller is validator contract.
+   * - The method caller must be validator contract.
    *
    * Emits the event `Unstaked`.
    *
    */
-  function deductStakingAmount(address _consensusAddr, uint256 _amount)
+  function execDeductStakingAmount(address _consensusAddr, uint256 _amount)
     external
     returns (uint256 _actualDeductingAmount);
 }

--- a/contracts/mocks/MockStaking.sol
+++ b/contracts/mocks/MockStaking.sol
@@ -30,7 +30,7 @@ contract MockStaking is RewardCalculation {
     uint256[] memory _rewards = new uint256[](1);
     _addrs[0] = poolAddr;
     _rewards[0] = pendingReward;
-    this.recordRewards(_addrs, _rewards);
+    this.execRecordRewards(_addrs, _rewards);
 
     pendingReward = 0;
     lastUpdatedPeriod++;
@@ -64,7 +64,7 @@ contract MockStaking is RewardCalculation {
     pendingReward -= _amount;
   }
 
-  function recordRewards(address[] calldata _addrList, uint256[] calldata _rewards) external {
+  function execRecordRewards(address[] calldata _addrList, uint256[] calldata _rewards) external {
     _recordRewards(_addrList, _rewards, _currentPeriod());
   }
 

--- a/contracts/ronin/staking/BaseStaking.sol
+++ b/contracts/ronin/staking/BaseStaking.sol
@@ -25,7 +25,7 @@ abstract contract BaseStaking is
   uint256 internal _waitingSecsToRevoke;
 
   /// @dev Mapping from admin address of an active pool => consensus address.
-  mapping(address => address) internal _activePoolAdminMapping;
+  mapping(address => address) internal _adminOfActivePoolMapping;
   /**
    * @dev This empty reserved space is put in place to allow future versions to add new
    * variables without shifting down storage in the inheritance chain.
@@ -55,15 +55,15 @@ abstract contract BaseStaking is
   /**
    * @inheritdoc IBaseStaking
    */
-  function isActivePoolAdmin(address _poolAdminAddr) public view override returns (bool) {
-    return _activePoolAdminMapping[_poolAdminAddr] != address(0);
+  function isAdminOfActivePool(address _poolAdminAddr) public view override returns (bool) {
+    return _adminOfActivePoolMapping[_poolAdminAddr] != address(0);
   }
 
   /**
    * @inheritdoc IBaseStaking
    */
   function getPoolAddressOf(address _poolAdminAddr) external view override returns (address) {
-    return _activePoolAdminMapping[_poolAdminAddr];
+    return _adminOfActivePoolMapping[_poolAdminAddr];
   }
 
   /**

--- a/contracts/ronin/staking/BaseStaking.sol
+++ b/contracts/ronin/staking/BaseStaking.sol
@@ -33,7 +33,7 @@ abstract contract BaseStaking is
   uint256[49] private ______gap;
 
   modifier noEmptyValue() {
-    if (msg.value == 0) revert ErrZeroMessageValue();
+    if (msg.value == 0) revert ErrZeroValue();
     _;
   }
 

--- a/contracts/ronin/staking/BaseStaking.sol
+++ b/contracts/ronin/staking/BaseStaking.sol
@@ -33,22 +33,22 @@ abstract contract BaseStaking is
   uint256[49] private ______gap;
 
   modifier noEmptyValue() {
-    require(msg.value > 0, "BaseStaking: query with empty value");
+    if (msg.value == 0) revert ErrZeroMessageValue();
     _;
   }
 
   modifier notPoolAdmin(PoolDetail storage _pool, address _delegator) {
-    require(_pool.admin != _delegator, "BaseStaking: delegator must not be the pool admin");
+    if (_pool.admin == _delegator) revert ErrPoolAdminForbidden();
     _;
   }
 
   modifier onlyPoolAdmin(PoolDetail storage _pool, address _requester) {
-    require(_pool.admin == _requester, "BaseStaking: requester must be the pool admin");
+    if (_pool.admin != _requester) revert ErrOnlyPoolAdminAllowed();
     _;
   }
 
   modifier poolIsActive(address _poolAddr) {
-    require(_validatorContract.isValidatorCandidate(_poolAddr), "BaseStaking: query for inactive pool");
+    if (!_validatorContract.isValidatorCandidate(_poolAddr)) revert ErrInactivePool(_poolAddr);
     _;
   }
 
@@ -130,7 +130,7 @@ abstract contract BaseStaking is
     override
     returns (uint256[] memory _stakingAmounts)
   {
-    require(_poolAddrs.length == _userList.length, "BaseStaking: invalid input array");
+    if (_poolAddrs.length != _userList.length) revert ErrInvalidArrays();
     _stakingAmounts = new uint256[](_poolAddrs.length);
     for (uint _i = 0; _i < _stakingAmounts.length; _i++) {
       _stakingAmounts[_i] = _stakingPool[_poolAddrs[_i]].delegatingAmount[_userList[_i]];

--- a/contracts/ronin/staking/BaseStaking.sol
+++ b/contracts/ronin/staking/BaseStaking.sol
@@ -47,8 +47,8 @@ abstract contract BaseStaking is
     _;
   }
 
-  modifier poolExists(address _poolAddr) {
-    require(_validatorContract.isValidatorCandidate(_poolAddr), "BaseStaking: query for non-existent pool");
+  modifier poolIsActive(address _poolAddr) {
+    require(_validatorContract.isValidatorCandidate(_poolAddr), "BaseStaking: query for inactive pool");
     _;
   }
 

--- a/contracts/ronin/staking/BaseStaking.sol
+++ b/contracts/ronin/staking/BaseStaking.sol
@@ -24,7 +24,7 @@ abstract contract BaseStaking is
   /// @dev The number of seconds that a candidate must wait to be revoked and take the self-staking amount back.
   uint256 internal _waitingSecsToRevoke;
 
-  /// @dev Mapping from active pool admin address => consensus address.
+  /// @dev Mapping from admin address of an active pool => consensus address.
   mapping(address => address) internal _activePoolAdminMapping;
   /**
    * @dev This empty reserved space is put in place to allow future versions to add new
@@ -64,6 +64,32 @@ abstract contract BaseStaking is
    */
   function getPoolAddressOf(address _poolAdminAddr) external view override returns (address) {
     return _activePoolAdminMapping[_poolAdminAddr];
+  }
+
+  /**
+   * @inheritdoc IBaseStaking
+   */
+  function getPoolDetail(address _poolAddr)
+    external
+    view
+    returns (
+      address _admin,
+      uint256 _stakingAmount,
+      uint256 _stakingTotal
+    )
+  {
+    PoolDetail storage _pool = _stakingPool[_poolAddr];
+    return (_pool.admin, _pool.stakingAmount, _pool.stakingTotal);
+  }
+
+  /**
+   * @inheritdoc IBaseStaking
+   */
+  function getManySelfStakings(address[] calldata _pools) external view returns (uint256[] memory _selfStakings) {
+    _selfStakings = new uint256[](_pools.length);
+    for (uint _i = 0; _i < _pools.length; _i++) {
+      _selfStakings[_i] = _stakingPool[_pools[_i]].stakingAmount;
+    }
   }
 
   /**

--- a/contracts/ronin/staking/CandidateStaking.sol
+++ b/contracts/ronin/staking/CandidateStaking.sol
@@ -124,7 +124,7 @@ abstract contract CandidateStaking is BaseStaking, ICandidateStaking {
     if (_remainAmount < _minValidatorStakingAmount) revert ErrStakingAmountLeft();
 
     _unstake(_pool, _requester, _amount);
-    if (_unsafeSendRON(payable(_requester), _amount, 3500)) revert ErrCannotTransferRON();
+    if (!_unsafeSendRON(payable(_requester), _amount, 3500)) revert ErrCannotTransferRON();
   }
 
   /**
@@ -173,7 +173,7 @@ abstract contract CandidateStaking is BaseStaking, ICandidateStaking {
     _diffAddrs[0] = _poolAdmin;
     _diffAddrs[1] = _consensusAddr;
     _diffAddrs[2] = _bridgeOperatorAddr;
-    if (AddressArrayUtils.hasDuplicate(_diffAddrs)) revert ErrThreeOperationAddrNotDistinct();
+    if (AddressArrayUtils.hasDuplicate(_diffAddrs)) revert ErrThreeOperationAddrsNotDistinct();
 
     _validatorContract.grantValidatorCandidate(
       _candidateAdmin,

--- a/contracts/ronin/staking/CandidateStaking.sol
+++ b/contracts/ronin/staking/CandidateStaking.sol
@@ -70,7 +70,7 @@ abstract contract CandidateStaking is BaseStaking, ICandidateStaking {
     address _consensusAddr,
     uint256 _effectiveDaysOnwards,
     uint256 _commissionRate
-  ) external override poolExists(_consensusAddr) onlyPoolAdmin(_stakingPool[_consensusAddr], msg.sender) {
+  ) external override poolIsActive(_consensusAddr) onlyPoolAdmin(_stakingPool[_consensusAddr], msg.sender) {
     _validatorContract.execRequestUpdateCommissionRate(_consensusAddr, _effectiveDaysOnwards, _commissionRate);
   }
 
@@ -104,14 +104,19 @@ abstract contract CandidateStaking is BaseStaking, ICandidateStaking {
   /**
    * @inheritdoc ICandidateStaking
    */
-  function stake(address _consensusAddr) external payable override noEmptyValue poolExists(_consensusAddr) {
+  function stake(address _consensusAddr) external payable override noEmptyValue poolIsActive(_consensusAddr) {
     _stake(_stakingPool[_consensusAddr], msg.sender, msg.value);
   }
 
   /**
    * @inheritdoc ICandidateStaking
    */
-  function unstake(address _consensusAddr, uint256 _amount) external override nonReentrant poolExists(_consensusAddr) {
+  function unstake(address _consensusAddr, uint256 _amount)
+    external
+    override
+    nonReentrant
+    poolIsActive(_consensusAddr)
+  {
     require(_amount > 0, "CandidateStaking: invalid amount");
     address _delegator = msg.sender;
     PoolDetail storage _pool = _stakingPool[_consensusAddr];
@@ -128,7 +133,7 @@ abstract contract CandidateStaking is BaseStaking, ICandidateStaking {
   function requestRenounce(address _consensusAddr)
     external
     override
-    poolExists(_consensusAddr)
+    poolIsActive(_consensusAddr)
     onlyPoolAdmin(_stakingPool[_consensusAddr], msg.sender)
   {
     _validatorContract.requestRevokeCandidate(_consensusAddr, _waitingSecsToRevoke);
@@ -140,7 +145,7 @@ abstract contract CandidateStaking is BaseStaking, ICandidateStaking {
   function requestEmergencyExit(address _consensusAddr)
     external
     override
-    poolExists(_consensusAddr)
+    poolIsActive(_consensusAddr)
     onlyPoolAdmin(_stakingPool[_consensusAddr], msg.sender)
   {
     _validatorContract.execEmergencyExit(_consensusAddr, _waitingSecsToRevoke);

--- a/contracts/ronin/staking/CandidateStaking.sol
+++ b/contracts/ronin/staking/CandidateStaking.sol
@@ -40,7 +40,7 @@ abstract contract CandidateStaking is BaseStaking, ICandidateStaking {
     address _bridgeOperatorAddr,
     uint256 _commissionRate
   ) external payable override nonReentrant {
-    require(!isActivePoolAdmin(msg.sender), "CandidateStaking: pool admin is active");
+    require(!isActivePoolAdmin(msg.sender), "CandidateStaking: pool is active");
 
     uint256 _amount = msg.value;
     address payable _poolAdmin = payable(msg.sender);

--- a/contracts/ronin/staking/DelegatorStaking.sol
+++ b/contracts/ronin/staking/DelegatorStaking.sol
@@ -148,8 +148,8 @@ abstract contract DelegatorStaking is BaseStaking, IDelegatorStaking {
     uint256 _amount
   ) private notPoolAdmin(_pool, _delegator) {
     if (_amount == 0) revert ErrUndelegateZeroAmount();
-    if (_pool.delegatingAmount[_delegator] >= _amount) revert ErrInsufficientDelegatingAmount();
-    if (_pool.lastDelegatingTimestamp[_delegator] + _cooldownSecsToUndelegate < block.timestamp) {
+    if (_pool.delegatingAmount[_delegator] < _amount) revert ErrInsufficientDelegatingAmount();
+    if (_pool.lastDelegatingTimestamp[_delegator] + _cooldownSecsToUndelegate >= block.timestamp) {
       revert ErrUndelegateTooEarly();
     }
 

--- a/contracts/ronin/staking/DelegatorStaking.sol
+++ b/contracts/ronin/staking/DelegatorStaking.sol
@@ -16,7 +16,7 @@ abstract contract DelegatorStaking is BaseStaking, IDelegatorStaking {
    * @inheritdoc IDelegatorStaking
    */
   function delegate(address _consensusAddr) external payable noEmptyValue poolIsActive(_consensusAddr) {
-    if (isActivePoolAdmin(msg.sender)) revert ErrAdminOfAnyActivePoolForbidden(msg.sender);
+    if (isAdminOfActivePool(msg.sender)) revert ErrAdminOfAnyActivePoolForbidden(msg.sender);
     _delegate(_stakingPool[_consensusAddr], msg.sender, msg.value);
   }
 
@@ -148,7 +148,7 @@ abstract contract DelegatorStaking is BaseStaking, IDelegatorStaking {
     uint256 _amount
   ) private notPoolAdmin(_pool, _delegator) {
     if (_amount == 0) revert ErrUndelegateZeroAmount();
-    if (_pool.delegatingAmount[_delegator] >= _amount) revert ErrInsufficientUndelegateAmount();
+    if (_pool.delegatingAmount[_delegator] >= _amount) revert ErrInsufficientDelegatingAmount();
     if (_pool.lastDelegatingTimestamp[_delegator] + _cooldownSecsToUndelegate < block.timestamp) {
       revert ErrUndelegateTooEarly();
     }

--- a/contracts/ronin/staking/DelegatorStaking.sol
+++ b/contracts/ronin/staking/DelegatorStaking.sol
@@ -15,7 +15,7 @@ abstract contract DelegatorStaking is BaseStaking, IDelegatorStaking {
   /**
    * @inheritdoc IDelegatorStaking
    */
-  function delegate(address _consensusAddr) external payable noEmptyValue poolExists(_consensusAddr) {
+  function delegate(address _consensusAddr) external payable noEmptyValue poolIsActive(_consensusAddr) {
     require(!isActivePoolAdmin(msg.sender), "DelegatorStaking: admin of an active pool cannot delegate");
     _delegate(_stakingPool[_consensusAddr], msg.sender, msg.value);
   }
@@ -56,7 +56,7 @@ abstract contract DelegatorStaking is BaseStaking, IDelegatorStaking {
     address _consensusAddrSrc,
     address _consensusAddrDst,
     uint256 _amount
-  ) external nonReentrant poolExists(_consensusAddrDst) {
+  ) external nonReentrant poolIsActive(_consensusAddrDst) {
     address _delegator = msg.sender;
     _undelegate(_stakingPool[_consensusAddrSrc], _delegator, _amount);
     _delegate(_stakingPool[_consensusAddrDst], _delegator, _amount);
@@ -82,7 +82,7 @@ abstract contract DelegatorStaking is BaseStaking, IDelegatorStaking {
     external
     override
     nonReentrant
-    poolExists(_consensusAddrDst)
+    poolIsActive(_consensusAddrDst)
     returns (uint256 _amount)
   {
     return _delegateRewards(msg.sender, _consensusAddrList, _consensusAddrDst);

--- a/contracts/ronin/staking/DelegatorStaking.sol
+++ b/contracts/ronin/staking/DelegatorStaking.sol
@@ -16,7 +16,7 @@ abstract contract DelegatorStaking is BaseStaking, IDelegatorStaking {
    * @inheritdoc IDelegatorStaking
    */
   function delegate(address _consensusAddr) external payable noEmptyValue poolIsActive(_consensusAddr) {
-    require(!isActivePoolAdmin(msg.sender), "DelegatorStaking: admin of an active pool cannot delegate");
+    if (isActivePoolAdmin(msg.sender)) revert ErrAdminOfAnyActivePoolForbidden(msg.sender);
     _delegate(_stakingPool[_consensusAddr], msg.sender, msg.value);
   }
 
@@ -26,17 +26,14 @@ abstract contract DelegatorStaking is BaseStaking, IDelegatorStaking {
   function undelegate(address _consensusAddr, uint256 _amount) external nonReentrant {
     address payable _delegator = payable(msg.sender);
     _undelegate(_stakingPool[_consensusAddr], _delegator, _amount);
-    require(_sendRON(_delegator, _amount), "DelegatorStaking: could not transfer RON");
+    if (!_sendRON(_delegator, _amount)) revert ErrCannotTransferRON();
   }
 
   /**
    * @inheritdoc IDelegatorStaking
    */
   function bulkUndelegate(address[] calldata _consensusAddrs, uint256[] calldata _amounts) external nonReentrant {
-    require(
-      _consensusAddrs.length > 0 && _consensusAddrs.length == _amounts.length,
-      "DelegatorStaking: invalid array length"
-    );
+    if (_consensusAddrs.length == 0 || _consensusAddrs.length != _amounts.length) revert ErrInvalidArrays();
 
     address payable _delegator = payable(msg.sender);
     uint256 _total;
@@ -46,7 +43,7 @@ abstract contract DelegatorStaking is BaseStaking, IDelegatorStaking {
       _undelegate(_stakingPool[_consensusAddrs[_i]], _delegator, _amounts[_i]);
     }
 
-    require(_sendRON(_delegator, _total), "DelegatorStaking: could not transfer RON");
+    if (!_sendRON(_delegator, _total)) revert ErrCannotTransferRON();
   }
 
   /**
@@ -150,12 +147,12 @@ abstract contract DelegatorStaking is BaseStaking, IDelegatorStaking {
     address _delegator,
     uint256 _amount
   ) private notPoolAdmin(_pool, _delegator) {
-    require(_amount > 0, "DelegatorStaking: invalid amount");
-    require(_pool.delegatingAmount[_delegator] >= _amount, "DelegatorStaking: insufficient amount to undelegate");
-    require(
-      _pool.lastDelegatingTimestamp[_delegator] + _cooldownSecsToUndelegate < block.timestamp,
-      "DelegatorStaking: undelegate too early"
-    );
+    if (_amount == 0) revert ErrUndelegateZeroAmount();
+    if (_pool.delegatingAmount[_delegator] >= _amount) revert ErrInsufficientUndelegateAmount();
+    if (_pool.lastDelegatingTimestamp[_delegator] + _cooldownSecsToUndelegate < block.timestamp) {
+      revert ErrUndelegateTooEarly();
+    }
+
     _changeDelegatingAmount(
       _pool,
       _delegator,

--- a/contracts/ronin/staking/RewardCalculation.sol
+++ b/contracts/ronin/staking/RewardCalculation.sol
@@ -132,7 +132,7 @@ abstract contract RewardCalculation is IRewardPool {
     uint256 _diffAmount = _reward.minAmount - _minAmount;
     if (_diffAmount > 0) {
       _reward.minAmount = _minAmount;
-      require(_pool.shares.inner >= _diffAmount, "RewardCalculation: invalid pool shares");
+      if (_pool.shares.inner < _diffAmount) revert ErrInvalidPoolShare();
       _pool.shares.inner -= _diffAmount;
     }
   }

--- a/contracts/ronin/staking/Staking.sol
+++ b/contracts/ronin/staking/Staking.sol
@@ -38,7 +38,6 @@ contract Staking is IStaking, CandidateStaking, DelegatorStaking, Initializable 
   function getStakingPool(address _poolAddr)
     external
     view
-    poolExists(_poolAddr)
     returns (
       address _admin,
       uint256 _stakingAmount,

--- a/contracts/ronin/staking/Staking.sol
+++ b/contracts/ronin/staking/Staking.sol
@@ -35,7 +35,7 @@ contract Staking is IStaking, CandidateStaking, DelegatorStaking, Initializable 
   /**
    * @inheritdoc IStaking
    */
-  function recordRewards(
+  function execRecordRewards(
     address[] calldata _consensusAddrs,
     uint256[] calldata _rewards,
     uint256 _period
@@ -46,7 +46,7 @@ contract Staking is IStaking, CandidateStaking, DelegatorStaking, Initializable 
   /**
    * @inheritdoc IStaking
    */
-  function deductStakingAmount(address _consensusAddr, uint256 _amount)
+  function execDeductStakingAmount(address _consensusAddr, uint256 _amount)
     external
     onlyValidatorContract
     returns (uint256 _actualDeductingAmount)

--- a/contracts/ronin/staking/Staking.sol
+++ b/contracts/ronin/staking/Staking.sol
@@ -35,32 +35,6 @@ contract Staking is IStaking, CandidateStaking, DelegatorStaking, Initializable 
   /**
    * @inheritdoc IStaking
    */
-  function getStakingPool(address _poolAddr)
-    external
-    view
-    returns (
-      address _admin,
-      uint256 _stakingAmount,
-      uint256 _stakingTotal
-    )
-  {
-    PoolDetail storage _pool = _stakingPool[_poolAddr];
-    return (_pool.admin, _pool.stakingAmount, _pool.stakingTotal);
-  }
-
-  /**
-   * @inheritdoc IStaking
-   */
-  function getManySelfStakings(address[] calldata _pools) external view returns (uint256[] memory _selfStakings) {
-    _selfStakings = new uint256[](_pools.length);
-    for (uint _i = 0; _i < _pools.length; _i++) {
-      _selfStakings[_i] = _stakingPool[_pools[_i]].stakingAmount;
-    }
-  }
-
-  /**
-   * @inheritdoc IStaking
-   */
   function recordRewards(
     address[] calldata _consensusAddrs,
     uint256[] calldata _rewards,

--- a/contracts/ronin/validator/CoinbaseExecution.sol
+++ b/contracts/ronin/validator/CoinbaseExecution.sol
@@ -313,7 +313,7 @@ abstract contract CoinbaseExecution is
     IStaking _staking = _stakingContract;
     if (_totalDelegatingReward > 0) {
       if (_unsafeSendRON(payable(address(_staking)), _totalDelegatingReward)) {
-        _staking.recordRewards(_currentValidators, _delegatingRewards, _period);
+        _staking.execRecordRewards(_currentValidators, _delegatingRewards, _period);
         emit StakingRewardDistributed(_totalDelegatingReward, _currentValidators, _delegatingRewards);
         return;
       }

--- a/contracts/ronin/validator/EmergencyExit.sol
+++ b/contracts/ronin/validator/EmergencyExit.sol
@@ -34,7 +34,7 @@ abstract contract EmergencyExit is IEmergencyExit, RONTransferHelper, CandidateM
     _setRevokingTimestamp(_candidateInfo[_consensusAddr], _revokingTimestamp);
     _emergencyExitJailedTimestamp[_consensusAddr] = _revokingTimestamp;
 
-    uint256 _deductedAmount = _stakingContract.deductStakingAmount(_consensusAddr, _emergencyExitLockedAmount);
+    uint256 _deductedAmount = _stakingContract.execDeductStakingAmount(_consensusAddr, _emergencyExitLockedAmount);
     if (_deductedAmount > 0) {
       uint256 _recyclingAt = block.timestamp + _emergencyExpiryDuration;
       _lockedConsensusList.push(_consensusAddr);

--- a/contracts/ronin/validator/SlashingExecution.sol
+++ b/contracts/ronin/validator/SlashingExecution.sol
@@ -34,7 +34,7 @@ abstract contract SlashingExecution is
     }
 
     if (_slashAmount > 0) {
-      uint256 _actualAmount = _stakingContract.deductStakingAmount(_validatorAddr, _slashAmount);
+      uint256 _actualAmount = _stakingContract.execDeductStakingAmount(_validatorAddr, _slashAmount);
       _totalDeprecatedReward += _actualAmount;
     }
 

--- a/test/integration/ActionSlashValidators.test.ts
+++ b/test/integration/ActionSlashValidators.test.ts
@@ -514,7 +514,9 @@ describe('[Integration] Slash validators', () => {
             const topUpTx = stakingContract.connect(slashee.poolAdmin).stake(slashee.consensusAddr.address, {
               value: slashAmountForUnavailabilityTier2Threshold,
             });
-            await expect(topUpTx).revertedWith('BaseStaking: query for non-existent pool');
+            await expect(topUpTx)
+              .revertedWithCustomError(stakingContract, 'ErrInactivePool')
+              .withArgs(slashee.consensusAddr.address);
           }
         });
 

--- a/test/staking/RewardCalculation.test.ts
+++ b/test/staking/RewardCalculation.test.ts
@@ -66,16 +66,16 @@ describe('Reward Calculation test', () => {
 
   describe('Period: x+1 -> x+2', () => {
     it('Should not be able to record reward with invalid arguments', async () => {
-      tx = await stakingContract.recordRewards([poolAddr], [100, 100]);
+      tx = await stakingContract.execRecordRewards([poolAddr], [100, 100]);
       await expect(tx).emit(stakingContract, 'PoolsUpdateFailed').withArgs(period, [poolAddr], [100, 100]);
     });
 
     it('Should not be able to record reward more than once for a pool', async () => {
       aRps = aRps.add(MASK.mul(1000 / 100));
-      tx = await stakingContract.recordRewards([poolAddr], [1000]);
+      tx = await stakingContract.execRecordRewards([poolAddr], [1000]);
       await expect(tx).emit(stakingContract, 'PoolsUpdated').withArgs(period, [poolAddr], [aRps], [100]);
 
-      tx = await stakingContract.recordRewards([poolAddr], [1000]);
+      tx = await stakingContract.execRecordRewards([poolAddr], [1000]);
       await expect(tx).emit(stakingContract, 'PoolsUpdateConflicted').withArgs(period, [poolAddr]);
       await expect(tx).not.emit(stakingContract, 'PoolsUpdated');
       await stakingContract.increasePeriod(); // period = 2
@@ -86,7 +86,7 @@ describe('Reward Calculation test', () => {
     it('Should not able to reward reward more than once for multiple pools', async () => {
       let addrList = Array.from(Array(10).keys()).map(randomAddress);
       let arr = addrList.map(() => 0);
-      tx = await stakingContract.recordRewards(
+      tx = await stakingContract.execRecordRewards(
         addrList,
         addrList.map(() => 1000)
       );
@@ -95,7 +95,7 @@ describe('Reward Calculation test', () => {
       const conflictNumber = 7;
       arr = arr.slice(conflictNumber);
       addrList = addrList.map((_, i) => (i >= conflictNumber ? randomAddress() : _));
-      tx = await stakingContract.recordRewards(
+      tx = await stakingContract.execRecordRewards(
         addrList,
         addrList.map(() => 1000)
       );

--- a/test/staking/Staking.test.ts
+++ b/test/staking/Staking.test.ts
@@ -138,7 +138,7 @@ describe('Staking test', () => {
     it('Should not be able to stake with empty value', async () => {
       await expect(stakingContract.stake(poolAddrSet.consensusAddr.address, { value: 0 })).revertedWithCustomError(
         stakingContract,
-        'ErrZeroMessageValue'
+        'ErrZeroValue'
       );
     });
 
@@ -347,7 +347,7 @@ describe('Staking test', () => {
     it('Should not be able to delegate with empty value', async () => {
       await expect(stakingContract.delegate(otherPoolAddrSet.consensusAddr.address)).revertedWithCustomError(
         stakingContract,
-        'ErrZeroMessageValue'
+        'ErrZeroValue'
       );
     });
 

--- a/test/staking/Staking.test.ts
+++ b/test/staking/Staking.test.ts
@@ -315,7 +315,7 @@ describe('Staking test', () => {
             1,
             /* 0.01% */ { value: minValidatorStakingAmount.mul(2) }
           )
-      ).revertedWith('CandidateStaking: pool admin is active');
+      ).revertedWith('CandidateStaking: pool is active');
 
       await stakingContract.connect(poolAddrSet.poolAdmin).requestRenounce(poolAddrSet.consensusAddr.address);
       await network.provider.send('evm_increaseTime', [waitingSecsToRevoke]);

--- a/test/staking/Staking.test.ts
+++ b/test/staking/Staking.test.ts
@@ -267,14 +267,14 @@ describe('Staking test', () => {
     it('Should the consensus account is no longer be a candidate, and the staked amount is transferred back to the pool admin', async () => {
       await network.provider.send('evm_increaseTime', [waitingSecsToRevoke]);
       const stakingAmount = minValidatorStakingAmount.mul(2);
-      expect(await stakingContract.getStakingPool(poolAddrSet.consensusAddr.address)).eql([
+      expect(await stakingContract.getPoolDetail(poolAddrSet.consensusAddr.address)).eql([
         poolAddrSet.poolAdmin.address,
         stakingAmount,
         stakingAmount.add(9),
       ]);
 
       await expect(() => validatorContract.wrapUpEpoch()).changeEtherBalance(poolAddrSet.poolAdmin, stakingAmount);
-      await expect(stakingContract.getStakingPool(poolAddrSet.consensusAddr.address)).revertedWith(
+      await expect(stakingContract.getPoolDetail(poolAddrSet.consensusAddr.address)).revertedWith(
         'BaseStaking: query for non-existent pool'
       );
     });
@@ -427,7 +427,7 @@ describe('Staking test', () => {
           2,
           /* 0.02% */ { value: minValidatorStakingAmount }
         );
-      expect(await stakingContract.getStakingPool(poolAddrSet.consensusAddr.address)).eql([
+      expect(await stakingContract.getPoolDetail(poolAddrSet.consensusAddr.address)).eql([
         poolAddrSet.poolAdmin.address,
         minValidatorStakingAmount,
         minValidatorStakingAmount.add(8),

--- a/test/validator/EmergencyExit.test.ts
+++ b/test/validator/EmergencyExit.test.ts
@@ -166,9 +166,9 @@ describe('Emergency Exit test', () => {
   });
 
   it('Should not be able to request emergency exit using unauthorized accounts', async () => {
-    await expect(stakingContract.requestEmergencyExit(compromisedValidator.consensusAddr.address)).revertedWith(
-      'BaseStaking: requester must be the pool admin'
-    );
+    await expect(
+      stakingContract.requestEmergencyExit(compromisedValidator.consensusAddr.address)
+    ).revertedWithCustomError(stakingContract, 'ErrOnlyPoolAdminAllowed');
   });
 
   it('Should be able to request emergency exit', async () => {

--- a/test/validator/RoninValidatorSet.test.ts
+++ b/test/validator/RoninValidatorSet.test.ts
@@ -212,7 +212,9 @@ describe('Ronin Validator Set test', () => {
           }
         );
 
-      await expect(tx).revertedWith('CandidateStaking: pool is active');
+      await expect(tx)
+        .revertedWithCustomError(stakingContract, 'ErrAdminOfAnyActivePoolForbidden')
+        .withArgs(validatorCandidates[3].poolAdmin.address);
     });
 
     it('Should not be able to apply for candidate role with existed candidate admin address', async () => {
@@ -229,7 +231,7 @@ describe('Ronin Validator Set test', () => {
           }
         );
 
-      await expect(tx).revertedWith('CandidateStaking: three interaction addresses must be of the same');
+      await expect(tx).revertedWithCustomError(stakingContract, 'ErrThreeInteractionAddrsNotEqual');
     });
 
     it('Should not be able to apply for candidate role with existed treasury address', async () => {
@@ -246,7 +248,7 @@ describe('Ronin Validator Set test', () => {
           }
         );
 
-      await expect(tx).revertedWith('CandidateStaking: three interaction addresses must be of the same');
+      await expect(tx).revertedWithCustomError(stakingContract, 'ErrThreeInteractionAddrsNotEqual');
     });
 
     it('Should not be able to apply for candidate role with existed bridge operator address', async () => {

--- a/test/validator/RoninValidatorSet.test.ts
+++ b/test/validator/RoninValidatorSet.test.ts
@@ -212,7 +212,7 @@ describe('Ronin Validator Set test', () => {
           }
         );
 
-      await expect(tx).revertedWith('CandidateStaking: pool admin is active');
+      await expect(tx).revertedWith('CandidateStaking: pool is active');
     });
 
     it('Should not be able to apply for candidate role with existed candidate admin address', async () => {


### PR DESCRIPTION
### Description
- Rename internal methods and modifier for clarity. 
    - Active pool: pool of a working candidate,
    - Existing pool: pool of any candidate, including exited ones. 
- Rename `getStakingPool` to `getPoolDetail`, and remove pre-check.
- Add `exec-` prefix for cross-contract methods.
- Change error messages to custom errors.

### ABI changes
| Old | New |
| ---- | ---- |
|  `function getStakingPool(address _poolAddr)` | `function getPoolDetail(address _poolAddr)` |
| `function isActivePoolAdmin(address _poolAdminAddr) public view returns (bool)` | `function isAdminOfActivePool(address _poolAdminAddr) public view returns (bool)` |

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
