### PR TITLE
[GA] For Loop Should Not Return Early When Casting Vote For Bridge Operators

### DIFF
--- a/contracts/extensions/isolated-governance/bridge-operator-governance/BOsGovernanceProposal.sol
+++ b/contracts/extensions/isolated-governance/bridge-operator-governance/BOsGovernanceProposal.sol
@@ -81,9 +81,7 @@ abstract contract BOsGovernanceProposal is SignatureConsumer, IsolatedGovernance
         _lastVotedBlock[_signer] = block.number;
         _info.signatureOf[_signer] = _signatures[_i];
         _info.voters.push(_signer);
-        if (_castVote(_v, _signer, _weight, _minimumVoteWeight, _hash) == VoteStatus.Approved) {
-          return;
-        }
+        _castVote(_v, _signer, _weight, _minimumVoteWeight, _hash);
       }
     }
 


### PR DESCRIPTION
### Description
Remove early return early and have all votes be processed

### Contract changes

The table below shows the following info:
- **Logic**: the logic is changed.
- **ABI**: the ABI is changed.
- **Init data**: new storage field is declared and needs initializing.
- **Dependent**: needs to be changed due to changes in other contracts.

| **Contract name** | **Logic** | **ABI** | **Init data** | **Dependent** |
|-------------------|:---------:|:-------:|:-------------:|:-------------:|
| BridgeTracking    |           |         |               |        [x]       |
| GovernanceAdmin   |    [x]       |         |               |               |
| Maintenance       |           |         |               |        [x]       |
| SlashIndicator    |           |         |               |        [x]       |
| Staking           |           |         |               |         [x]      |
| StakingVesting    |           |         |               |       [x]        |
| ValidatorSet      |           |         |               |        [x]       |

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
