### PR TITLE
[RoninGateway] Fix Reentrancy Attack

### DIFF
--- a/contracts/ronin/RoninGatewayV2.sol
+++ b/contracts/ronin/RoninGatewayV2.sol
@@ -201,8 +201,8 @@ contract RoninGatewayV2 is
         bytes32 _hash = _withdrawal.hash();
         VoteStatus _status = _castVote(_proposal, _governor, _weight, _minVoteWeight, _hash);
         if (_status == VoteStatus.Approved) {
-          _bridgeTrackingContract.handleVoteApproved(IBridgeTracking.VoteKind.MainchainWithdrawal, _withdrawalId);
           _proposal.status = VoteStatus.Executed;
+          _bridgeTrackingContract.handleVoteApproved(IBridgeTracking.VoteKind.MainchainWithdrawal, _withdrawalId);
           emit MainchainWithdrew(_hash, _withdrawal);
         }
       }
@@ -280,8 +280,8 @@ contract RoninGatewayV2 is
       IsolatedVote storage _proposal = withdrawalStatVote[_id];
       VoteStatus _status = _castVote(_proposal, _validator, _weight, _minVoteWeight, bytes32(_id));
       if (_status == VoteStatus.Approved) {
-        _bridgeTrackingContract.handleVoteApproved(IBridgeTracking.VoteKind.Withdrawal, _id);
         _proposal.status = VoteStatus.Executed;
+        _bridgeTrackingContract.handleVoteApproved(IBridgeTracking.VoteKind.Withdrawal, _id);
       }
     }
   }
@@ -386,9 +386,9 @@ contract RoninGatewayV2 is
     bytes32 _receiptHash = _receipt.hash();
     VoteStatus _status = _castVote(_proposal, _validator, _weight, _minVoteWeight, _receiptHash);
     if (_status == VoteStatus.Approved) {
-      _bridgeTrackingContract.handleVoteApproved(IBridgeTracking.VoteKind.Deposit, _receipt.id);
       _proposal.status = VoteStatus.Executed;
       _receipt.info.handleAssetTransfer(payable(_receipt.ronin.addr), _receipt.ronin.tokenAddr, IWETH(address(0)));
+      _bridgeTrackingContract.handleVoteApproved(IBridgeTracking.VoteKind.Deposit, _receipt.id);
       emit Deposited(_receiptHash, _receipt);
     }
   }


### PR DESCRIPTION
### Description

Apply [Checks-Effects-Interactions Pattern](https://docs.soliditylang.org/en/v0.6.12/security-considerations.html#use-the-checks-effects-interactions-pattern) on all calls to `bridgeTrackingContract.handleVoteApproved`

### Contract changes

The table below shows the following info:
- **Logic**: the logic is changed.
- **ABI**: the ABI is changed.
- **Init data**: new storage field is declared and needs initializing.
- **Dependent**: needs to be changed due to changes in other contracts.

| **Contract name** | **Logic** | **ABI** | **Init data** | **Dependent** |
|-------------------|:---------:|:-------:|:-------------:|:-------------:|
| BridgeTracking    |           |         |               |               |
| GovernanceAdmin   |           |         |               |               |
| Maintenance       |           |         |               |               |
| SlashIndicator    |           |         |               |               |
| Staking           |           |         |               |               |
| StakingVesting    |           |         |               |               |
| ValidatorSet      |           |         |               |               |
| RoninGateway |    [x]  | | | |

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
