### PR TITLE
[ValidatorSet] Incorrect current period start at block

### DIFF
--- a/contracts/ronin/validator/CoinbaseExecution.sol
+++ b/contracts/ronin/validator/CoinbaseExecution.sol
@@ -97,7 +97,6 @@ abstract contract CoinbaseExecution is
   function wrapUpEpoch() external payable virtual override onlyCoinbase whenEpochEnding oncePerEpoch {
     uint256 _newPeriod = _computePeriod(block.timestamp);
     bool _periodEnding = _isPeriodEnding(_newPeriod);
-    _currentPeriodStartAtBlock = block.number + 1;
 
     address[] memory _currentValidators = getValidators();
     uint256 _epoch = epochOf(block.number);
@@ -105,6 +104,7 @@ abstract contract CoinbaseExecution is
     uint256 _lastPeriod = currentPeriod();
 
     if (_periodEnding) {
+      _currentPeriodStartAtBlock = block.number + 1;
       _syncBridgeOperatingReward(_lastPeriod, _currentValidators);
       (
         uint256 _totalDelegatingReward,

--- a/contracts/ronin/validator/storage-fragments/TimingStorage.sol
+++ b/contracts/ronin/validator/storage-fragments/TimingStorage.sol
@@ -85,7 +85,7 @@ abstract contract TimingStorage is ITimingInfo {
   /**
    * @dev See `ITimingInfo-isPeriodEnding`
    */
-  function _isPeriodEnding(uint256 _newPeriod) public view virtual returns (bool) {
+  function _isPeriodEnding(uint256 _newPeriod) internal view virtual returns (bool) {
     return _newPeriod > _lastUpdatedPeriod;
   }
 


### PR DESCRIPTION
### Description
- Fix bug of period start block should not be updated at the beginning of each epoch.
- Fix visibility of `_isPeriodEnding` to internal.

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
