### PR TITLE
[CreditScore] Reset credit score after revoking

### DIFF
--- a/contracts/interfaces/slash-indicator/ICreditScore.sol
+++ b/contracts/interfaces/slash-indicator/ICreditScore.sol
@@ -28,6 +28,18 @@ interface ICreditScore {
   function updateCreditScores(address[] calldata _validators, uint256 _period) external;
 
   /**
+   * @dev Resets the credit score for the revoked validators.
+   *
+   * Requirements:
+   * - Only validator contract can call this method.
+   * - This method is only called at the end of each period.
+   *
+   * Emits the event `CreditScoresUpdated`.
+   *
+   */
+  function execResetCreditScores(address[] calldata _validators) external;
+
+  /**
    * @dev A slashed validator use this method to get out of jail.
    *
    * Requirements:

--- a/contracts/ronin/slash-indicator/CreditScore.sol
+++ b/contracts/ronin/slash-indicator/CreditScore.sol
@@ -61,6 +61,16 @@ abstract contract CreditScore is ICreditScore, HasValidatorContract, HasMaintena
     emit CreditScoresUpdated(_validators, _updatedCreditScores);
   }
 
+  function execResetCreditScores(address[] calldata _validators) external override onlyValidatorContract {
+    uint256[] memory _updatedCreditScores = new uint256[](_validators.length);
+    for (uint _i = 0; _i < _validators.length; _i++) {
+      address _validator = _validators[_i];
+      _creditScore[_validator] = 0;
+      _updatedCreditScores[_i] = 0;
+    }
+    emit CreditScoresUpdated(_validators, _updatedCreditScores);
+  }
+
   /**
    * @inheritdoc ICreditScore
    */

--- a/contracts/ronin/slash-indicator/CreditScore.sol
+++ b/contracts/ronin/slash-indicator/CreditScore.sol
@@ -65,8 +65,8 @@ abstract contract CreditScore is ICreditScore, HasValidatorContract, HasMaintena
     uint256[] memory _updatedCreditScores = new uint256[](_validators.length);
     for (uint _i = 0; _i < _validators.length; _i++) {
       address _validator = _validators[_i];
-      _creditScore[_validator] = 0;
-      _updatedCreditScores[_i] = 0;
+      delete _creditScore[_validator];
+      delete _updatedCreditScores[_i];
     }
     emit CreditScoresUpdated(_validators, _updatedCreditScores);
   }

--- a/contracts/ronin/validator/CandidateManager.sol
+++ b/contracts/ronin/validator/CandidateManager.sol
@@ -177,7 +177,7 @@ abstract contract CandidateManager is ICandidateManager, PercentageConsumer, Has
    * Emits the event `CandidatesRevoked` when a candidate is revoked.
    *
    */
-  function _syncCandidateSet() internal {
+  function _syncCandidateSet() internal returns (address[] memory _unsatisfiedCandidates) {
     IStaking _staking = _stakingContract;
     uint256 _waitingSecsToRevoke = _staking.waitingSecsToRevoke();
     uint256 _minStakingAmount = _staking.minValidatorStakingAmount();
@@ -185,7 +185,7 @@ abstract contract CandidateManager is ICandidateManager, PercentageConsumer, Has
 
     uint256 _length = _candidates.length;
     uint256 _unsatisfiedCount;
-    address[] memory _unsatisfiedCandidates = new address[](_length);
+    _unsatisfiedCandidates = new address[](_length);
 
     {
       uint256 _i;

--- a/test/slash/CreditScore.test.ts
+++ b/test/slash/CreditScore.test.ts
@@ -254,7 +254,7 @@ describe('Credit score and bail out test', () => {
     });
     it('Should the score get reset when the candidate is revoked', async () => {
       snapshotId = await network.provider.send('evm_snapshot');
-      let snapshotScore = localIndicatorController.getAt(0);
+      let snapshotScore = localScoreController.getAt(0);
 
       await stakingContract
         .connect(validatorCandidates[0].poolAdmin)


### PR DESCRIPTION
### Description
https://skymavis.atlassian.net/jira/software/projects/PSC/boards/47?selectedIssue=PSC-168

- Reset the credit score when the candidate is revoked
- Emit the event `CreditScoresUpdated` with scores of `0`s.
- Add `exec-` prefix to method name for consistency.

### Contracts with ABI changes:
- ValidatorSet
- SlashIndicator

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
