### PR TITLE
[TrustedOrg] Lack of Check When Updating Trusted Organization

### DIFF
--- a/contracts/multi-chains/RoninTrustedOrganization.sol
+++ b/contracts/multi-chains/RoninTrustedOrganization.sol
@@ -263,7 +263,7 @@ contract RoninTrustedOrganization is IRoninTrustedOrganization, HasProxyAdmin, I
    */
   function _addTrustedOrganization(TrustedOrganization memory _v) internal virtual {
     require(_v.addedBlock == 0, "RoninTrustedOrganization: invalid request");
-    _sanityCheckTOData(_v);
+    _sanityCheckTrustedOrganizationData(_v);
 
     if (_consensusWeight[_v.consensusAddr] > 0) {
       revert(
@@ -324,7 +324,7 @@ contract RoninTrustedOrganization is IRoninTrustedOrganization, HasProxyAdmin, I
    *
    */
   function _updateTrustedOrganization(TrustedOrganization memory _v) internal virtual {
-    _sanityCheckTOData(_v);
+    _sanityCheckTrustedOrganizationData(_v);
 
     uint256 _weight = _consensusWeight[_v.consensusAddr];
     if (_weight == 0) {
@@ -433,7 +433,14 @@ contract RoninTrustedOrganization is IRoninTrustedOrganization, HasProxyAdmin, I
     emit ThresholdUpdated(_nonce++, _numerator, _denominator, _previousNum, _previousDenom);
   }
 
-  function _sanityCheckTOData(TrustedOrganization memory _v) private pure {
+  /**
+   * @dev Hook that checks trusted organization's data. Reverts if the requirements are not met.
+   *
+   * Requirements:
+   * - The weight must be larger than 0.
+   * - The consensus address, governor address, and bridge voter address are different.
+   */
+  function _sanityCheckTrustedOrganizationData(TrustedOrganization memory _v) private pure {
     require(_v.weight > 0, "RoninTrustedOrganization: invalid weight");
 
     address[] memory _addresses = new address[](3);

--- a/contracts/multi-chains/RoninTrustedOrganization.sol
+++ b/contracts/multi-chains/RoninTrustedOrganization.sol
@@ -263,13 +263,7 @@ contract RoninTrustedOrganization is IRoninTrustedOrganization, HasProxyAdmin, I
    */
   function _addTrustedOrganization(TrustedOrganization memory _v) internal virtual {
     require(_v.addedBlock == 0, "RoninTrustedOrganization: invalid request");
-    require(_v.weight > 0, "RoninTrustedOrganization: invalid weight");
-
-    address[] memory _addresses = new address[](3);
-    _addresses[0] = _v.consensusAddr;
-    _addresses[1] = _v.governor;
-    _addresses[2] = _v.bridgeVoter;
-    require(!AddressArrayUtils.hasDuplicate(_addresses), "RoninTrustedOrganization: three addresses must be distinct");
+    _sanityCheckTOData(_v);
 
     if (_consensusWeight[_v.consensusAddr] > 0) {
       revert(
@@ -330,7 +324,7 @@ contract RoninTrustedOrganization is IRoninTrustedOrganization, HasProxyAdmin, I
    *
    */
   function _updateTrustedOrganization(TrustedOrganization memory _v) internal virtual {
-    require(_v.weight > 0, "RoninTrustedOrganization: invalid weight");
+    _sanityCheckTOData(_v);
 
     uint256 _weight = _consensusWeight[_v.consensusAddr];
     if (_weight == 0) {
@@ -437,5 +431,15 @@ contract RoninTrustedOrganization is IRoninTrustedOrganization, HasProxyAdmin, I
     _num = _numerator;
     _denom = _denominator;
     emit ThresholdUpdated(_nonce++, _numerator, _denominator, _previousNum, _previousDenom);
+  }
+
+  function _sanityCheckTOData(TrustedOrganization memory _v) private pure {
+    require(_v.weight > 0, "RoninTrustedOrganization: invalid weight");
+
+    address[] memory _addresses = new address[](3);
+    _addresses[0] = _v.consensusAddr;
+    _addresses[1] = _v.governor;
+    _addresses[2] = _v.bridgeVoter;
+    require(!AddressArrayUtils.hasDuplicate(_addresses), "RoninTrustedOrganization: three addresses must be distinct");
   }
 }


### PR DESCRIPTION
### Description
- Adds a check when updating a trusted organization to ensure that the consensus, governor, and bridge voter addresses are all distinct from each other in `updateTrustedOrganizations` method.

### Contract changes

The table below shows the following info:
- **Logic**: the logic is changed.
- **ABI**: the ABI is changed.
- **Init data**: new storage field is declared and needs initializing.
- **Dependent**: needs to be changed due to changes in other contracts.

| **Contract name** | **Logic** | **ABI** | **Init data** | **Dependent** |
|-------------------|:---------:|:-------:|:-------------:|:-------------:|
| BridgeTracking    |           |         |               |               |
| GovernanceAdmin   |           |         |               |               |
| Maintenance       |           |         |               |               |
| SlashIndicator    |           |         |               |               |
| Staking           |           |         |               |               |
| StakingVesting    |           |         |               |               |
| RoninTrustedOrganization      |     [x]      |         |               |               |
| ValidatorSet      |           |         |               |               |

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
