### PR TITLE
[Staking] Send last reward for revoked candidates

### DIFF
--- a/contracts/interfaces/staking/ICandidateStaking.sol
+++ b/contracts/interfaces/staking/ICandidateStaking.sol
@@ -98,7 +98,7 @@ interface ICandidateStaking is IRewardPool {
    * Emits the event `StakingAmountTransferFailed` if the contract cannot transfer RON back to the pool admin.
    *
    */
-  function deprecatePools(address[] calldata _pools) external;
+  function execDeprecatePools(address[] calldata _pools, uint256 _period) external;
 
   /**
    * @dev Self-delegates to the validator candidate `_consensusAddr`.

--- a/contracts/interfaces/staking/IStaking.sol
+++ b/contracts/interfaces/staking/IStaking.sol
@@ -38,18 +38,4 @@ interface IStaking is IRewardPool, IBaseStaking, ICandidateStaking, IDelegatorSt
   function execDeductStakingAmount(address _consensusAddr, uint256 _amount)
     external
     returns (uint256 _actualDeductingAmount);
-
-  /**
-   * @dev Sends the last claimable reward of candidates when they are getting revoked.
-   *
-   * Requirements:
-   * - The method caller must be the validator contract.
-   *
-   * Emits the `RewardClaimed` event and the `UserRewardUpdated` event.
-   *
-   * Note:
-   * - This method should be called once at the period ending.
-   * - This method should only be called when there are revoked candidates.
-   */
-  function execSettleAndTransferUnclaimedReward(address[] memory _consensusAddrs, uint256 _period) external;
 }

--- a/contracts/interfaces/staking/IStaking.sol
+++ b/contracts/interfaces/staking/IStaking.sol
@@ -45,6 +45,8 @@ interface IStaking is IRewardPool, IBaseStaking, ICandidateStaking, IDelegatorSt
    * Requirements:
    * - The method caller must be the validator contract.
    *
+   * Emits the `RewardClaimed` event and the `UserRewardUpdated` event.
+   *
    * Note:
    * - This method should be called once at the period ending.
    * - This method should only be called when there are revoked candidates.

--- a/contracts/interfaces/staking/IStaking.sol
+++ b/contracts/interfaces/staking/IStaking.sol
@@ -40,7 +40,7 @@ interface IStaking is IRewardPool, IBaseStaking, ICandidateStaking, IDelegatorSt
     returns (uint256 _actualDeductingAmount);
 
   /**
-   * @dev Sends the pending reward of a candidate when (s)he is getting revoked.
+   * @dev Sends the last claimable reward of candidates when they are getting revoked.
    *
    * Requirements:
    * - The method caller must be the validator contract.
@@ -51,5 +51,5 @@ interface IStaking is IRewardPool, IBaseStaking, ICandidateStaking, IDelegatorSt
    * - This method should be called once at the period ending.
    * - This method should only be called when there are revoked candidates.
    */
-  function execPayLastReward(address _consensusAddr) external;
+  function execSettleAndTransferUnclaimedReward(address[] memory _consensusAddrs, uint256 _period) external;
 }

--- a/contracts/interfaces/staking/IStaking.sol
+++ b/contracts/interfaces/staking/IStaking.sol
@@ -38,4 +38,16 @@ interface IStaking is IRewardPool, IBaseStaking, ICandidateStaking, IDelegatorSt
   function execDeductStakingAmount(address _consensusAddr, uint256 _amount)
     external
     returns (uint256 _actualDeductingAmount);
+
+  /**
+   * @dev Sends the pending reward of a candidate when (s)he is getting revoked.
+   *
+   * Requirements:
+   * - The method caller must be the validator contract.
+   *
+   * Note:
+   * - This method should be called once at the period ending.
+   * - This method should only be called when there are revoked candidates.
+   */
+  function execPayLastReward(address _consensusAddr) external;
 }

--- a/contracts/mocks/MockStaking.sol
+++ b/contracts/mocks/MockStaking.sol
@@ -73,7 +73,7 @@ contract MockStaking is RewardCalculation {
   }
 
   function claimReward(address _user) external returns (uint256 _amount) {
-    _amount = _claimReward(poolAddr, _user);
+    _amount = _claimReward(poolAddr, _user, getPeriod());
   }
 
   function getStakingAmount(address, address _user) public view override returns (uint256) {

--- a/contracts/mocks/validator/MockValidatorSet.sol
+++ b/contracts/mocks/validator/MockValidatorSet.sol
@@ -33,7 +33,7 @@ contract MockValidatorSet is IRoninValidatorSet, CandidateManager {
   function submitBlockReward() external payable override {}
 
   function wrapUpEpoch() external payable override {
-    _syncCandidateSet();
+    _syncCandidateSet(_lastUpdatedPeriod + 1);
     _lastUpdatedPeriod = currentPeriod();
   }
 

--- a/contracts/ronin/staking/DelegatorStaking.sol
+++ b/contracts/ronin/staking/DelegatorStaking.sol
@@ -166,7 +166,7 @@ abstract contract DelegatorStaking is BaseStaking, IDelegatorStaking {
    * @dev Claims rewards from the pools `_poolAddrList`.
    * Note: This function does not transfer reward to user.
    */
-  function _claimRewards(address _user, address[] calldata _poolAddrList) internal returns (uint256 _amount) {
+  function _claimRewards(address _user, address[] memory _poolAddrList) internal returns (uint256 _amount) {
     for (uint256 _i = 0; _i < _poolAddrList.length; _i++) {
       _amount += _claimReward(_poolAddrList[_i], _user);
     }

--- a/contracts/ronin/staking/DelegatorStaking.sol
+++ b/contracts/ronin/staking/DelegatorStaking.sol
@@ -167,8 +167,9 @@ abstract contract DelegatorStaking is BaseStaking, IDelegatorStaking {
    * Note: This function does not transfer reward to user.
    */
   function _claimRewards(address _user, address[] memory _poolAddrList) internal returns (uint256 _amount) {
+    uint256 _period = _currentPeriod();
     for (uint256 _i = 0; _i < _poolAddrList.length; _i++) {
-      _amount += _claimReward(_poolAddrList[_i], _user);
+      _amount += _claimReward(_poolAddrList[_i], _user, _period);
     }
   }
 

--- a/contracts/ronin/staking/RewardCalculation.sol
+++ b/contracts/ronin/staking/RewardCalculation.sol
@@ -140,6 +140,9 @@ abstract contract RewardCalculation is IRewardPool {
   /**
    * @dev Claims the settled reward for a specific user.
    *
+   * @param _lastPeriod Must be in two possible value: `_currentPeriod` in normal calculation, or
+   * `_currentPeriod + 1` in case of calculating the reward for revoked validators.
+   *
    * Emits the `RewardClaimed` event and the `UserRewardUpdated` event.
    *
    * Note: This method should be called before transferring rewards for the user.
@@ -148,16 +151,16 @@ abstract contract RewardCalculation is IRewardPool {
   function _claimReward(
     address _poolAddr,
     address _user,
-    uint256 _period
+    uint256 _lastPeriod
   ) internal returns (uint256 _amount) {
     uint256 _currentStakingAmount = getStakingAmount(_poolAddr, _user);
-    _amount = _getReward(_poolAddr, _user, _period, _currentStakingAmount);
+    _amount = _getReward(_poolAddr, _user, _lastPeriod, _currentStakingAmount);
     emit RewardClaimed(_poolAddr, _user, _amount);
 
     UserRewardFields storage _reward = _userReward[_poolAddr][_user];
     _reward.debited = 0;
-    _syncMinStakingAmount(_stakingPool[_poolAddr], _reward, _period, _currentStakingAmount, _currentStakingAmount);
-    _reward.lastPeriod = _period;
+    _syncMinStakingAmount(_stakingPool[_poolAddr], _reward, _lastPeriod, _currentStakingAmount, _currentStakingAmount);
+    _reward.lastPeriod = _lastPeriod;
     _reward.aRps = _stakingPool[_poolAddr].aRps;
     emit UserRewardUpdated(_poolAddr, _user, 0);
   }

--- a/contracts/ronin/staking/RewardCalculation.sol
+++ b/contracts/ronin/staking/RewardCalculation.sol
@@ -140,7 +140,7 @@ abstract contract RewardCalculation is IRewardPool {
   /**
    * @dev Claims the settled reward for a specific user.
    *
-   * Emits the `PendingRewardUpdated` event and the `SettledRewardUpdated` event.
+   * Emits the `RewardClaimed` event and the `UserRewardUpdated` event.
    *
    * Note: This method should be called before transferring rewards for the user.
    *

--- a/contracts/ronin/staking/RewardCalculation.sol
+++ b/contracts/ronin/staking/RewardCalculation.sol
@@ -145,22 +145,19 @@ abstract contract RewardCalculation is IRewardPool {
    * Note: This method should be called before transferring rewards for the user.
    *
    */
-  function _claimReward(address _poolAddr, address _user) internal returns (uint256 _amount) {
-    uint256 _latestPeriod = _currentPeriod();
+  function _claimReward(
+    address _poolAddr,
+    address _user,
+    uint256 _period
+  ) internal returns (uint256 _amount) {
     uint256 _currentStakingAmount = getStakingAmount(_poolAddr, _user);
-    _amount = _getReward(_poolAddr, _user, _latestPeriod, _currentStakingAmount);
+    _amount = _getReward(_poolAddr, _user, _period, _currentStakingAmount);
     emit RewardClaimed(_poolAddr, _user, _amount);
 
     UserRewardFields storage _reward = _userReward[_poolAddr][_user];
     _reward.debited = 0;
-    _syncMinStakingAmount(
-      _stakingPool[_poolAddr],
-      _reward,
-      _latestPeriod,
-      _currentStakingAmount,
-      _currentStakingAmount
-    );
-    _reward.lastPeriod = _latestPeriod;
+    _syncMinStakingAmount(_stakingPool[_poolAddr], _reward, _period, _currentStakingAmount, _currentStakingAmount);
+    _reward.lastPeriod = _period;
     _reward.aRps = _stakingPool[_poolAddr].aRps;
     emit UserRewardUpdated(_poolAddr, _user, 0);
   }

--- a/contracts/ronin/staking/Staking.sol
+++ b/contracts/ronin/staking/Staking.sol
@@ -63,9 +63,7 @@ contract Staking is IStaking, CandidateStaking, DelegatorStaking, Initializable 
    */
   function execPayLastReward(address _consensusAddr) external onlyValidatorContract {
     address _poolAdmin = _stakingPool[_consensusAddr].admin;
-    address[] memory _poolAddrArr = new address[](1);
-    _poolAddrArr[0] = _consensusAddr;
-    uint256 _amount = _claimRewards(_poolAdmin, _poolAddrArr);
+    uint256 _amount = _claimReward(_consensusAddr, _poolAdmin);
     _transferRON(payable(_poolAdmin), _amount);
   }
 

--- a/contracts/ronin/staking/Staking.sol
+++ b/contracts/ronin/staking/Staking.sol
@@ -63,7 +63,8 @@ contract Staking is IStaking, CandidateStaking, DelegatorStaking, Initializable 
    */
   function execPayLastReward(address _consensusAddr) external onlyValidatorContract {
     address _poolAdmin = _stakingPool[_consensusAddr].admin;
-    uint256 _amount = _claimReward(_consensusAddr, _poolAdmin);
+    uint256 _period = _currentPeriod() + 1;
+    uint256 _amount = _claimReward(_consensusAddr, _poolAdmin, _period);
     _transferRON(payable(_poolAdmin), _amount);
   }
 

--- a/contracts/ronin/staking/Staking.sol
+++ b/contracts/ronin/staking/Staking.sol
@@ -59,6 +59,17 @@ contract Staking is IStaking, CandidateStaking, DelegatorStaking, Initializable 
   }
 
   /**
+   * @inheritdoc IStaking
+   */
+  function execPayLastReward(address _consensusAddr) external onlyValidatorContract {
+    address _poolAdmin = _stakingPool[_consensusAddr].admin;
+    address[] memory _poolAddrArr = new address[](1);
+    _poolAddrArr[0] = _consensusAddr;
+    uint256 _amount = _claimRewards(_poolAdmin, _poolAddrArr);
+    _transferRON(payable(_poolAdmin), _amount);
+  }
+
+  /**
    * @inheritdoc RewardCalculation
    */
   function _currentPeriod() internal view virtual override returns (uint256) {

--- a/contracts/ronin/staking/Staking.sol
+++ b/contracts/ronin/staking/Staking.sol
@@ -60,22 +60,6 @@ contract Staking is IStaking, CandidateStaking, DelegatorStaking, Initializable 
   }
 
   /**
-   * @inheritdoc IStaking
-   */
-  function execSettleAndTransferUnclaimedReward(address[] calldata _consensusAddrs, uint256 _period)
-    external
-    override
-    onlyValidatorContract
-  {
-    for (uint _i = 0; _i < _consensusAddrs.length; _i++) {
-      address _poolAddr = _consensusAddrs[_i];
-      address _poolAdmin = _stakingPool[_poolAddr].admin;
-      uint256 _amount = _claimReward(_poolAddr, _poolAdmin, _period);
-      _transferRON(payable(_poolAdmin), _amount);
-    }
-  }
-
-  /**
    * @inheritdoc RewardCalculation
    */
   function _currentPeriod() internal view virtual override returns (uint256) {

--- a/contracts/ronin/staking/Staking.sol
+++ b/contracts/ronin/staking/Staking.sol
@@ -39,7 +39,7 @@ contract Staking is IStaking, CandidateStaking, DelegatorStaking, Initializable 
     address[] calldata _consensusAddrs,
     uint256[] calldata _rewards,
     uint256 _period
-  ) external payable onlyValidatorContract {
+  ) external payable override onlyValidatorContract {
     _recordRewards(_consensusAddrs, _rewards, _period);
   }
 
@@ -48,6 +48,7 @@ contract Staking is IStaking, CandidateStaking, DelegatorStaking, Initializable 
    */
   function execDeductStakingAmount(address _consensusAddr, uint256 _amount)
     external
+    override
     onlyValidatorContract
     returns (uint256 _actualDeductingAmount)
   {
@@ -61,11 +62,17 @@ contract Staking is IStaking, CandidateStaking, DelegatorStaking, Initializable 
   /**
    * @inheritdoc IStaking
    */
-  function execPayLastReward(address _consensusAddr) external onlyValidatorContract {
-    address _poolAdmin = _stakingPool[_consensusAddr].admin;
-    uint256 _period = _currentPeriod() + 1;
-    uint256 _amount = _claimReward(_consensusAddr, _poolAdmin, _period);
-    _transferRON(payable(_poolAdmin), _amount);
+  function execSettleAndTransferUnclaimedReward(address[] calldata _consensusAddrs, uint256 _period)
+    external
+    override
+    onlyValidatorContract
+  {
+    for (uint _i = 0; _i < _consensusAddrs.length; _i++) {
+      address _poolAddr = _consensusAddrs[_i];
+      address _poolAdmin = _stakingPool[_poolAddr].admin;
+      uint256 _amount = _claimReward(_poolAddr, _poolAdmin, _period);
+      _transferRON(payable(_poolAdmin), _amount);
+    }
   }
 
   /**

--- a/contracts/ronin/validator/CandidateManager.sol
+++ b/contracts/ronin/validator/CandidateManager.sol
@@ -216,7 +216,6 @@ abstract contract CandidateManager is ICandidateManager, PercentageConsumer, Has
         bool _topupDeadlineMissed = _info.topupDeadline != 0 && _info.topupDeadline <= block.timestamp;
         if (_revokingActivated || _topupDeadlineMissed) {
           _selfStakings[_i] = _selfStakings[--_length];
-          _stakingContract.execPayLastReward(_addr);
           _unsatisfiedCandidates[_unsatisfiedCount++] = _addr;
           _removeCandidate(_addr);
           continue;

--- a/contracts/ronin/validator/CandidateManager.sol
+++ b/contracts/ronin/validator/CandidateManager.sol
@@ -216,6 +216,7 @@ abstract contract CandidateManager is ICandidateManager, PercentageConsumer, Has
         bool _topupDeadlineMissed = _info.topupDeadline != 0 && _info.topupDeadline <= block.timestamp;
         if (_revokingActivated || _topupDeadlineMissed) {
           _selfStakings[_i] = _selfStakings[--_length];
+          _stakingContract.execPayLastReward(_addr);
           _unsatisfiedCandidates[_unsatisfiedCount++] = _addr;
           _removeCandidate(_addr);
           continue;

--- a/contracts/ronin/validator/CandidateManager.sol
+++ b/contracts/ronin/validator/CandidateManager.sol
@@ -177,7 +177,7 @@ abstract contract CandidateManager is ICandidateManager, PercentageConsumer, Has
    * Emits the event `CandidatesRevoked` when a candidate is revoked.
    *
    */
-  function _syncCandidateSet() internal returns (address[] memory _unsatisfiedCandidates) {
+  function _syncCandidateSet(uint256 _nextPeriod) internal returns (address[] memory _unsatisfiedCandidates) {
     IStaking _staking = _stakingContract;
     uint256 _waitingSecsToRevoke = _staking.waitingSecsToRevoke();
     uint256 _minStakingAmount = _staking.minValidatorStakingAmount();
@@ -239,7 +239,7 @@ abstract contract CandidateManager is ICandidateManager, PercentageConsumer, Has
         mstore(_unsatisfiedCandidates, _unsatisfiedCount)
       }
       emit CandidatesRevoked(_unsatisfiedCandidates);
-      _staking.deprecatePools(_unsatisfiedCandidates);
+      _staking.execDeprecatePools(_unsatisfiedCandidates, _nextPeriod);
     }
   }
 

--- a/contracts/ronin/validator/CoinbaseExecution.sol
+++ b/contracts/ronin/validator/CoinbaseExecution.sol
@@ -99,7 +99,7 @@ abstract contract CoinbaseExecution is
     bool _periodEnding = _isPeriodEnding(_newPeriod);
 
     address[] memory _currentValidators = getValidators();
-    address[] memory _unsastifiedCandidates;
+    address[] memory _revokedCandidates;
     uint256 _epoch = epochOf(block.number);
     uint256 _nextEpoch = _epoch + 1;
     uint256 _lastPeriod = currentPeriod();
@@ -115,8 +115,11 @@ abstract contract CoinbaseExecution is
       _tryRecycleLockedFundsFromEmergencyExits();
       _recycleDeprecatedRewards();
       _slashIndicatorContract.updateCreditScores(_currentValidators, _lastPeriod);
-      (_currentValidators, _unsastifiedCandidates) = _syncValidatorSet(_newPeriod);
-      _slashIndicatorContract.execResetCreditScores(_unsastifiedCandidates);
+      (_currentValidators, _revokedCandidates) = _syncValidatorSet(_newPeriod);
+      if (_revokedCandidates.length > 0) {
+        _stakingContract.execSettleAndTransferUnclaimedReward(_revokedCandidates, _nextEpoch);
+        _slashIndicatorContract.execResetCreditScores(_revokedCandidates);
+      }
     }
     _revampRoles(_newPeriod, _nextEpoch, _currentValidators);
     emit WrappedUpEpoch(_lastPeriod, _epoch, _periodEnding);

--- a/contracts/ronin/validator/CoinbaseExecution.sol
+++ b/contracts/ronin/validator/CoinbaseExecution.sol
@@ -117,7 +117,6 @@ abstract contract CoinbaseExecution is
       _slashIndicatorContract.updateCreditScores(_currentValidators, _lastPeriod);
       (_currentValidators, _revokedCandidates) = _syncValidatorSet(_newPeriod);
       if (_revokedCandidates.length > 0) {
-        _stakingContract.execSettleAndTransferUnclaimedReward(_revokedCandidates, _nextEpoch);
         _slashIndicatorContract.execResetCreditScores(_revokedCandidates);
       }
     }
@@ -378,7 +377,7 @@ abstract contract CoinbaseExecution is
     private
     returns (address[] memory _newValidators, address[] memory _unsastifiedCandidates)
   {
-    _unsastifiedCandidates = _syncCandidateSet();
+    _unsastifiedCandidates = _syncCandidateSet(_newPeriod);
     uint256[] memory _weights = _stakingContract.getManyStakingTotals(_candidates);
     uint256[] memory _trustedWeights = _roninTrustedOrganizationContract.getConsensusWeights(_candidates);
     uint256 _newValidatorCount;

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -8,7 +8,7 @@ The table below shows following info:
 - **Dependent**: need to be changed due to changes in other contracts.
 
 | **Contract name** | **ABI** | **Init data** | **Dependent** |
-|-------------------|---------|---------------|---------------|
+|-------------------|:-------:|:-------------:|:-------------:|
 | BridgeTracking    |         |               |               |
 | GovernanceAdmin   |         |               |               |
 | Maintenance       |         |               |               |

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -2,10 +2,10 @@
 
 ### Contract changes
 
-The table below shows following info:
+The table below shows the following info:
 - **ABI**: the ABI is changed.
-- **Init data**: new storage field is declared and need initialized.
-- **Dependent**: need to be changed due to changes in other contracts.
+- **Init data**: new storage field is declared and needs initializing.
+- **Dependent**: needs to be changed due to changes in other contracts.
 
 | **Contract name** | **ABI** | **Init data** | **Dependent** |
 |-------------------|:-------:|:-------------:|:-------------:|

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,5 +1,22 @@
 ### Description
 
+### Contract changes
+
+The table below shows following info:
+- **ABI**: the ABI is changed.
+- **Init data**: new storage field is declared and need initialized.
+- **Dependent**: need to be changed due to changes in other contracts.
+
+| **Contract name** | **ABI** | **Init data** | **Dependent** |
+|-------------------|---------|---------------|---------------|
+| BridgeTracking    |         |               |               |
+| GovernanceAdmin   |         |               |               |
+| Maintenance       |         |               |               |
+| SlashIndicator    |         |               |               |
+| Staking           |         |               |               |
+| StakingVesting    |         |               |               |
+| ValidatorSet      |         |               |               |
+
 ### Checklist
 - [ ] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
 - [ ] The box that allows repo maintainers to update this PR is checked

--- a/test/slash/CreditScore.test.ts
+++ b/test/slash/CreditScore.test.ts
@@ -268,6 +268,8 @@ describe('Credit score and bail out test', () => {
     it('Should the score get reset when the candidate is revoked', async () => {
       snapshotId = await network.provider.send('evm_snapshot');
       let snapshotScore = localScoreController.getAt(0);
+      await expect(snapshotScore).gt(0);
+      await validateScoreAt(0);
 
       await stakingContract
         .connect(validatorCandidates[0].poolAdmin)
@@ -276,6 +278,9 @@ describe('Credit score and bail out test', () => {
 
       let tx = await endPeriodAndWrapUpAndResetIndicators();
       await CandidateManagerExpects.emitCandidatesRevokedEvent(tx, [validatorCandidates[0].consensusAddr.address]);
+      await expect(tx)
+        .emit(slashContract, 'CreditScoresUpdated')
+        .withArgs([validatorCandidates[0].consensusAddr.address], [1]);
 
       localScoreController.resetAt(0);
       await validateScoreAt(0);

--- a/test/slash/CreditScore.test.ts
+++ b/test/slash/CreditScore.test.ts
@@ -280,7 +280,7 @@ describe('Credit score and bail out test', () => {
       await CandidateManagerExpects.emitCandidatesRevokedEvent(tx, [validatorCandidates[0].consensusAddr.address]);
       await expect(tx)
         .emit(slashContract, 'CreditScoresUpdated')
-        .withArgs([validatorCandidates[0].consensusAddr.address], [1]);
+        .withArgs([validatorCandidates[0].consensusAddr.address], [0]);
 
       localScoreController.resetAt(0);
       await validateScoreAt(0);

--- a/test/staking/Staking.test.ts
+++ b/test/staking/Staking.test.ts
@@ -11,6 +11,7 @@ import { MockValidatorSet } from '../../src/types/MockValidatorSet';
 import { createManyValidatorCandidateAddressSets, ValidatorCandidateAddressSet } from '../helpers/address-set-types';
 import { getLastBlockTimestamp } from '../helpers/utils';
 
+let coinbase: SignerWithAddress;
 let deployer: SignerWithAddress;
 
 let proxyAdmin: SignerWithAddress;
@@ -28,7 +29,7 @@ let validatorCandidates: ValidatorCandidateAddressSet[];
 
 const ONE_DAY = 60 * 60 * 24;
 
-const minValidatorStakingAmount = BigNumber.from(20);
+const minValidatorStakingAmount = BigNumber.from(2_000_000);
 const maxValidatorCandidate = 50;
 const numberOfBlocksInEpoch = 2;
 const cooldownSecsToUndelegate = 3 * 86400;
@@ -38,7 +39,7 @@ const numberOfCandidate = 4;
 
 describe('Staking test', () => {
   before(async () => {
-    [deployer, proxyAdmin, userA, userB, ...signers] = await ethers.getSigners();
+    [coinbase, deployer, proxyAdmin, userA, userB, ...signers] = await ethers.getSigners();
     validatorCandidates = createManyValidatorCandidateAddressSets(signers.slice(0, numberOfCandidate * 3));
     sparePoolAddrSet = validatorCandidates.splice(validatorCandidates.length - 1)[0];
 

--- a/test/validator/RoninValidatorSet-Candidate.test.ts
+++ b/test/validator/RoninValidatorSet-Candidate.test.ts
@@ -86,7 +86,7 @@ describe('Ronin Validator Set: candidate test', () => {
       stakingContractAddress,
       roninGovernanceAdminAddress,
       stakingVestingContractAddress,
-    } = await initTest('RoninValidatorSet')({
+    } = await initTest('RoninValidatorSet-Candidate')({
       slashIndicatorArguments: {
         doubleSignSlashing: {
           slashDoubleSignAmount,

--- a/test/validator/RoninValidatorSet-CoinbaseExecution.test.ts
+++ b/test/validator/RoninValidatorSet-CoinbaseExecution.test.ts
@@ -85,7 +85,7 @@ describe('Ronin Validator Set: Coinbase execution test', () => {
       stakingContractAddress,
       roninGovernanceAdminAddress,
       stakingVestingContractAddress,
-    } = await initTest('RoninValidatorSet')({
+    } = await initTest('RoninValidatorSet-Coinbase')({
       slashIndicatorArguments: {
         doubleSignSlashing: {
           slashDoubleSignAmount,

--- a/test/validator/RoninValidatorSet-CoinbaseExecution.test.ts
+++ b/test/validator/RoninValidatorSet-CoinbaseExecution.test.ts
@@ -375,6 +375,10 @@ describe('Ronin Validator Set: Coinbase execution test', () => {
       await expect(wrapupEpochTx!)
         .emit(stakingContract, 'RewardClaimed')
         .withArgs(currValidator.consensusAddr.address, currValidator.poolAdmin.address, unclaimedReward);
+
+      expect(await stakingContract.getReward(currValidator.consensusAddr.address, currValidator.poolAdmin.address)).eq(
+        0
+      );
     });
   });
 


### PR DESCRIPTION
### Description
https://skymavis.atlassian.net/browse/PSC-174?atlOrigin=eyJpIjoiM2UzNWE4Mjk0ZDAyNGNiZTlhMDQ5MTk4M2JmNjc2OTciLCJwIjoiaiJ9

- Transfer unclaimed reward for the candidates on revoking

### Contract changes

The table below shows following info:
- **ABI**: the ABI is changed.
- **Init data**: new storage field is declared and need initialized.
- **Dependent**: need to be changed due to changes in other contracts.

| **Contract name** | **ABI** | **Init data** | **Dependent** |
|-------------------|:-------:|:-------------:|:-------------:|
| BridgeTracking    |         |               |               |
| GovernanceAdmin   |         |               |               |
| Maintenance       |         |               |               |
| SlashIndicator    |         |               |               |
| Staking           |   [x]   |               |               |
| StakingVesting    |         |               |               |
| ValidatorSet      |   [x]   |               |               |

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
