### PR TITLE
[GA] Fix wrong calculation of `round`

### DIFF
--- a/contracts/extensions/sequential-governance/GovernanceProposal.sol
+++ b/contracts/extensions/sequential-governance/GovernanceProposal.sol
@@ -112,12 +112,7 @@ abstract contract GovernanceProposal is CoreGovernance {
     address _gatewayContract,
     address _creator
   ) internal returns (Proposal.ProposalDetail memory _proposal) {
-    (_proposal, ) = _proposeGlobalStruct(
-      _globalProposal,
-      _roninTrustedOrganizationContract,
-      _gatewayContract,
-      _creator
-    );
+    _proposal = _proposeGlobalStruct(_globalProposal, _roninTrustedOrganizationContract, _gatewayContract, _creator);
     bytes32 _globalProposalHash = _globalProposal.hash();
     _castVotesBySignatures(
       _proposal,

--- a/contracts/extensions/sequential-governance/GovernanceRelay.sol
+++ b/contracts/extensions/sequential-governance/GovernanceRelay.sol
@@ -120,7 +120,7 @@ abstract contract GovernanceRelay is CoreGovernance {
     address _gatewayContract,
     address _creator
   ) internal {
-    (Proposal.ProposalDetail memory _proposal, ) = _proposeGlobalStruct(
+    Proposal.ProposalDetail memory _proposal = _proposeGlobalStruct(
       _globalProposal,
       _roninTrustedOrganizationContract,
       _gatewayContract,

--- a/contracts/ronin/RoninGovernanceAdmin.sol
+++ b/contracts/ronin/RoninGovernanceAdmin.sol
@@ -230,16 +230,12 @@ contract RoninGovernanceAdmin is
     bytes[] calldata _calldatas,
     uint256[] calldata _gasAmounts
   ) external onlyGovernor {
-    _proposeGlobal(
-      _expiryTimestamp,
-      _targetOptions,
-      _values,
-      _calldatas,
-      _gasAmounts,
-      roninTrustedOrganizationContract(),
-      bridgeContract(),
-      msg.sender
-    );
+    address[] memory _addressPack = new address[](3);
+    _addressPack[0] = roninTrustedOrganizationContract();
+    _addressPack[1] = bridgeContract();
+    _addressPack[2] = msg.sender;
+
+    _proposeGlobal(_expiryTimestamp, _targetOptions, _values, _calldatas, _gasAmounts, _addressPack);
   }
 
   /**

--- a/contracts/ronin/RoninGovernanceAdmin.sol
+++ b/contracts/ronin/RoninGovernanceAdmin.sol
@@ -230,12 +230,16 @@ contract RoninGovernanceAdmin is
     bytes[] calldata _calldatas,
     uint256[] calldata _gasAmounts
   ) external onlyGovernor {
-    address[3] memory _addressPack;
-    _addressPack[0] = roninTrustedOrganizationContract();
-    _addressPack[1] = bridgeContract();
-    _addressPack[2] = msg.sender;
-
-    _proposeGlobal(_expiryTimestamp, _targetOptions, _values, _calldatas, _gasAmounts, _addressPack);
+    _proposeGlobal(
+      _expiryTimestamp,
+      _targetOptions,
+      _values,
+      _calldatas,
+      _gasAmounts,
+      roninTrustedOrganizationContract(),
+      bridgeContract(),
+      msg.sender
+    );
   }
 
   /**
@@ -280,10 +284,16 @@ contract RoninGovernanceAdmin is
   }
 
   /**
-   * @dev See `CoreGovernance-_deleteExpiredProposal`
+   * @dev Deletes the expired proposal by its chainId and nonce, without creating a new proposal.
+   *
+   * Requirements:
+   * - The proposal is already created.
+   *
    */
-  function deleteExpired(uint256 chainId, uint256 round) external {
-    _deleteExpiredVotingRound(chainId, round);
+  function deleteExpired(uint256 _chainId, uint256 _round) external {
+    ProposalVote storage _vote = vote[_chainId][_round];
+    require(_vote.hash != bytes32(0), "RoninGovernanceAdmin: query for empty voting");
+    _tryDeleteExpiredVotingRound(_vote);
   }
 
   /**

--- a/contracts/ronin/RoninGovernanceAdmin.sol
+++ b/contracts/ronin/RoninGovernanceAdmin.sol
@@ -230,7 +230,7 @@ contract RoninGovernanceAdmin is
     bytes[] calldata _calldatas,
     uint256[] calldata _gasAmounts
   ) external onlyGovernor {
-    address[] memory _addressPack = new address[](3);
+    address[3] memory _addressPack;
     _addressPack[0] = roninTrustedOrganizationContract();
     _addressPack[1] = bridgeContract();
     _addressPack[2] = msg.sender;

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -108,6 +108,9 @@ const config: HardhatUserConfig = {
     enabled: REPORT_GAS ? true : false,
     showTimeSpent: true,
   },
+  mocha: {
+    timeout: 100000,
+  },
 };
 
 export default config;

--- a/test/governance-admin/GovernanceAdmin.test.ts
+++ b/test/governance-admin/GovernanceAdmin.test.ts
@@ -352,6 +352,8 @@ describe('Governance Admin test', () => {
     let previousSupports: VoteType[];
     let previousSignatures: SignatureStruct[];
 
+    let previousProposal2: ProposalDetailStruct;
+
     it('Should not be able to propose a proposal with invalid expiry time', async () => {
       const newMinValidatorStakingAmount = 1337;
       const latestTimestamp = await getLastBlockTimestamp();
@@ -393,6 +395,7 @@ describe('Governance Admin test', () => {
         500_000
       );
       previousProposal = proposal;
+      previousProposal2 = proposal;
       previousHash = getProposalHash(proposal);
 
       signatures = await governanceAdminInterface.generateSignatures(proposal);
@@ -426,7 +429,9 @@ describe('Governance Admin test', () => {
       ).revertedWith('GovernanceAdmin: cast vote for invalid proposal');
     });
 
-    it('Should the new proposal replace the expired proposal', async () => {
+    it('Should the new proposal replace the expired proposal -- with implicit round', async () => {
+      snapshotId = await network.provider.send('evm_snapshot');
+
       let currentProposalVote = await governanceAdmin.vote(previousProposal.chainId, previousProposal.nonce);
       expect(currentProposalVote.hash).eq(ZERO_BYTES32);
       expect(currentProposalVote.status).eq(VoteStatus.Pending);
@@ -458,6 +463,55 @@ describe('Governance Admin test', () => {
 
       await governanceAdmin.connect(trustedOrgs[0].governor).castProposalBySignatures(proposal, supports, signatures);
       currentProposalVote = await governanceAdmin.vote(previousProposal.chainId, previousProposal.nonce);
+      expect(currentProposalVote.status).eq(VoteStatus.Executed);
+
+      previousProposal = proposal;
+      previousHash = getProposalHash(proposal);
+
+      await network.provider.send('evm_revert', [snapshotId]);
+    });
+
+    it('Should the new proposal replace the expired proposal -- with explicit round', async () => {
+      let currentProposalVote = await governanceAdmin.vote(previousProposal2.chainId, previousProposal2.nonce);
+      expect(currentProposalVote.hash).eq(ZERO_BYTES32);
+      expect(currentProposalVote.status).eq(VoteStatus.Pending);
+
+      const newMinValidatorStakingAmount = 202881;
+      const latestTimestamp = await getLastBlockTimestamp();
+      const expiryTimestamp = latestTimestamp + proposalExpiryDuration;
+      proposal = await governanceAdminInterface.createProposal(
+        expiryTimestamp,
+        stakingContract.address,
+        0,
+        governanceAdminInterface.interface.encodeFunctionData('functionDelegateCall', [
+          stakingContract.interface.encodeFunctionData('setMinValidatorStakingAmount', [newMinValidatorStakingAmount]),
+        ]),
+        500_000,
+        BigNumber.from(previousProposal2.nonce)
+      );
+
+      previousSignatures = signatures = await governanceAdminInterface.generateSignatures(proposal);
+      previousSupports = supports = signatures.map(() => VoteType.For);
+
+      await governanceAdmin
+        .connect(trustedOrgs[0].governor)
+        .proposeProposalForCurrentNetwork(
+          proposal.expiryTimestamp,
+          proposal.targets,
+          proposal.values,
+          proposal.calldatas,
+          proposal.gasAmounts,
+          supports[0]
+        );
+
+      currentProposalVote = await governanceAdmin.vote(previousProposal2.chainId, previousProposal2.nonce);
+      expect(currentProposalVote.hash).not.eq(previousProposal2);
+      expect(currentProposalVote.status).eq(VoteStatus.Pending);
+
+      supports.splice(0, 1);
+      signatures.splice(0, 1);
+      await governanceAdmin.connect(trustedOrgs[0].governor).castProposalBySignatures(proposal, supports, signatures);
+      currentProposalVote = await governanceAdmin.vote(previousProposal2.chainId, previousProposal2.nonce);
       expect(currentProposalVote.status).eq(VoteStatus.Executed);
 
       previousProposal = proposal;

--- a/test/governance-admin/GovernanceAdmin.test.ts
+++ b/test/governance-admin/GovernanceAdmin.test.ts
@@ -738,7 +738,7 @@ describe('Governance Admin test', () => {
         await network.provider.send('evm_revert', [snapshotId]);
       });
 
-      it("Should be able to clear when it' is expired", async () => {
+      it('Should be able to clear the proposal when it is expired', async () => {
         expect(
           await governanceAdmin.connect(trustedOrgs[0].governor).deleteExpired(proposal.chainId, proposal.nonce)
         ).emit(governanceAdmin, 'ProposalExpired');


### PR DESCRIPTION
### Description

https://skymavis.atlassian.net/browse/PSC-177?atlOrigin=eyJpIjoiZTBiNzJlNDhhYzI1NGQwOWE3MzQ4ZGVlMmYzZjBjYmIiLCJwIjoiaiJ9

New proposal can be created by these following methods:
1. `proposeProposalStructAndCastVotes`
2. `proposeProposalForCurrentNetwork`
3. `proposeGlobal`
4. `proposeGlobalProposalStructAndCastVotes`

All methods except the first one calculate incorrect `round` number when the proposal with previous round number is expired. This PR fixes this by checking whether the previous proposal is expired and updating the `round` number accordingly.

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
