### PR TITLE
[ValidatorSet] Add prefix for custom errors

### DIFF
--- a/contracts/interfaces/validator/info-fragments/ICommonInfo.sol
+++ b/contracts/interfaces/validator/info-fragments/ICommonInfo.sol
@@ -19,7 +19,7 @@ interface ICommonInfo is ITimingInfo, IJailingInfo, IValidatorInfo {
   event DeprecatedRewardRecycleFailed(address indexed recipientAddr, uint256 amount, uint256 balance);
 
   // Error thrown when receives RON from neither staking vesting contract nor staking contract"
-  error UnauthorizedReceiveRON();
+  error ErrUnauthorizedReceiveRON();
 
   /**
    * @dev Returns the total deprecated reward, which includes reward that is not sent for slashed validators and unsastified bridge operators

--- a/contracts/interfaces/validator/info-fragments/IValidatorInfo.sol
+++ b/contracts/interfaces/validator/info-fragments/IValidatorInfo.sol
@@ -9,7 +9,7 @@ interface IValidatorInfo {
   event MaxPrioritizedValidatorNumberUpdated(uint256);
 
   /// @dev Error of number of prioritized greater than number of max validators.
-  error InvalidMaxPrioitizedValidatorNumber();
+  error ErrInvalidMaxPrioritizedValidatorNumber();
 
   /**
    * @dev Returns the maximum number of validators in the epoch.

--- a/contracts/ronin/validator/RoninValidatorSet.sol
+++ b/contracts/ronin/validator/RoninValidatorSet.sol
@@ -59,7 +59,7 @@ contract RoninValidatorSet is Initializable, CoinbaseExecution, SlashingExecutio
    * deducting amount on slashing).
    */
   function _fallback() internal view {
-    if (msg.sender != stakingVestingContract() && msg.sender != stakingContract()) revert UnauthorizedReceiveRON();
+    if (msg.sender != stakingVestingContract() && msg.sender != stakingContract()) revert ErrUnauthorizedReceiveRON();
   }
 
   /**

--- a/contracts/ronin/validator/storage-fragments/ValidatorInfoStorage.sol
+++ b/contracts/ronin/validator/storage-fragments/ValidatorInfoStorage.sol
@@ -171,7 +171,7 @@ abstract contract ValidatorInfoStorage is IValidatorInfo, HasRoninTrustedOrganiz
    * @dev See `IValidatorInfo-setMaxPrioritizedValidatorNumber`
    */
   function _setMaxPrioritizedValidatorNumber(uint256 _number) internal {
-    if (_number > _maxValidatorNumber) revert InvalidMaxPrioitizedValidatorNumber();
+    if (_number > _maxValidatorNumber) revert ErrInvalidMaxPrioritizedValidatorNumber();
     _maxPrioritizedValidatorNumber = _number;
     emit MaxPrioritizedValidatorNumberUpdated(_number);
   }


### PR DESCRIPTION
### Description
Add `Err-` prefix to custom errors for consistency.

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
