### PR TITLE
Remove redundant check before storage assignment

### DIFF
--- a/contracts/ronin/slash-indicator/CreditScore.sol
+++ b/contracts/ronin/slash-indicator/CreditScore.sol
@@ -53,13 +53,8 @@ abstract contract CreditScore is ICreditScore, HasValidatorContract, HasMaintena
       uint256 _actualGain = (_isJailedInPeriod || _isMaintainingInPeriod)
         ? 0
         : Math.subNonNegative(_gainCreditScore, _indicator);
-      uint256 _scoreBeforeGain = _creditScore[_validator];
-      uint256 _scoreAfterGain = Math.addWithUpperbound(_creditScore[_validator], _actualGain, _maxCreditScore);
 
-      if (_scoreBeforeGain != _scoreAfterGain) {
-        _creditScore[_validator] = _scoreAfterGain;
-      }
-
+      _creditScore[_validator] = Math.addWithUpperbound(_creditScore[_validator], _actualGain, _maxCreditScore);
       _updatedCreditScores[_i] = _creditScore[_validator];
     }
 

--- a/contracts/ronin/staking/RewardCalculation.sol
+++ b/contracts/ronin/staking/RewardCalculation.sol
@@ -212,9 +212,7 @@ abstract contract RewardCalculation is IRewardPool {
       _rps = _pool.shares.inner == 0 ? 0 : (_rewards[_i] * 1e18) / _pool.shares.inner;
       _aRps[_i - _count] = _pool.aRps += _rps;
       _accumulatedRps[_poolAddr][_period] = PeriodWrapper(_pool.aRps, _period);
-      if (_pool.shares.inner != _stakingTotal) {
-        _pool.shares.inner = _stakingTotal;
-      }
+      _pool.shares.inner = _stakingTotal;
       _shares[_i - _count] = _pool.shares.inner;
       _poolAddrs[_i - _count] = _poolAddr;
     }


### PR DESCRIPTION
### Description

Since the gas consumption is already handled in EVM, the current check is redundant and could be safely removed.

[SSTORE Documentation](https://github.com/wolflo/evm-opcodes/blob/main/gas.md#a7-sstore): 
```
If new_val == current_val (no-op):
   gas_cost += 100
```

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
