### PR TITLE
[Maintenance] Prevent second schedule within 3 days from the previous schedule

### DIFF
--- a/contracts/interfaces/IMaintenance.sol
+++ b/contracts/interfaces/IMaintenance.sol
@@ -7,6 +7,7 @@ interface IMaintenance {
     uint256 from;
     uint256 to;
     uint256 lastUpdatedBlock;
+    uint256 requestTimestamp;
   }
 
   /// @dev Emitted when a maintenance is scheduled.
@@ -19,7 +20,8 @@ interface IMaintenance {
     uint256 maxMaintenanceDurationInBlock,
     uint256 minOffsetToStartSchedule,
     uint256 maxOffsetToStartSchedule,
-    uint256 maxSchedules
+    uint256 maxSchedules,
+    uint256 cooldownSecsToMaintain
   );
 
   /**
@@ -56,6 +58,11 @@ interface IMaintenance {
   function checkScheduled(address _consensusAddr) external view returns (bool);
 
   /**
+   * @dev Returns whether the validator `_consensusAddr`
+   */
+  function checkCooldownEnds(address _consensusAddr) external view returns (bool);
+
+  /**
    * @dev Returns the detailed schedule of the validator `_consensusAddr`.
    */
   function getSchedule(address _consensusAddr) external view returns (Schedule memory);
@@ -81,7 +88,8 @@ interface IMaintenance {
     uint256 _maxMaintenanceDurationInBlock,
     uint256 _minOffsetToStartSchedule,
     uint256 _maxOffsetToStartSchedule,
-    uint256 _maxSchedules
+    uint256 _maxSchedules,
+    uint256 _cooldownSecsToMaintain
   ) external;
 
   /**

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -108,6 +108,9 @@ const config: HardhatUserConfig = {
     enabled: REPORT_GAS ? true : false,
     showTimeSpent: true,
   },
+  mocha: {
+    timeout: 100000, // 100s
+  },
 };
 
 export default config;

--- a/src/config.ts
+++ b/src/config.ts
@@ -67,6 +67,7 @@ const defaultMaintenanceConf: MaintenanceArguments = {
   minOffsetToStartSchedule: 28800, // requests before maintaining at least ~1 day
   maxOffsetToStartSchedule: 28800 * 7, // requests before maintaining at most ~7 day
   maxSchedules: 3, // only 3 schedules are happening|in the futures
+  cooldownSecsToMaintain: 86400 * 3, // request next maintenance must wait at least 3 days.
 };
 
 // TODO: update config for testnet & mainnet

--- a/src/deploy/proxy/maintenance-proxy.ts
+++ b/src/deploy/proxy/maintenance-proxy.ts
@@ -22,6 +22,7 @@ const deploy = async ({ getNamedAccounts, deployments }: HardhatRuntimeEnvironme
     maintenanceConf[network.name]!.minOffsetToStartSchedule,
     maintenanceConf[network.name]!.maxOffsetToStartSchedule,
     maintenanceConf[network.name]!.maxSchedules,
+    maintenanceConf[network.name]!.cooldownSecsToMaintain,
   ]);
 
   const deployment = await deploy('MaintenanceProxy', {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -70,6 +70,7 @@ export interface MaintenanceArguments {
   minOffsetToStartSchedule?: BigNumberish;
   maxOffsetToStartSchedule?: BigNumberish;
   maxSchedules?: BigNumberish;
+  cooldownSecsToMaintain?: BigNumberish;
 }
 
 export interface RoninTrustedOrganizationArguments {

--- a/test/helpers/fixture.ts
+++ b/test/helpers/fixture.ts
@@ -64,6 +64,7 @@ export const defaultTestConfig: InitTestInput = {
     minOffsetToStartSchedule: 200,
     maxOffsetToStartSchedule: 200 * 7,
     maxSchedules: 2,
+    cooldownSecsToMaintain: 86400 * 3,
   },
 
   stakingArguments: {


### PR DESCRIPTION
### Description

https://skymavis.atlassian.net/browse/PSC-179?atlOrigin=eyJpIjoiYWZhMmVhMDA0YjExNDVkNjhlODA0YzNkZDcxYWMxZjEiLCJwIjoiaiJ9

- Prevent the second schedule within 3 days from the previous schedule
- Increase test timeout

### Contract changes

The table below shows the following info:
- **ABI**: the ABI is changed.
- **Init data**: new storage field is declared and needs initializing.
- **Dependent**: needs to be changed due to changes in other contracts.

| **Contract name** | **ABI** | **Init data** | **Dependent** |
|-------------------|:-------:|:-------------:|:-------------:|
| BridgeTracking    |         |               |               |
| GovernanceAdmin   |         |               |               |
| Maintenance       |  [x]    |    [x]           |               |
| SlashIndicator    |         |               |               |
| Staking           |        |              |               |
| StakingVesting    |         |               |               |
| ValidatorSet      |         |               |               |

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
