### PR TITLE
[BridgeTracking] Redundant check of period number

### DIFF
--- a/contracts/ronin/BridgeTracking.sol
+++ b/contracts/ronin/BridgeTracking.sol
@@ -202,11 +202,7 @@ contract BridgeTracking is HasBridgeContract, HasValidatorContract, Initializabl
   function _trySyncPeriodStats() internal {
     uint256 _currentEpoch = _validatorContract.epochOf(block.number);
     if (_temporaryStats.lastEpoch < _currentEpoch) {
-      (bool _filled, uint256 _period) = _validatorContract.tryGetPeriodOfEpoch(_temporaryStats.lastEpoch + 1);
-      if (!_filled) {
-        return;
-      }
-
+      (, uint256 _period) = _validatorContract.tryGetPeriodOfEpoch(_temporaryStats.lastEpoch + 1);
       VoteStats storage _stats = _periodStats[_period];
       _stats.totalVotes += _temporaryStats.info.totalVotes;
       _stats.totalBallots += _temporaryStats.info.totalBallots;

--- a/contracts/ronin/validator/storage-fragments/TimingStorage.sol
+++ b/contracts/ronin/validator/storage-fragments/TimingStorage.sol
@@ -44,7 +44,7 @@ abstract contract TimingStorage is ITimingInfo {
    * @inheritdoc ITimingInfo
    */
   function tryGetPeriodOfEpoch(uint256 _epoch) external view returns (bool _filled, uint256 _periodNumber) {
-    return (_periodOf[_epoch] > 0, _periodOf[_epoch]);
+    return (_epoch <= epochOf(block.number) || _periodOf[_epoch] > 0, _periodOf[_epoch]);
   }
 
   /**

--- a/contracts/ronin/validator/storage-fragments/TimingStorage.sol
+++ b/contracts/ronin/validator/storage-fragments/TimingStorage.sol
@@ -44,7 +44,7 @@ abstract contract TimingStorage is ITimingInfo {
    * @inheritdoc ITimingInfo
    */
   function tryGetPeriodOfEpoch(uint256 _epoch) external view returns (bool _filled, uint256 _periodNumber) {
-    return (_epoch <= epochOf(block.number) || _periodOf[_epoch] > 0, _periodOf[_epoch]);
+    return (_periodOf[_epoch] > 0, _periodOf[_epoch]);
   }
 
   /**


### PR DESCRIPTION
### Description

Remove redundant check of period number.

### Contract changes

The table below shows the following info:
- **ABI**: the ABI is changed.
- **Init data**: new storage field is declared and needs initializing.
- **Dependent**: needs to be changed due to changes in other contracts.

| **Contract name** |**Logic**| **ABI** | **Init data** | **Dependent** |
|-------------------|:---:|:-------:|:-------------:|:-------------:|
| BridgeTracking    |    [x]|     |               |               |
| GovernanceAdmin   |     |    |               |               |
| Maintenance       |      |    |           |               |
| SlashIndicator    |         |  |             |               |
| Staking           |        |        |     |               |
| StakingVesting    |         |   |            |               |
| ValidatorSet      |    |     |          |               |

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works