### PR TITLE
[ValidatorSet | Staking] Prevent trusted orgs from renouncing

### DIFF
--- a/contracts/interfaces/validator/ICandidateManager.sol
+++ b/contracts/interfaces/validator/ICandidateManager.sol
@@ -69,10 +69,12 @@ interface ICandidateManager {
   error ErrInvalidEffectiveDaysOnwards();
   /// @dev Error of invalid min effective days onwards.
   error ErrInvalidMinEffectiveDaysOnwards();
-  /// @dev Error of already requested revoking candidate before
+  /// @dev Error of already requested revoking candidate before.
   error ErrAlreadyRequestedRevokingCandidate();
-  /// @dev Error of commission change schedule exists
+  /// @dev Error of commission change schedule exists.
   error ErrAlreadyRequestedUpdatingCommissionRate();
+  /// @dev Error of trusted org cannot renounce.
+  error ErrTrustedOrgCannotRenounce();
 
   /**
    * @dev Returns the maximum number of validator candidate.
@@ -115,7 +117,7 @@ interface ICandidateManager {
    * Emits the event `CandidateGranted`.
    *
    */
-  function grantValidatorCandidate(
+  function execApplyValidatorCandidate(
     address _admin,
     address _consensusAddr,
     address payable _treasuryAddr,
@@ -132,7 +134,7 @@ interface ICandidateManager {
    * Emits the event `CandidateRevokingTimestampUpdated`.
    *
    */
-  function requestRevokeCandidate(address, uint256 _secsLeft) external;
+  function execRequestRenounceCandidate(address, uint256 _secsLeft) external;
 
   /**
    * @dev Fallback function of `CandidateStaking-requestUpdateCommissionRate`.

--- a/contracts/interfaces/validator/info-fragments/IValidatorInfo.sol
+++ b/contracts/interfaces/validator/info-fragments/IValidatorInfo.sol
@@ -57,7 +57,7 @@ interface IValidatorInfo {
   function isBridgeOperator(address _addr) external view returns (bool);
 
   /**
-   * @dev Returns whether the consensus address is operatoring the bridge or not.
+   * @dev Returns whether the consensus address is operating the bridge or not.
    */
   function isOperatingBridge(address _consensusAddr) external view returns (bool);
 

--- a/contracts/mocks/validator/MockValidatorSet.sol
+++ b/contracts/mocks/validator/MockValidatorSet.sol
@@ -165,4 +165,6 @@ contract MockValidatorSet is IRoninValidatorSet, CandidateManager {
   function isOperatingBridge(address) external view returns (bool) {}
 
   function _emergencyExitLockedFundReleased(address _consensusAddr) internal virtual override returns (bool) {}
+
+  function _isTrustedOrg(address _consensusAddr) internal virtual override returns (bool) {}
 }

--- a/contracts/ronin/staking/CandidateStaking.sol
+++ b/contracts/ronin/staking/CandidateStaking.sol
@@ -136,7 +136,7 @@ abstract contract CandidateStaking is BaseStaking, ICandidateStaking {
     poolIsActive(_consensusAddr)
     onlyPoolAdmin(_stakingPool[_consensusAddr], msg.sender)
   {
-    _validatorContract.requestRevokeCandidate(_consensusAddr, _waitingSecsToRevoke);
+    _validatorContract.execRequestRenounceCandidate(_consensusAddr, _waitingSecsToRevoke);
   }
 
   /**
@@ -175,7 +175,7 @@ abstract contract CandidateStaking is BaseStaking, ICandidateStaking {
     _diffAddrs[2] = _bridgeOperatorAddr;
     if (AddressArrayUtils.hasDuplicate(_diffAddrs)) revert ErrThreeOperationAddrsNotDistinct();
 
-    _validatorContract.grantValidatorCandidate(
+    _validatorContract.execApplyValidatorCandidate(
       _candidateAdmin,
       _consensusAddr,
       _treasuryAddr,

--- a/contracts/ronin/validator/CandidateManager.sol
+++ b/contracts/ronin/validator/CandidateManager.sol
@@ -63,7 +63,7 @@ abstract contract CandidateManager is ICandidateManager, PercentageConsumer, Has
   /**
    * @inheritdoc ICandidateManager
    */
-  function grantValidatorCandidate(
+  function execApplyValidatorCandidate(
     address _candidateAdmin,
     address _consensusAddr,
     address payable _treasuryAddr,
@@ -97,7 +97,13 @@ abstract contract CandidateManager is ICandidateManager, PercentageConsumer, Has
   /**
    * @inheritdoc ICandidateManager
    */
-  function requestRevokeCandidate(address _consensusAddr, uint256 _secsLeft) external override onlyStakingContract {
+  function execRequestRenounceCandidate(address _consensusAddr, uint256 _secsLeft)
+    external
+    override
+    onlyStakingContract
+  {
+    if (_isTrustedOrg(_consensusAddr)) revert ErrTrustedOrgCannotRenounce();
+
     ValidatorCandidate storage _info = _candidateInfo[_consensusAddr];
     if (_info.revokingTimestamp != 0) revert ErrAlreadyRequestedRevokingCandidate();
     _setRevokingTimestamp(_info, block.timestamp + _secsLeft);
@@ -309,4 +315,9 @@ abstract contract CandidateManager is ICandidateManager, PercentageConsumer, Has
    * @dev Returns a flag indicating whether the fund is unlocked.
    */
   function _emergencyExitLockedFundReleased(address _consensusAddr) internal virtual returns (bool);
+
+  /**
+   * @dev Returns whether the consensus address is a trusted org or not.
+   */
+  function _isTrustedOrg(address _consensusAddr) internal virtual returns (bool);
 }

--- a/contracts/ronin/validator/CoinbaseExecution.sol
+++ b/contracts/ronin/validator/CoinbaseExecution.sol
@@ -453,4 +453,11 @@ abstract contract CoinbaseExecution is
     emit BlockProducerSetUpdated(_newPeriod, _nextEpoch, getBlockProducers());
     emit BridgeOperatorSetUpdated(_newPeriod, _nextEpoch, getBridgeOperators());
   }
+
+  /**
+   * @dev Override `CandidateManager-isTrustedOrg`.
+   */
+  function _isTrustedOrg(address _consensusAddr) internal view override returns (bool) {
+    return _roninTrustedOrganizationContract.getConsensusWeight(_consensusAddr) > 0;
+  }
 }

--- a/test/helpers/address-set-types.ts
+++ b/test/helpers/address-set-types.ts
@@ -15,6 +15,8 @@ export type ValidatorCandidateAddressSet = {
   bridgeOperator: SignerWithAddress;
 };
 
+export type WhitelistedCandidateAddressSet = TrustedOrganizationAddressSet & ValidatorCandidateAddressSet;
+
 export function createTrustedOrganizationAddressSet(
   addrs: SignerWithAddress[]
 ): TrustedOrganizationAddressSet | undefined {
@@ -125,6 +127,26 @@ export function createManyValidatorCandidateAddressSets(
     treasuryAddr: treasuryAddrs![i],
     bridgeOperator: bridgeOperators![i],
   }));
+}
+
+export function mergeToWhitelistedCandidateAddressSet(
+  trustedOrg: TrustedOrganizationAddressSet,
+  candidate: ValidatorCandidateAddressSet
+): WhitelistedCandidateAddressSet {
+  candidate.consensusAddr = trustedOrg.consensusAddr;
+  return { ...trustedOrg, ...candidate };
+}
+
+export function mergeToManyWhitelistedCandidateAddressSets(
+  trustedOrgs: TrustedOrganizationAddressSet[],
+  candidates: ValidatorCandidateAddressSet[]
+): WhitelistedCandidateAddressSet[] {
+  expect(checkArraysHaveSameSize([trustedOrgs, candidates])).eq(
+    true,
+    'mergeToManyWhitelistedCandidateAddressSets: input arrays of signers must have same length'
+  );
+
+  return trustedOrgs.map((org, idx) => mergeToWhitelistedCandidateAddressSet(org, candidates[idx]));
 }
 
 const checkArraysHaveSameSize = (arrays: Array<any>[]) => {

--- a/test/validator/RoninValidatorSet-Candidate.test.ts
+++ b/test/validator/RoninValidatorSet-Candidate.test.ts
@@ -1,0 +1,319 @@
+import { expect } from 'chai';
+import { BigNumber, ContractTransaction } from 'ethers';
+import { ethers, network } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+
+import {
+  Staking,
+  MockRoninValidatorSetExtended,
+  MockRoninValidatorSetExtended__factory,
+  Staking__factory,
+  MockSlashIndicatorExtended__factory,
+  MockSlashIndicatorExtended,
+  RoninGovernanceAdmin__factory,
+  RoninGovernanceAdmin,
+  StakingVesting__factory,
+  StakingVesting,
+} from '../../src/types';
+import * as RoninValidatorSet from '../helpers/ronin-validator-set';
+import { mineBatchTxs } from '../helpers/utils';
+import { initTest } from '../helpers/fixture';
+import { GovernanceAdminInterface } from '../../src/script/governance-admin-interface';
+import { Address } from 'hardhat-deploy/dist/types';
+import {
+  createManyTrustedOrganizationAddressSets,
+  createManyValidatorCandidateAddressSets,
+  mergeToManyWhitelistedCandidateAddressSets,
+  TrustedOrganizationAddressSet,
+  ValidatorCandidateAddressSet,
+  WhitelistedCandidateAddressSet,
+} from '../helpers/address-set-types';
+import { anyValue } from '@nomicfoundation/hardhat-chai-matchers/withArgs';
+
+let roninValidatorSet: MockRoninValidatorSetExtended;
+let stakingVesting: StakingVesting;
+let stakingContract: Staking;
+let slashIndicator: MockSlashIndicatorExtended;
+let governanceAdmin: RoninGovernanceAdmin;
+let governanceAdminInterface: GovernanceAdminInterface;
+
+let poolAdmin: SignerWithAddress;
+let candidateAdmin: SignerWithAddress;
+let consensusAddr: SignerWithAddress;
+let treasury: SignerWithAddress;
+let bridgeOperator: SignerWithAddress;
+let deployer: SignerWithAddress;
+let signers: SignerWithAddress[];
+let trustedOrgs: TrustedOrganizationAddressSet[];
+let validatorCandidates: ValidatorCandidateAddressSet[];
+let whitelistedCandidates: WhitelistedCandidateAddressSet[];
+
+let currentValidatorSet: string[];
+let lastPeriod: BigNumber;
+let epoch: BigNumber;
+
+const localValidatorCandidatesLength = 6;
+const localTrustedOrgsLength = 1;
+
+const slashAmountForUnavailabilityTier2Threshold = 100;
+const maxValidatorNumber = 4;
+const maxPrioritizedValidatorNumber = 1;
+const maxValidatorCandidate = 100;
+const minValidatorStakingAmount = BigNumber.from(20000);
+const blockProducerBonusPerBlock = BigNumber.from(5000);
+const bridgeOperatorBonusPerBlock = BigNumber.from(37);
+const zeroTopUpAmount = 0;
+const topUpAmount = BigNumber.from(100_000_000_000);
+const slashDoubleSignAmount = BigNumber.from(2000);
+
+describe('Ronin Validator Set: candidate test', () => {
+  before(async () => {
+    [poolAdmin, consensusAddr, bridgeOperator, deployer, ...signers] = await ethers.getSigners();
+    candidateAdmin = poolAdmin;
+    treasury = poolAdmin;
+
+    trustedOrgs = createManyTrustedOrganizationAddressSets(signers.splice(0, localTrustedOrgsLength * 3));
+    validatorCandidates = createManyValidatorCandidateAddressSets(
+      signers.splice(0, localValidatorCandidatesLength * 3)
+    );
+    whitelistedCandidates = mergeToManyWhitelistedCandidateAddressSets([trustedOrgs[0]], [validatorCandidates[0]]);
+
+    await network.provider.send('hardhat_setCoinbase', [consensusAddr.address]);
+
+    const {
+      slashContractAddress,
+      validatorContractAddress,
+      stakingContractAddress,
+      roninGovernanceAdminAddress,
+      stakingVestingContractAddress,
+    } = await initTest('RoninValidatorSet')({
+      slashIndicatorArguments: {
+        doubleSignSlashing: {
+          slashDoubleSignAmount,
+        },
+        unavailabilitySlashing: {
+          slashAmountForUnavailabilityTier2Threshold,
+        },
+      },
+      stakingArguments: {
+        minValidatorStakingAmount,
+      },
+      stakingVestingArguments: {
+        blockProducerBonusPerBlock,
+        bridgeOperatorBonusPerBlock,
+        topupAmount: zeroTopUpAmount,
+      },
+      roninValidatorSetArguments: {
+        maxValidatorNumber,
+        maxPrioritizedValidatorNumber,
+        maxValidatorCandidate,
+      },
+      roninTrustedOrganizationArguments: {
+        trustedOrganizations: trustedOrgs.map((v) => ({
+          consensusAddr: v.consensusAddr.address,
+          governor: v.governor.address,
+          bridgeVoter: v.bridgeVoter.address,
+          weight: 100,
+          addedBlock: 0,
+        })),
+      },
+    });
+
+    roninValidatorSet = MockRoninValidatorSetExtended__factory.connect(validatorContractAddress, deployer);
+    stakingVesting = StakingVesting__factory.connect(stakingVestingContractAddress, deployer);
+    slashIndicator = MockSlashIndicatorExtended__factory.connect(slashContractAddress, deployer);
+    stakingContract = Staking__factory.connect(stakingContractAddress, deployer);
+    governanceAdmin = RoninGovernanceAdmin__factory.connect(roninGovernanceAdminAddress, deployer);
+    governanceAdminInterface = new GovernanceAdminInterface(
+      governanceAdmin,
+      network.config.chainId!,
+      undefined,
+      ...trustedOrgs.map((_) => _.governor)
+    );
+
+    const mockValidatorLogic = await new MockRoninValidatorSetExtended__factory(deployer).deploy();
+    await mockValidatorLogic.deployed();
+    await governanceAdminInterface.upgrade(roninValidatorSet.address, mockValidatorLogic.address);
+    await roninValidatorSet.initEpoch();
+
+    const mockSlashIndicator = await new MockSlashIndicatorExtended__factory(deployer).deploy();
+    await mockSlashIndicator.deployed();
+    await governanceAdminInterface.upgrade(slashIndicator.address, mockSlashIndicator.address);
+  });
+
+  after(async () => {
+    await network.provider.send('hardhat_setCoinbase', [ethers.constants.AddressZero]);
+  });
+
+  describe('Apply candidate', async () => {
+    let expectingValidatorsAddr: Address[];
+    it('Should normal user can apply for candidate and the set get synced', async () => {
+      for (let i = 1; i < 5; i++) {
+        await stakingContract
+          .connect(validatorCandidates[i].poolAdmin)
+          .applyValidatorCandidate(
+            validatorCandidates[i].candidateAdmin.address,
+            validatorCandidates[i].consensusAddr.address,
+            validatorCandidates[i].treasuryAddr.address,
+            validatorCandidates[i].bridgeOperator.address,
+            2_00,
+            {
+              value: minValidatorStakingAmount.add(i),
+            }
+          );
+      }
+
+      let tx: ContractTransaction;
+      await RoninValidatorSet.EpochController.setTimestampToPeriodEnding();
+      epoch = await roninValidatorSet.epochOf(await ethers.provider.getBlockNumber());
+      lastPeriod = await roninValidatorSet.currentPeriod();
+      await mineBatchTxs(async () => {
+        await roninValidatorSet.endEpoch();
+        tx = await roninValidatorSet.connect(consensusAddr).wrapUpEpoch();
+      });
+
+      expectingValidatorsAddr = validatorCandidates
+        .slice(1, 5)
+        .reverse()
+        .map((_) => _.consensusAddr.address);
+
+      await expect(tx!).emit(roninValidatorSet, 'WrappedUpEpoch').withArgs(lastPeriod, epoch, true);
+      lastPeriod = await roninValidatorSet.currentPeriod();
+      await RoninValidatorSet.expects.emitValidatorSetUpdatedEvent(tx!, lastPeriod, expectingValidatorsAddr);
+      expect(await roninValidatorSet.getValidators()).eql(expectingValidatorsAddr);
+      expect(await roninValidatorSet.getBlockProducers()).eql(expectingValidatorsAddr);
+    });
+
+    it('Should trusted org can apply for candidate and the set get synced', async () => {
+      for (let i = 0; i < 1; i++) {
+        await stakingContract
+          .connect(whitelistedCandidates[i].poolAdmin)
+          .applyValidatorCandidate(
+            whitelistedCandidates[i].candidateAdmin.address,
+            whitelistedCandidates[i].consensusAddr.address,
+            whitelistedCandidates[i].treasuryAddr.address,
+            whitelistedCandidates[i].bridgeOperator.address,
+            2_00,
+            {
+              value: minValidatorStakingAmount.add(i),
+            }
+          );
+      }
+
+      let tx: ContractTransaction;
+      await RoninValidatorSet.EpochController.setTimestampToPeriodEnding();
+      epoch = await roninValidatorSet.epochOf(await ethers.provider.getBlockNumber());
+      lastPeriod = await roninValidatorSet.currentPeriod();
+      await mineBatchTxs(async () => {
+        await roninValidatorSet.endEpoch();
+        tx = await roninValidatorSet.connect(consensusAddr).wrapUpEpoch();
+      });
+
+      expectingValidatorsAddr = validatorCandidates
+        .slice(2, 5)
+        .reverse()
+        .map((_) => _.consensusAddr.address);
+      expectingValidatorsAddr = [whitelistedCandidates[0].consensusAddr.address, ...expectingValidatorsAddr];
+
+      await expect(tx!).emit(roninValidatorSet, 'WrappedUpEpoch').withArgs(lastPeriod, epoch, true);
+      lastPeriod = await roninValidatorSet.currentPeriod();
+      await RoninValidatorSet.expects.emitValidatorSetUpdatedEvent(tx!, lastPeriod, expectingValidatorsAddr);
+      expect(await roninValidatorSet.getValidators()).eql(expectingValidatorsAddr);
+      expect(await roninValidatorSet.getBlockProducers()).eql(expectingValidatorsAddr);
+    });
+  });
+
+  describe('Grant validator candidate sanity check', async () => {
+    it('Should not be able to apply for candidate role with existed pool admin address', async () => {
+      let tx = stakingContract
+        .connect(validatorCandidates[4].poolAdmin)
+        .applyValidatorCandidate(
+          validatorCandidates[4].candidateAdmin.address,
+          validatorCandidates[4].consensusAddr.address,
+          validatorCandidates[4].treasuryAddr.address,
+          validatorCandidates[4].bridgeOperator.address,
+          2_00,
+          {
+            value: minValidatorStakingAmount,
+          }
+        );
+
+      await expect(tx)
+        .revertedWithCustomError(stakingContract, 'ErrAdminOfAnyActivePoolForbidden')
+        .withArgs(validatorCandidates[4].poolAdmin.address);
+    });
+
+    it('Should not be able to apply for candidate role with existed candidate admin address', async () => {
+      let tx = stakingContract
+        .connect(validatorCandidates[5].poolAdmin)
+        .applyValidatorCandidate(
+          validatorCandidates[0].candidateAdmin.address,
+          validatorCandidates[5].consensusAddr.address,
+          validatorCandidates[5].treasuryAddr.address,
+          validatorCandidates[5].bridgeOperator.address,
+          2_00,
+          {
+            value: minValidatorStakingAmount,
+          }
+        );
+
+      await expect(tx).revertedWithCustomError(stakingContract, 'ErrThreeInteractionAddrsNotEqual');
+    });
+
+    it('Should not be able to apply for candidate role with existed treasury address', async () => {
+      let tx = stakingContract
+        .connect(validatorCandidates[5].poolAdmin)
+        .applyValidatorCandidate(
+          validatorCandidates[5].candidateAdmin.address,
+          validatorCandidates[5].consensusAddr.address,
+          validatorCandidates[0].treasuryAddr.address,
+          validatorCandidates[5].bridgeOperator.address,
+          2_00,
+          {
+            value: minValidatorStakingAmount,
+          }
+        );
+
+      await expect(tx).revertedWithCustomError(stakingContract, 'ErrThreeInteractionAddrsNotEqual');
+    });
+
+    it('Should not be able to apply for candidate role with existed bridge operator address', async () => {
+      let tx = stakingContract
+        .connect(validatorCandidates[5].poolAdmin)
+        .applyValidatorCandidate(
+          validatorCandidates[5].candidateAdmin.address,
+          validatorCandidates[5].consensusAddr.address,
+          validatorCandidates[5].treasuryAddr.address,
+          validatorCandidates[0].bridgeOperator.address,
+          2_00,
+          {
+            value: minValidatorStakingAmount,
+          }
+        );
+
+      await expect(tx)
+        .revertedWithCustomError(roninValidatorSet, 'ErrExistentBridgeOperator')
+        .withArgs(validatorCandidates[0].bridgeOperator.address);
+    });
+  });
+
+  describe('Renounce candidate', async () => {
+    it('Should trusted org not be able to renounce candidate role', async () => {
+      await expect(
+        stakingContract
+          .connect(whitelistedCandidates[0].poolAdmin)
+          .requestRenounce(whitelistedCandidates[0].consensusAddr.address)
+      ).revertedWithCustomError(roninValidatorSet, 'ErrTrustedOrgCannotRenounce');
+    });
+
+    it('Should normal candidate be able to request renounce', async () => {
+      expect(
+        await stakingContract
+          .connect(validatorCandidates[1].poolAdmin)
+          .requestRenounce(validatorCandidates[1].consensusAddr.address)
+      )
+        .emit(roninValidatorSet, 'CandidateRevokingTimestampUpdated')
+        .withArgs(validatorCandidates[1].consensusAddr.address, anyValue);
+    });
+  });
+});

--- a/test/validator/RoninValidatorSet-CoinbaseExecution.test.ts
+++ b/test/validator/RoninValidatorSet-CoinbaseExecution.test.ts
@@ -63,7 +63,7 @@ const zeroTopUpAmount = 0;
 const topUpAmount = BigNumber.from(100_000_000_000);
 const slashDoubleSignAmount = BigNumber.from(2000);
 
-describe('Ronin Validator Set test', () => {
+describe('Ronin Validator Set: Coinbase execution test', () => {
   before(async () => {
     [poolAdmin, consensusAddr, bridgeOperator, deployer, ...signers] = await ethers.getSigners();
     candidateAdmin = poolAdmin;
@@ -195,80 +195,6 @@ describe('Ronin Validator Set test', () => {
       expect(await roninValidatorSet.getValidators()).eql([]);
       expect(await roninValidatorSet.getBlockProducers()).eql([]);
       await expect(tx!).not.emit(roninValidatorSet, 'ValidatorSetUpdated');
-    });
-  });
-
-  describe('Grant validator candidate sanity check', async () => {
-    it('Should not be able to apply for candidate role with existed pool admin address', async () => {
-      let tx = stakingContract
-        .connect(validatorCandidates[3].poolAdmin)
-        .applyValidatorCandidate(
-          validatorCandidates[3].candidateAdmin.address,
-          validatorCandidates[3].consensusAddr.address,
-          validatorCandidates[3].treasuryAddr.address,
-          validatorCandidates[3].bridgeOperator.address,
-          2_00,
-          {
-            value: minValidatorStakingAmount,
-          }
-        );
-
-      await expect(tx)
-        .revertedWithCustomError(stakingContract, 'ErrAdminOfAnyActivePoolForbidden')
-        .withArgs(validatorCandidates[3].poolAdmin.address);
-    });
-
-    it('Should not be able to apply for candidate role with existed candidate admin address', async () => {
-      let tx = stakingContract
-        .connect(validatorCandidates[4].poolAdmin)
-        .applyValidatorCandidate(
-          validatorCandidates[0].candidateAdmin.address,
-          validatorCandidates[4].consensusAddr.address,
-          validatorCandidates[4].treasuryAddr.address,
-          validatorCandidates[4].bridgeOperator.address,
-          2_00,
-          {
-            value: minValidatorStakingAmount,
-          }
-        );
-
-      await expect(tx).revertedWithCustomError(stakingContract, 'ErrThreeInteractionAddrsNotEqual');
-    });
-
-    it('Should not be able to apply for candidate role with existed treasury address', async () => {
-      let tx = stakingContract
-        .connect(validatorCandidates[4].poolAdmin)
-        .applyValidatorCandidate(
-          validatorCandidates[4].candidateAdmin.address,
-          validatorCandidates[4].consensusAddr.address,
-          validatorCandidates[0].treasuryAddr.address,
-          validatorCandidates[4].bridgeOperator.address,
-          2_00,
-          {
-            value: minValidatorStakingAmount,
-          }
-        );
-
-      await expect(tx).revertedWithCustomError(stakingContract, 'ErrThreeInteractionAddrsNotEqual');
-    });
-
-    it('Should not be able to apply for candidate role with existed bridge operator address', async () => {
-      let tx = stakingContract
-        .connect(validatorCandidates[4].poolAdmin)
-        .applyValidatorCandidate(
-          validatorCandidates[4].candidateAdmin.address,
-          validatorCandidates[4].consensusAddr.address,
-          validatorCandidates[4].treasuryAddr.address,
-          validatorCandidates[0].bridgeOperator.address,
-          2_00,
-          {
-            value: minValidatorStakingAmount,
-          }
-        );
-
-      await expect(tx)
-        .revertedWithCustomError(roninValidatorSet, 'ErrExistentBridgeOperator')
-        .withArgs(validatorCandidates[0].bridgeOperator.address);
     });
   });
 


### PR DESCRIPTION
### Description
- Prevent trusted orgs from renouncing
- Update cross-contract method names
- Fix typo

### ABI changes
**Staking**
| Old | New |
| -- | -- |
| `grantValidatorCandidate` | `execApplyValidatorCandidate` |
| `requestRevokeCandidate` | `execRequestRenounceCandidate` |

### New custom error
`0x030081e7: ErrTrustedOrgCannotRenounce()`

### Contracts affected 
- Validator Set
- Staking


### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
