### PR TITLE
[Staking] Validator commission rate must not exceed 20%

### DIFF
--- a/contracts/interfaces/staking/ICandidateStaking.sol
+++ b/contracts/interfaces/staking/ICandidateStaking.sol
@@ -49,12 +49,17 @@ interface ICandidateStaking is IRewardPool {
   /// @dev Error of unstaking too early.
   error ErrUnstakeTooEarly();
   /// @dev Error of setting commission rate exceeds max allowed.
-  error ErrExceedsMaxCommissionRate();
+  error ErrInvalidCommissionRate();
 
   /**
    * @dev Returns the minimum threshold for being a validator candidate.
    */
   function minValidatorStakingAmount() external view returns (uint256);
+
+  /**
+   * @dev Returns the max commission rate that the candidate can set.
+   */
+  function maxCommissionRate() external view returns (uint256);
 
   /**
    * @dev Sets the minimum threshold for being a validator candidate.
@@ -66,6 +71,17 @@ interface ICandidateStaking is IRewardPool {
    *
    */
   function setMinValidatorStakingAmount(uint256) external;
+
+  /**
+   * @dev Sets the max commission rate that a candidate can set.
+   *
+   * Requirements:
+   * - The method caller is admin.
+   *
+   * Emits the `MaxCommissionRateUpdated` event.
+   *
+   */
+  function setMaxCommissionRate(uint256 _maxRate) external;
 
   /**
    * @dev Proposes a candidate to become a validator.

--- a/contracts/interfaces/staking/ICandidateStaking.sol
+++ b/contracts/interfaces/staking/ICandidateStaking.sol
@@ -7,6 +7,8 @@ import "./IRewardPool.sol";
 interface ICandidateStaking is IRewardPool {
   /// @dev Emitted when the minimum staking amount for being a validator is updated.
   event MinValidatorStakingAmountUpdated(uint256 threshold);
+  /// @dev Emitted when the max commission rate is updated.
+  event MaxCommissionRateUpdated(uint256 maxRate);
 
   /// @dev Emitted when the pool admin staked for themself.
   event Staked(address indexed consensuAddr, uint256 amount);
@@ -46,6 +48,8 @@ interface ICandidateStaking is IRewardPool {
   error ErrInsufficientStakingAmount();
   /// @dev Error of unstaking too early.
   error ErrUnstakeTooEarly();
+  /// @dev Error of setting commission rate exceeds max allowed.
+  error ErrExceedsMaxCommissionRate();
 
   /**
    * @dev Returns the minimum threshold for being a validator candidate.

--- a/contracts/ronin/staking/Staking.sol
+++ b/contracts/ronin/staking/Staking.sol
@@ -23,11 +23,13 @@ contract Staking is IStaking, CandidateStaking, DelegatorStaking, Initializable 
   function initialize(
     address __validatorContract,
     uint256 __minValidatorStakingAmount,
+    uint256 __maxCommissionRate,
     uint256 __cooldownSecsToUndelegate,
     uint256 __waitingSecsToRevoke
   ) external initializer {
     _setValidatorContract(__validatorContract);
     _setMinValidatorStakingAmount(__minValidatorStakingAmount);
+    _setMaxCommissionRate(__maxCommissionRate);
     _setCooldownSecsToUndelegate(__cooldownSecsToUndelegate);
     _setWaitingSecsToRevoke(__waitingSecsToRevoke);
   }

--- a/contracts/ronin/validator/CoinbaseExecution.sol
+++ b/contracts/ronin/validator/CoinbaseExecution.sol
@@ -83,7 +83,8 @@ abstract contract CoinbaseExecution is
     }
 
     _reward -= _cutOffReward;
-    uint256 _rate = _candidateInfo[_coinbaseAddr].commissionRate;
+    uint256 _maxRate = _stakingContract.maxCommissionRate();
+    uint256 _rate = Math.min(_candidateInfo[_coinbaseAddr].commissionRate, _maxRate);
     uint256 _miningAmount = (_rate * _reward) / _MAX_PERCENTAGE;
     _miningReward[_coinbaseAddr] += _miningAmount;
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -82,7 +82,7 @@ export const maintenanceConf: MaintenanceConfig = {
 
 const defaultStakingConf: StakingArguments = {
   minValidatorStakingAmount: BigNumber.from(10).pow(18).mul(BigNumber.from(10).pow(5)), // 100.000 RON
-  maxCommissionRate: 10_00, // 10%
+  maxCommissionRate: 20_00, // 20%
   cooldownSecsToUndelegate: 3 * 86400, // at least 3 days
   waitingSecsToRevoke: 7 * 86400, // at least 7 days
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -82,6 +82,7 @@ export const maintenanceConf: MaintenanceConfig = {
 
 const defaultStakingConf: StakingArguments = {
   minValidatorStakingAmount: BigNumber.from(10).pow(18).mul(BigNumber.from(10).pow(5)), // 100.000 RON
+  maxCommissionRate: 10_00, // 10%
   cooldownSecsToUndelegate: 3 * 86400, // at least 3 days
   waitingSecsToRevoke: 7 * 86400, // at least 7 days
 };

--- a/src/deploy/proxy/staking-proxy.ts
+++ b/src/deploy/proxy/staking-proxy.ts
@@ -18,6 +18,7 @@ const deploy = async ({ getNamedAccounts, deployments }: HardhatRuntimeEnvironme
   const data = new Staking__factory().interface.encodeFunctionData('initialize', [
     generalRoninConf[network.name]!.validatorContract?.address,
     stakingConfig[network.name]!.minValidatorStakingAmount,
+    stakingConfig[network.name]!.maxCommissionRate,
     stakingConfig[network.name]!.cooldownSecsToUndelegate,
     stakingConfig[network.name]!.waitingSecsToRevoke,
   ]);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -88,6 +88,7 @@ export interface MaintenanceConfig {
 
 export interface StakingArguments {
   minValidatorStakingAmount?: BigNumberish;
+  maxCommissionRate?: BigNumberish;
   cooldownSecsToUndelegate?: BigNumberish;
   waitingSecsToRevoke?: BigNumberish;
 }

--- a/test/helpers/fixture.ts
+++ b/test/helpers/fixture.ts
@@ -68,6 +68,7 @@ export const defaultTestConfig: InitTestInput = {
 
   stakingArguments: {
     minValidatorStakingAmount: BigNumber.from(100),
+    maxCommissionRate: 100_00,
     cooldownSecsToUndelegate: 3 * 86400,
     waitingSecsToRevoke: 7 * 86400,
   },

--- a/test/staking/Staking.test.ts
+++ b/test/staking/Staking.test.ts
@@ -237,6 +237,18 @@ describe('Staking test', () => {
       ).revertedWithCustomError(validatorContract, 'ErrInvalidCommissionRate');
     });
 
+    it('Should the pool admin not be able to request updating the commission rate exceeding max rate', async () => {
+      await expect(
+        stakingContract
+          .connect(poolAddrSet.poolAdmin)
+          .requestUpdateCommissionRate(
+            poolAddrSet.consensusAddr.address,
+            minEffectiveDaysOnwards,
+            maxCommissionRate + 1
+          )
+      ).revertedWithCustomError(stakingContract, 'ErrInvalidCommissionRate');
+    });
+
     it('Should the pool admin be able to request updating the commission rate', async () => {
       let _info = await validatorContract.getCandidateInfo(poolAddrSet.consensusAddr.address);
       let _previousRate = _info.commissionRate;

--- a/test/staking/Staking.test.ts
+++ b/test/staking/Staking.test.ts
@@ -34,6 +34,7 @@ const maxValidatorCandidate = 50;
 const numberOfBlocksInEpoch = 2;
 const cooldownSecsToUndelegate = 3 * 86400;
 const waitingSecsToRevoke = 7 * 86400;
+const maxCommissionRate = 30_00;
 const minEffectiveDaysOnwards = 7;
 const numberOfCandidate = 4;
 
@@ -63,6 +64,7 @@ describe('Staking test', () => {
       logicContract.interface.encodeFunctionData('initialize', [
         validatorContract.address,
         minValidatorStakingAmount,
+        maxCommissionRate,
         cooldownSecsToUndelegate,
         waitingSecsToRevoke,
       ])
@@ -223,6 +225,16 @@ describe('Staking test', () => {
           20_00 // 20%
         )
       ).revertedWithCustomError(validatorContract, 'ErrInvalidEffectiveDaysOnwards');
+    });
+
+    it('Should the pool admin not be able to request updating the commission rate higher than max rate allowed', async () => {
+      await expect(
+        stakingContract.connect(poolAddrSet.poolAdmin).requestUpdateCommissionRate(
+          poolAddrSet.consensusAddr.address,
+          minEffectiveDaysOnwards - 1,
+          maxCommissionRate + 1 // 20%
+        )
+      ).revertedWithCustomError(validatorContract, 'ErrInvalidCommissionRate');
     });
 
     it('Should the pool admin be able to request updating the commission rate', async () => {

--- a/test/validator/RoninValidatorSet-Candidate.test.ts
+++ b/test/validator/RoninValidatorSet-Candidate.test.ts
@@ -65,6 +65,7 @@ const bridgeOperatorBonusPerBlock = BigNumber.from(37);
 const zeroTopUpAmount = 0;
 const topUpAmount = BigNumber.from(100_000_000_000);
 const slashDoubleSignAmount = BigNumber.from(2000);
+const maxCommissionRate = 30_00; // 30%
 
 describe('Ronin Validator Set: candidate test', () => {
   before(async () => {
@@ -97,6 +98,7 @@ describe('Ronin Validator Set: candidate test', () => {
       },
       stakingArguments: {
         minValidatorStakingAmount,
+        maxCommissionRate,
       },
       stakingVestingArguments: {
         blockProducerBonusPerBlock,
@@ -294,6 +296,23 @@ describe('Ronin Validator Set: candidate test', () => {
       await expect(tx)
         .revertedWithCustomError(roninValidatorSet, 'ErrExistentBridgeOperator')
         .withArgs(validatorCandidates[0].bridgeOperator.address);
+    });
+
+    it('Should not be able to apply for candidate role with commission rate higher than allowed', async () => {
+      let tx = stakingContract
+        .connect(validatorCandidates[5].poolAdmin)
+        .applyValidatorCandidate(
+          validatorCandidates[5].candidateAdmin.address,
+          validatorCandidates[5].consensusAddr.address,
+          validatorCandidates[5].treasuryAddr.address,
+          validatorCandidates[5].bridgeOperator.address,
+          maxCommissionRate + 1,
+          {
+            value: minValidatorStakingAmount,
+          }
+        );
+
+      await expect(tx).revertedWithCustomError(stakingContract, 'ErrInvalidCommissionRate');
     });
   });
 


### PR DESCRIPTION
### Description

Validator commission rate must not exceed 20%

### Contract changes

The table below shows the following info:
- **ABI**: the ABI is changed.
- **Init data**: new storage field is declared and needs initializing.
- **Dependent**: needs to be changed due to changes in other contracts.

| **Contract name** | **Logic** | **ABI** | **Init data** | **Dependent** |
| ----------------- | :-------: | :-----: | :-----------: | :-----------: |
| BridgeTracking    |       |         |               |               |
| GovernanceAdmin   |           |         |               |               |
| Maintenance       |           |         |               |               |
| SlashIndicator    |           |         |               |               |
| Staking           |    [x]    |   [x]   |      [x]      |               |
| StakingVesting    |           |         |               |               |
| ValidatorSet      |           |         |               |               |

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
