### PR TITLE
[SlashIndicator] Fix setter in bridge voting configs

### DIFF
--- a/contracts/ronin/slash-indicator/SlashBridgeVoting.sol
+++ b/contracts/ronin/slash-indicator/SlashBridgeVoting.sol
@@ -66,7 +66,7 @@ abstract contract SlashBridgeVoting is
    */
   function _setBridgeVotingSlashingConfigs(uint256 _threshold, uint256 _slashAmount) internal {
     _bridgeVotingThreshold = _threshold;
-    _slashAmount = _bridgeVotingSlashAmount;
+    _bridgeVotingSlashAmount = _slashAmount;
     emit BridgeVotingSlashingConfigsUpdated(_threshold, _slashAmount);
   }
 }

--- a/test/integration/Configuration.test.ts
+++ b/test/integration/Configuration.test.ts
@@ -85,6 +85,12 @@ const config: InitTestInput = {
       slashAmountForUnavailabilityTier2Threshold: BigNumber.from(10).pow(18).mul(1),
       jailDurationForUnavailabilityTier2Threshold: 28800 * 2,
     },
+    creditScore: {
+      gainCreditScore: 50,
+      maxCreditScore: 600,
+      bailOutCostMultiplier: 5,
+      cutOffPercentageAfterBailout: 50_00, // 50%
+    },
   },
   roninValidatorSetArguments: {
     maxValidatorNumber: 4,
@@ -218,6 +224,34 @@ describe('[Integration] Configuration check', () => {
         config.slashIndicatorArguments?.bridgeOperatorSlashing?.missingVotesRatioTier2,
         config.slashIndicatorArguments?.bridgeOperatorSlashing?.jailDurationForMissingVotesRatioTier2,
         config.slashIndicatorArguments?.bridgeOperatorSlashing?.skipBridgeOperatorSlashingThreshold,
+      ].map(BigNumber.from)
+    );
+    expect(await slashContract.getBridgeVotingSlashingConfigs()).to.eql(
+      [
+        config.slashIndicatorArguments?.bridgeVotingSlashing?.bridgeVotingThreshold,
+        config.slashIndicatorArguments?.bridgeVotingSlashing?.bridgeVotingSlashAmount,
+      ].map(BigNumber.from)
+    );
+    expect(await slashContract.getDoubleSignSlashingConfigs()).to.eql(
+      [
+        config.slashIndicatorArguments?.doubleSignSlashing?.slashDoubleSignAmount,
+        config.slashIndicatorArguments?.doubleSignSlashing?.doubleSigningJailUntilBlock,
+      ].map(BigNumber.from)
+    );
+    expect(await slashContract.getUnavailabilitySlashingConfigs()).to.eql(
+      [
+        config.slashIndicatorArguments?.unavailabilitySlashing?.unavailabilityTier1Threshold,
+        config.slashIndicatorArguments?.unavailabilitySlashing?.unavailabilityTier2Threshold,
+        config.slashIndicatorArguments?.unavailabilitySlashing?.slashAmountForUnavailabilityTier2Threshold,
+        config.slashIndicatorArguments?.unavailabilitySlashing?.jailDurationForUnavailabilityTier2Threshold,
+      ].map(BigNumber.from)
+    );
+    expect(await slashContract.getCreditScoreConfigs()).to.eql(
+      [
+        config.slashIndicatorArguments?.creditScore?.gainCreditScore,
+        config.slashIndicatorArguments?.creditScore?.maxCreditScore,
+        config.slashIndicatorArguments?.creditScore?.bailOutCostMultiplier,
+        config.slashIndicatorArguments?.creditScore?.cutOffPercentageAfterBailout,
       ].map(BigNumber.from)
     );
   });


### PR DESCRIPTION
### Description

### Contract changes

The table below shows the following info:
- **Logic**: the logic is changed.
- **ABI**: the ABI is changed.
- **Init data**: new storage field is declared and needs initializing.
- **Dependent**: needs to be changed due to changes in other contracts.

| **Contract name** | **Logic** | **ABI** | **Init data** | **Dependent** |
|-------------------|:---------:|:-------:|:-------------:|:-------------:|
| BridgeTracking    |           |         |               |               |
| GovernanceAdmin   |           |         |               |               |
| Maintenance       |           |         |               |               |
| SlashIndicator    |     [x]      |         |               |               |
| Staking           |           |         |               |               |
| StakingVesting    |           |         |               |               |
| ValidatorSet      |           |         |               |               |

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
