### PR TITLE
[ValidatorSet] Validators May Have The Wrong Block Producer Status

### DIFF
--- a/contracts/ronin/validator/CoinbaseExecution.sol
+++ b/contracts/ronin/validator/CoinbaseExecution.sol
@@ -442,7 +442,7 @@ abstract contract CoinbaseExecution is
     uint256 _nextEpoch,
     address[] memory _currentValidators
   ) private {
-    bool[] memory _maintainedList = _maintenanceContract.checkManyMaintained(_candidates, block.number + 1);
+    bool[] memory _maintainedList = _maintenanceContract.checkManyMaintained(_currentValidators, block.number + 1);
 
     for (uint _i = 0; _i < _currentValidators.length; _i++) {
       address _validator = _currentValidators[_i];


### PR DESCRIPTION
### Description

Wrong args when calling `checkManyMaintained`

### Contract changes

The table below shows the following info:
- **Logic**: the logic is changed.
- **ABI**: the ABI is changed.
- **Init data**: new storage field is declared and needs initializing.
- **Dependent**: needs to be changed due to changes in other contracts.

| **Contract name** | **Logic** | **ABI** | **Init data** | **Dependent** |
|-------------------|:---------:|:-------:|:-------------:|:-------------:|
| BridgeTracking    |           |         |               |               |
| GovernanceAdmin   |           |         |               |               |
| Maintenance       |           |         |               |               |
| SlashIndicator    |           |         |               |               |
| Staking           |           |         |               |               |
| StakingVesting    |           |         |               |               |
| ValidatorSet      |      [x]     |         |               |               |

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
