### PR TITLE
[SlashIndicator] Improve slash double sign

### DIFF
--- a/contracts/interfaces/slash-indicator/ISlashDoubleSign.sol
+++ b/contracts/interfaces/slash-indicator/ISlashDoubleSign.sol
@@ -9,7 +9,11 @@ interface ISlashDoubleSign is IBaseSlash {
    * @dev Emitted when the configs to slash double sign is updated. See the method `getDoubleSignSlashingConfigs`
    * for param details.
    */
-  event DoubleSignSlashingConfigsUpdated(uint256 slashDoubleSignAmount, uint256 doubleSigningJailUntilBlock);
+  event DoubleSignSlashingConfigsUpdated(
+    uint256 slashDoubleSignAmount,
+    uint256 doubleSigningJailUntilBlock,
+    uint256 doubleSigningOffsetLimitBlock
+  );
 
   /**
    * @dev Slashes for double signing.
@@ -31,12 +35,18 @@ interface ISlashDoubleSign is IBaseSlash {
    * @return _slashDoubleSignAmount The amount of RON to slash double sign.
    * @return _doubleSigningJailUntilBlock The block number that the punished validator will be jailed until, due to
    * double signing.
+   * @param _doubleSigningOffsetLimitBlock The number of block that the current block is at most far from the double
+   * signing block.
    *
    */
   function getDoubleSignSlashingConfigs()
     external
     view
-    returns (uint256 _slashDoubleSignAmount, uint256 _doubleSigningJailUntilBlock);
+    returns (
+      uint256 _slashDoubleSignAmount,
+      uint256 _doubleSigningJailUntilBlock,
+      uint256 _doubleSigningOffsetLimitBlock
+    );
 
   /**
    * @dev Sets the configs to slash block producers.
@@ -48,7 +58,13 @@ interface ISlashDoubleSign is IBaseSlash {
    *
    * @param _slashAmount The amount of RON to slash double sign.
    * @param _jailUntilBlock The block number that the punished validator will be jailed until, due to double signing.
+   * @param _doubleSigningOffsetLimitBlock The number of block that the current block is at most far from the double
+   * signing block.
    *
    */
-  function setDoubleSignSlashingConfigs(uint256 _slashAmount, uint256 _jailUntilBlock) external;
+  function setDoubleSignSlashingConfigs(
+    uint256 _slashAmount,
+    uint256 _jailUntilBlock,
+    uint256 _doubleSigningOffsetLimitBlock
+  ) external;
 }

--- a/contracts/mocks/MockPrecompile.sol
+++ b/contracts/mocks/MockPrecompile.sol
@@ -15,6 +15,7 @@ contract MockPrecompile {
   }
 
   function validatingDoubleSignProof(
+    address, /*consensusAddr*/
     bytes calldata, /*_header1*/
     bytes calldata /*_header2*/
   ) public pure returns (bool _validEvidence) {

--- a/contracts/mocks/MockSlashIndicatorExtended.sol
+++ b/contracts/mocks/MockSlashIndicatorExtended.sol
@@ -14,12 +14,11 @@ contract MockSlashIndicatorExtended is SlashIndicator, MockPrecompile {
     _validatorContract.execSlash(_validatorAddr, 0, 0, false);
   }
 
-  function _pcValidateEvidence(bytes calldata _header1, bytes calldata _header2)
-    internal
-    pure
-    override
-    returns (bool _validEvidence)
-  {
-    return validatingDoubleSignProof(_header1, _header2);
+  function _pcValidateEvidence(
+    address _consensusAddr,
+    bytes calldata _header1,
+    bytes calldata _header2
+  ) internal pure override returns (bool _validEvidence) {
+    return validatingDoubleSignProof(_consensusAddr, _header1, _header2);
   }
 }

--- a/contracts/mocks/precompile-usages/MockPCUValidateDoubleSign.sol
+++ b/contracts/mocks/precompile-usages/MockPCUValidateDoubleSign.sol
@@ -19,7 +19,11 @@ contract MockPCUValidateDoubleSign is PCUValidateDoubleSign {
     return _precompileValidateDoubleSignAddress;
   }
 
-  function callPrecompile(bytes calldata _header1, bytes calldata _header2) public view returns (bool) {
-    return _pcValidateEvidence(_header1, _header2);
+  function callPrecompile(
+    address _consensusAddr,
+    bytes calldata _header1,
+    bytes calldata _header2
+  ) public view returns (bool) {
+    return _pcValidateEvidence(_consensusAddr, _header1, _header2);
   }
 }

--- a/contracts/precompile-usages/PCUValidateDoubleSign.sol
+++ b/contracts/precompile-usages/PCUValidateDoubleSign.sol
@@ -16,16 +16,20 @@ abstract contract PCUValidateDoubleSign is PrecompiledUsage {
    * Note: The recover process is done by pre-compiled contract. This function is marked as
    * virtual for implementing mocking contract for testing purpose.
    */
-  function _pcValidateEvidence(bytes calldata _header1, bytes calldata _header2)
-    internal
-    view
-    virtual
-    returns (bool _validEvidence)
-  {
+  function _pcValidateEvidence(
+    address _consensusAddr,
+    bytes calldata _header1,
+    bytes calldata _header2
+  ) internal view virtual returns (bool _validEvidence) {
     address _smc = precompileValidateDoubleSignAddress();
     bool _success = true;
 
-    bytes memory _payload = abi.encodeWithSignature("validatingDoubleSignProof(bytes,bytes)", _header1, _header2);
+    bytes memory _payload = abi.encodeWithSignature(
+      "validatingDoubleSignProof(address,bytes,bytes)",
+      _consensusAddr,
+      _header1,
+      _header2
+    );
     uint _payloadLength = _payload.length;
     uint[1] memory _output;
 

--- a/contracts/ronin/slash-indicator/SlashDoubleSign.sol
+++ b/contracts/ronin/slash-indicator/SlashDoubleSign.sol
@@ -11,12 +11,14 @@ abstract contract SlashDoubleSign is ISlashDoubleSign, HasValidatorContract, PCU
   uint256 internal _slashDoubleSignAmount;
   /// @dev The block number that the punished validator will be jailed until, due to double signing.
   uint256 internal _doubleSigningJailUntilBlock;
+  /// @dev Recording of submitted proof to prevent relay attack.
+  mapping(bytes32 => bool) _submittedEvidence;
 
   /**
    * @dev This empty reserved space is put in place to allow future versions to add new
    * variables without shifting down storage in the inheritance chain.
    */
-  uint256[50] private ______gap;
+  uint256[49] private ______gap;
 
   /**
    * @inheritdoc ISlashDoubleSign
@@ -26,12 +28,20 @@ abstract contract SlashDoubleSign is ISlashDoubleSign, HasValidatorContract, PCU
     bytes calldata _header1,
     bytes calldata _header2
   ) external override onlyAdmin {
-    if (!_shouldSlash(_consensusAddr)) {
-      return;
-    }
+    require(_shouldSlash(_consensusAddr), "SlashDoubleSign: invalid slashee");
+
+    bytes32 _header1Checksum = keccak256(_header1);
+    bytes32 _header2Checksum = keccak256(_header2);
+
+    require(
+      !_submittedEvidence[_header1Checksum] && !_submittedEvidence[_header2Checksum],
+      "SlashDoubleSign: evidence already submitted"
+    );
 
     if (_pcValidateEvidence(_header1, _header2)) {
       uint256 _period = _validatorContract.currentPeriod();
+      _submittedEvidence[_header1Checksum] = true;
+      _submittedEvidence[_header2Checksum] = true;
       emit Slashed(_consensusAddr, SlashType.DOUBLE_SIGNING, _period);
       _validatorContract.execSlash(_consensusAddr, _doubleSigningJailUntilBlock, _slashDoubleSignAmount, true);
     }

--- a/contracts/ronin/slash-indicator/SlashDoubleSign.sol
+++ b/contracts/ronin/slash-indicator/SlashDoubleSign.sol
@@ -22,19 +22,18 @@ abstract contract SlashDoubleSign is ISlashDoubleSign, HasValidatorContract, PCU
    * @inheritdoc ISlashDoubleSign
    */
   function slashDoubleSign(
-    address _consensuAddr,
+    address _consensusAddr,
     bytes calldata _header1,
     bytes calldata _header2
   ) external override {
-    require(msg.sender == block.coinbase, "SlashIndicator: method caller must be coinbase");
-    if (!_shouldSlash(_consensuAddr)) {
+    if (!_shouldSlash(_consensusAddr)) {
       return;
     }
 
     if (_pcValidateEvidence(_header1, _header2)) {
       uint256 _period = _validatorContract.currentPeriod();
-      emit Slashed(_consensuAddr, SlashType.DOUBLE_SIGNING, _period);
-      _validatorContract.execSlash(_consensuAddr, _doubleSigningJailUntilBlock, _slashDoubleSignAmount, false);
+      emit Slashed(_consensusAddr, SlashType.DOUBLE_SIGNING, _period);
+      _validatorContract.execSlash(_consensusAddr, _doubleSigningJailUntilBlock, _slashDoubleSignAmount, false);
     }
   }
 

--- a/contracts/ronin/slash-indicator/SlashDoubleSign.sol
+++ b/contracts/ronin/slash-indicator/SlashDoubleSign.sol
@@ -22,7 +22,7 @@ abstract contract SlashDoubleSign is ISlashDoubleSign, HasValidatorContract, PCU
    * @dev This empty reserved space is put in place to allow future versions to add new
    * variables without shifting down storage in the inheritance chain.
    */
-  uint256[49] private ______gap;
+  uint256[48] private ______gap;
 
   /**
    * @inheritdoc ISlashDoubleSign

--- a/contracts/ronin/slash-indicator/SlashDoubleSign.sol
+++ b/contracts/ronin/slash-indicator/SlashDoubleSign.sol
@@ -15,14 +15,12 @@ abstract contract SlashDoubleSign is ISlashDoubleSign, HasValidatorContract, PCU
    * This parameter is exposed for system transaction.
    **/
   uint256 internal _doubleSigningOffsetLimitBlock;
-  /// @dev Recording of submitted proof to prevent relay attack.
-  mapping(bytes32 => bool) _submittedEvidence;
 
   /**
    * @dev This empty reserved space is put in place to allow future versions to add new
    * variables without shifting down storage in the inheritance chain.
    */
-  uint256[48] private ______gap;
+  uint256[49] private ______gap;
 
   /**
    * @inheritdoc ISlashDoubleSign
@@ -32,18 +30,8 @@ abstract contract SlashDoubleSign is ISlashDoubleSign, HasValidatorContract, PCU
     bytes calldata _header1,
     bytes calldata _header2
   ) external override onlyAdmin {
-    bytes32 _header1Checksum = keccak256(_header1);
-    bytes32 _header2Checksum = keccak256(_header2);
-
-    require(
-      !_submittedEvidence[_header1Checksum] && !_submittedEvidence[_header2Checksum],
-      "SlashDoubleSign: evidence already submitted"
-    );
-
     if (_pcValidateEvidence(_consensusAddr, _header1, _header2)) {
       uint256 _period = _validatorContract.currentPeriod();
-      _submittedEvidence[_header1Checksum] = true;
-      _submittedEvidence[_header2Checksum] = true;
       emit Slashed(_consensusAddr, SlashType.DOUBLE_SIGNING, _period);
       _validatorContract.execSlash(_consensusAddr, _doubleSigningJailUntilBlock, _slashDoubleSignAmount, true);
     }

--- a/contracts/ronin/slash-indicator/SlashDoubleSign.sol
+++ b/contracts/ronin/slash-indicator/SlashDoubleSign.sol
@@ -15,12 +15,14 @@ abstract contract SlashDoubleSign is ISlashDoubleSign, HasValidatorContract, PCU
    * This parameter is exposed for system transaction.
    **/
   uint256 internal _doubleSigningOffsetLimitBlock;
+  /// @dev Recording of submitted proof to prevent relay attack.
+  mapping(bytes32 => bool) _submittedEvidence;
 
   /**
    * @dev This empty reserved space is put in place to allow future versions to add new
    * variables without shifting down storage in the inheritance chain.
    */
-  uint256[49] private ______gap;
+  uint256[48] private ______gap;
 
   /**
    * @inheritdoc ISlashDoubleSign
@@ -30,8 +32,18 @@ abstract contract SlashDoubleSign is ISlashDoubleSign, HasValidatorContract, PCU
     bytes calldata _header1,
     bytes calldata _header2
   ) external override onlyAdmin {
+    bytes32 _header1Checksum = keccak256(_header1);
+    bytes32 _header2Checksum = keccak256(_header2);
+
+    require(
+      !_submittedEvidence[_header1Checksum] && !_submittedEvidence[_header2Checksum],
+      "SlashDoubleSign: evidence already submitted"
+    );
+
     if (_pcValidateEvidence(_consensusAddr, _header1, _header2)) {
       uint256 _period = _validatorContract.currentPeriod();
+      _submittedEvidence[_header1Checksum] = true;
+      _submittedEvidence[_header2Checksum] = true;
       emit Slashed(_consensusAddr, SlashType.DOUBLE_SIGNING, _period);
       _validatorContract.execSlash(_consensusAddr, _doubleSigningJailUntilBlock, _slashDoubleSignAmount, true);
     }

--- a/contracts/ronin/slash-indicator/SlashDoubleSign.sol
+++ b/contracts/ronin/slash-indicator/SlashDoubleSign.sol
@@ -11,7 +11,9 @@ abstract contract SlashDoubleSign is ISlashDoubleSign, HasValidatorContract, PCU
   uint256 internal _slashDoubleSignAmount;
   /// @dev The block number that the punished validator will be jailed until, due to double signing.
   uint256 internal _doubleSigningJailUntilBlock;
-  /// @dev The offset from the submitted block to the current block, from which double signing will be invalidated.
+  /** @dev The offset from the submitted block to the current block, from which double signing will be invalidated.
+   * This parameter is exposed for system transaction.
+   **/
   uint256 internal _doubleSigningOffsetLimitBlock;
   /// @dev Recording of submitted proof to prevent relay attack.
   mapping(bytes32 => bool) _submittedEvidence;
@@ -30,8 +32,6 @@ abstract contract SlashDoubleSign is ISlashDoubleSign, HasValidatorContract, PCU
     bytes calldata _header1,
     bytes calldata _header2
   ) external override onlyAdmin {
-    require(_shouldSlash(_consensusAddr), "SlashDoubleSign: invalid slashee");
-
     bytes32 _header1Checksum = keccak256(_header1);
     bytes32 _header2Checksum = keccak256(_header2);
 

--- a/contracts/ronin/slash-indicator/SlashDoubleSign.sol
+++ b/contracts/ronin/slash-indicator/SlashDoubleSign.sol
@@ -33,7 +33,7 @@ abstract contract SlashDoubleSign is ISlashDoubleSign, HasValidatorContract, PCU
     if (_pcValidateEvidence(_header1, _header2)) {
       uint256 _period = _validatorContract.currentPeriod();
       emit Slashed(_consensusAddr, SlashType.DOUBLE_SIGNING, _period);
-      _validatorContract.execSlash(_consensusAddr, _doubleSigningJailUntilBlock, _slashDoubleSignAmount, false);
+      _validatorContract.execSlash(_consensusAddr, _doubleSigningJailUntilBlock, _slashDoubleSignAmount, true);
     }
   }
 

--- a/contracts/ronin/slash-indicator/SlashDoubleSign.sol
+++ b/contracts/ronin/slash-indicator/SlashDoubleSign.sol
@@ -25,7 +25,7 @@ abstract contract SlashDoubleSign is ISlashDoubleSign, HasValidatorContract, PCU
     address _consensusAddr,
     bytes calldata _header1,
     bytes calldata _header2
-  ) external override {
+  ) external override onlyAdmin {
     if (!_shouldSlash(_consensusAddr)) {
       return;
     }

--- a/contracts/ronin/slash-indicator/SlashIndicator.sol
+++ b/contracts/ronin/slash-indicator/SlashIndicator.sol
@@ -41,7 +41,8 @@ contract SlashIndicator is
     uint256[2] calldata _bridgeVotingSlashingConfigs,
     // _doubleSignSlashingConfigs[0]: _slashDoubleSignAmount
     // _doubleSignSlashingConfigs[1]: _doubleSigningJailUntilBlock
-    uint256[2] calldata _doubleSignSlashingConfigs,
+    // _doubleSignSlashingConfigs[2]: _doubleSigningOffsetLimitBlock
+    uint256[3] calldata _doubleSignSlashingConfigs,
     // _unavailabilitySlashingConfigs[0]: _unavailabilityTier1Threshold
     // _unavailabilitySlashingConfigs[1]: _unavailabilityTier2Threshold
     // _unavailabilitySlashingConfigs[2]: _slashAmountForUnavailabilityTier2Threshold
@@ -64,7 +65,11 @@ contract SlashIndicator is
       _bridgeOperatorSlashingConfigs[3]
     );
     _setBridgeVotingSlashingConfigs(_bridgeVotingSlashingConfigs[0], _bridgeVotingSlashingConfigs[1]);
-    _setDoubleSignSlashingConfigs(_doubleSignSlashingConfigs[0], _doubleSignSlashingConfigs[1]);
+    _setDoubleSignSlashingConfigs(
+      _doubleSignSlashingConfigs[0],
+      _doubleSignSlashingConfigs[1],
+      _doubleSignSlashingConfigs[2]
+    );
     _setUnavailabilitySlashingConfigs(
       _unavailabilitySlashingConfigs[0],
       _unavailabilitySlashingConfigs[1],

--- a/contracts/ronin/slash-indicator/SlashUnavailability.sol
+++ b/contracts/ronin/slash-indicator/SlashUnavailability.sol
@@ -51,6 +51,7 @@ abstract contract SlashUnavailability is ISlashUnavailability, HasValidatorContr
   function slashUnavailability(address _validatorAddr) external override oncePerBlock {
     require(msg.sender == block.coinbase, "SlashUnavailability: method caller must be coinbase");
     if (!_shouldSlash(_validatorAddr)) {
+      // Should return instead of throwing error since this is a part of system transaction.
       return;
     }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -129,7 +129,7 @@ const defaultSlashIndicatorConf: SlashIndicatorArguments = {
   doubleSignSlashing: {
     slashDoubleSignAmount: BigNumber.from(10).pow(18).mul(10), // 10 RON
     doubleSigningJailUntilBlock: ethers.constants.MaxUint256,
-    doubleSigningOffsetLimitBlock: 28800, // ~1 days
+    doubleSigningOffsetLimitBlock: 28800 * 7, // ~7 days
   },
   unavailabilitySlashing: {
     unavailabilityTier1Threshold: 50,

--- a/src/config.ts
+++ b/src/config.ts
@@ -129,6 +129,7 @@ const defaultSlashIndicatorConf: SlashIndicatorArguments = {
   doubleSignSlashing: {
     slashDoubleSignAmount: BigNumber.from(10).pow(18).mul(10), // 10 RON
     doubleSigningJailUntilBlock: ethers.constants.MaxUint256,
+    doubleSigningOffsetLimitBlock: 28800, // ~1 days
   },
   unavailabilitySlashing: {
     unavailabilityTier1Threshold: 50,

--- a/src/deploy/proxy/slash-indicator-proxy.ts
+++ b/src/deploy/proxy/slash-indicator-proxy.ts
@@ -33,6 +33,7 @@ const deploy = async ({ getNamedAccounts, deployments }: HardhatRuntimeEnvironme
     [
       slashIndicatorConf[network.name]!.doubleSignSlashing?.slashDoubleSignAmount,
       slashIndicatorConf[network.name]!.doubleSignSlashing?.doubleSigningJailUntilBlock,
+      slashIndicatorConf[network.name]!.doubleSignSlashing?.doubleSigningOffsetLimitBlock,
     ],
     [
       slashIndicatorConf[network.name]!.unavailabilitySlashing?.unavailabilityTier1Threshold,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -122,6 +122,7 @@ export interface BridgeVotingSlashingConfig {
 export interface DoubleSignSlashingConfig {
   slashDoubleSignAmount?: BigNumberish;
   doubleSigningJailUntilBlock?: BigNumberish;
+  doubleSigningOffsetLimitBlock?: BigNumberish;
 }
 
 export interface UnavailabilitySlashing {

--- a/test/helpers/encoder.ts
+++ b/test/helpers/encoder.ts
@@ -1,0 +1,11 @@
+import { Interface } from '@ethersproject/abi';
+import { ethers } from 'ethers';
+
+export class Encoder {
+  static readonly abi: string[] = ['function Error(string)'];
+  static readonly iface: Interface = new ethers.utils.Interface(Encoder.abi);
+
+  static encodeError(msg: string): string {
+    return Encoder.iface.encodeFunctionData('Error', [msg]);
+  }
+}

--- a/test/helpers/fixture.ts
+++ b/test/helpers/fixture.ts
@@ -93,6 +93,7 @@ export const defaultTestConfig: InitTestInput = {
     doubleSignSlashing: {
       slashDoubleSignAmount: BigNumber.from(10).pow(18).mul(10),
       doubleSigningJailUntilBlock: ethers.constants.MaxUint256,
+      doubleSigningOffsetLimitBlock: 28800, // ~1 days
     },
     unavailabilitySlashing: {
       unavailabilityTier1Threshold: 5,

--- a/test/helpers/governance-admin.ts
+++ b/test/helpers/governance-admin.ts
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+
+import { expectEvent } from './utils';
+import { GovernanceAdmin__factory, RoninValidatorSet__factory } from '../../src/types';
+import { ContractTransaction } from 'ethers';
+
+const contractInterface = GovernanceAdmin__factory.createInterface();
+
+export const expects = {
+  emitProposalExecutedEvent: async function (
+    tx: ContractTransaction,
+    expectingProposalHash: string,
+    expectingSuccessCalls: boolean[],
+    expectingReturnedDatas: string[]
+  ) {
+    await expectEvent(
+      contractInterface,
+      'ProposalExecuted',
+      tx,
+      (event) => {
+        expect(event.args[0], 'invalid proposal hash').eq(expectingProposalHash);
+        expect(event.args[1], 'invalid success calls').eql(expectingSuccessCalls);
+        expect(event.args[2], 'invalid returned datas').eql(expectingReturnedDatas);
+      },
+      1
+    );
+  },
+};

--- a/test/precompile-usages/PrecompileUsageValidateDoubleSign.test.ts
+++ b/test/precompile-usages/PrecompileUsageValidateDoubleSign.test.ts
@@ -8,6 +8,7 @@ import {
   MockPCUValidateDoubleSign,
   MockPCUValidateDoubleSign__factory,
 } from '../../src/types';
+import { Address } from 'hardhat-deploy/dist/types';
 
 let deployer: SignerWithAddress;
 let signers: SignerWithAddress[];
@@ -15,29 +16,31 @@ let precompileValidating: MockPrecompile;
 let usageValidating: MockPCUValidateDoubleSign;
 
 describe('[Precompile] Validate double sign test', () => {
+  let slasheeAddr: Address;
+  let header1 = ethers.utils.toUtf8Bytes('sampleHeader1');
+  let header2 = ethers.utils.toUtf8Bytes('sampleHeader2');
+
   before(async () => {
     [deployer, ...signers] = await ethers.getSigners();
 
     precompileValidating = await new MockPrecompile__factory(deployer).deploy();
     usageValidating = await new MockPCUValidateDoubleSign__factory(deployer).deploy(precompileValidating.address);
-  });
 
-  let consensusAddr = signers[0].address;
-  let header1 = ethers.utils.toUtf8Bytes('sampleHeader1');
-  let header2 = ethers.utils.toUtf8Bytes('sampleHeader2');
+    slasheeAddr = signers[0].address;
+  });
 
   it('Should the usage contract correctly configs the precompile address', async () => {
     expect(await usageValidating.precompileValidateDoubleSignAddress()).eq(precompileValidating.address);
   });
 
   it('Should the usage contract can call the precompile address', async () => {
-    let sortedValidators = await usageValidating.callPrecompile(consensusAddr, header1, header2);
+    let sortedValidators = await usageValidating.callPrecompile(slasheeAddr, header1, header2);
     expect(sortedValidators).eql(true);
   });
 
   it('Should the usage contract revert with proper message on calling the precompile contract fails', async () => {
     await usageValidating.setPrecompileValidateDoubleSignAddress(ethers.constants.AddressZero);
-    await expect(usageValidating.callPrecompile(consensusAddr, header1, header2)).revertedWithCustomError(
+    await expect(usageValidating.callPrecompile(slasheeAddr, header1, header2)).revertedWithCustomError(
       usageValidating,
       'ErrCallPrecompiled'
     );

--- a/test/precompile-usages/PrecompileUsageValidateDoubleSign.test.ts
+++ b/test/precompile-usages/PrecompileUsageValidateDoubleSign.test.ts
@@ -22,6 +22,7 @@ describe('[Precompile] Validate double sign test', () => {
     usageValidating = await new MockPCUValidateDoubleSign__factory(deployer).deploy(precompileValidating.address);
   });
 
+  let consensusAddr = signers[0].address;
   let header1 = ethers.utils.toUtf8Bytes('sampleHeader1');
   let header2 = ethers.utils.toUtf8Bytes('sampleHeader2');
 
@@ -30,13 +31,13 @@ describe('[Precompile] Validate double sign test', () => {
   });
 
   it('Should the usage contract can call the precompile address', async () => {
-    let sortedValidators = await usageValidating.callPrecompile(header1, header2);
+    let sortedValidators = await usageValidating.callPrecompile(consensusAddr, header1, header2);
     expect(sortedValidators).eql(true);
   });
 
   it('Should the usage contract revert with proper message on calling the precompile contract fails', async () => {
     await usageValidating.setPrecompileValidateDoubleSignAddress(ethers.constants.AddressZero);
-    await expect(usageValidating.callPrecompile(header1, header2)).revertedWithCustomError(
+    await expect(usageValidating.callPrecompile(consensusAddr, header1, header2)).revertedWithCustomError(
       usageValidating,
       'ErrCallPrecompiled'
     );

--- a/test/slash/SlashIndicator.test.ts
+++ b/test/slash/SlashIndicator.test.ts
@@ -24,6 +24,11 @@ import {
   TrustedOrganizationAddressSet,
   ValidatorCandidateAddressSet,
 } from '../helpers/address-set-types';
+import { getLastBlockTimestamp } from '../helpers/utils';
+import { ProposalDetailStruct } from '../../src/types/GovernanceAdmin';
+import { getProposalHash, VoteType } from '../../src/script/proposal';
+import { expects as GovernanceAdminExpects } from '../helpers/governance-admin';
+import { Encoder } from '../helpers/encoder';
 
 let slashContract: MockSlashIndicatorExtended;
 let mockSlashLogic: MockSlashIndicatorExtended;
@@ -53,6 +58,7 @@ const slashAmountForUnavailabilityTier2Threshold = BigNumber.from(2);
 const slashDoubleSignAmount = BigNumber.from(5);
 
 const minOffsetToStartSchedule = 200;
+const proposalExpiryDuration = 60;
 
 const validateIndicatorAt = async (idx: number) => {
   expect(await slashContract.currentUnavailabilityIndicator(validatorCandidates[idx].consensusAddr.address)).to.eq(
@@ -98,6 +104,9 @@ describe('Slash indicator test', () => {
             addedBlock: 0,
           })),
         },
+        governanceAdminArguments: {
+          proposalExpiryDuration,
+        },
       });
 
     stakingContract = Staking__factory.connect(stakingContractAddress, deployer);
@@ -107,7 +116,7 @@ describe('Slash indicator test', () => {
     governanceAdminInterface = new GovernanceAdminInterface(
       governanceAdmin,
       network.config.chainId!,
-      undefined,
+      { proposalExpiryDuration },
       ...trustedOrgs.map((_) => _.governor)
     );
 
@@ -359,43 +368,25 @@ describe('Slash indicator test', () => {
       });
     });
 
-    describe('Double signing slash', async () => {
+    describe.only('Double signing slash', async () => {
       let header1: BytesLike;
       let header2: BytesLike;
 
-      it('Should not be able to slash themselves', async () => {
+      it('Should not be able to slash themselves (only admin allowed)', async () => {
         const slasherIdx = 0;
         await network.provider.send('hardhat_setCoinbase', [validatorCandidates[slasherIdx].consensusAddr.address]);
 
         header1 = ethers.utils.toUtf8Bytes('sampleHeader1');
         header2 = ethers.utils.toUtf8Bytes('sampleHeader2');
 
-        let tx = await slashContract
+        let tx = slashContract
           .connect(validatorCandidates[slasherIdx].consensusAddr)
           .slashDoubleSign(validatorCandidates[slasherIdx].consensusAddr.address, header1, header2);
 
-        await expect(tx).to.not.emit(slashContract, 'Slashed');
+        await expect(tx).revertedWith('HasProxyAdmin: unauthorized sender');
       });
 
-      it('Should be able to slash validator with double signing', async () => {
-        const slasherIdx = 0;
-        const slasheeIdx = 1;
-
-        header1 = ethers.utils.toUtf8Bytes('sampleHeader1');
-        header2 = ethers.utils.toUtf8Bytes('sampleHeader2');
-
-        let tx = await slashContract
-          .connect(validatorCandidates[slasherIdx].consensusAddr)
-          .slashDoubleSign(validatorCandidates[slasheeIdx].consensusAddr.address, header1, header2);
-
-        let period = await validatorContract.currentPeriod();
-
-        await expect(tx)
-          .to.emit(slashContract, 'Slashed')
-          .withArgs(validatorCandidates[slasheeIdx].consensusAddr.address, SlashType.DOUBLE_SIGNING, period);
-      });
-
-      it('Should non-coinbase be able to slash validator with double signing', async () => {
+      it('Should non-admin not be able to slash validator with double signing', async () => {
         const slasherIdx = 0;
         const slasheeIdx = 1;
         const coinbaseIdx = 2;
@@ -404,15 +395,136 @@ describe('Slash indicator test', () => {
         header1 = ethers.utils.toUtf8Bytes('sampleHeader1');
         header2 = ethers.utils.toUtf8Bytes('sampleHeader2');
 
-        let tx = await slashContract
+        let tx = slashContract
           .connect(validatorCandidates[slasherIdx].consensusAddr)
           .slashDoubleSign(validatorCandidates[slasheeIdx].consensusAddr.address, header1, header2);
+
+        await expect(tx).revertedWith('HasProxyAdmin: unauthorized sender');
+      });
+
+      it('Should be able to slash validator with double signing', async () => {
+        const slasheeIdx = 1;
+        header1 = ethers.utils.toUtf8Bytes('sampleHeader1');
+        header2 = ethers.utils.toUtf8Bytes('sampleHeader2');
+
+        const latestTimestamp = await getLastBlockTimestamp();
+        let calldata = governanceAdminInterface.interface.encodeFunctionData('functionDelegateCall', [
+          slashContract.interface.encodeFunctionData('slashDoubleSign', [
+            validatorCandidates[slasheeIdx].consensusAddr.address,
+            header1,
+            header2,
+          ]),
+        ]);
+        let proposal: ProposalDetailStruct = await governanceAdminInterface.createProposal(
+          latestTimestamp + proposalExpiryDuration,
+          slashContract.address,
+          0,
+          calldata,
+          500_000
+        );
+        let signatures = await governanceAdminInterface.generateSignatures(
+          proposal,
+          trustedOrgs.map((_) => _.governor)
+        );
+        let supports = signatures.map(() => VoteType.For);
+
+        let tx = await governanceAdmin
+          .connect(trustedOrgs[0].governor)
+          .proposeProposalStructAndCastVotes(proposal, supports, signatures);
+
+        expect(await governanceAdmin.proposalVoted(proposal.chainId, proposal.nonce, trustedOrgs[0].governor.address))
+          .to.true;
+        await expect(tx).emit(governanceAdmin, 'ProposalExecuted');
+        console.log('[test] target', slashContract.address);
+        console.log('[test] calldata', calldata);
+        console.log((await tx.wait()).events?.filter((_) => _.event === 'ProposalExecuted')[0].args);
 
         let period = await validatorContract.currentPeriod();
 
         await expect(tx)
           .to.emit(slashContract, 'Slashed')
           .withArgs(validatorCandidates[slasheeIdx].consensusAddr.address, SlashType.DOUBLE_SIGNING, period);
+      });
+
+      it('Should not be able to slash validator with already submitted evidence', async () => {
+        const slasheeIdx = 1;
+        header1 = ethers.utils.toUtf8Bytes('sampleHeader1');
+        header2 = ethers.utils.toUtf8Bytes('sampleHeaderNew');
+
+        const latestTimestamp = await getLastBlockTimestamp();
+        let calldata = governanceAdminInterface.interface.encodeFunctionData('functionDelegateCall', [
+          slashContract.interface.encodeFunctionData('slashDoubleSign', [
+            validatorCandidates[slasheeIdx].consensusAddr.address,
+            header1,
+            header2,
+          ]),
+        ]);
+        let proposal: ProposalDetailStruct = await governanceAdminInterface.createProposal(
+          latestTimestamp + proposalExpiryDuration,
+          slashContract.address,
+          0,
+          calldata,
+          500_000
+        );
+        let proposalHash = getProposalHash(proposal);
+        let signatures = await governanceAdminInterface.generateSignatures(
+          proposal,
+          trustedOrgs.map((_) => _.governor)
+        );
+        let supports = signatures.map(() => VoteType.For);
+
+        let tx = await governanceAdmin
+          .connect(trustedOrgs[0].governor)
+          .proposeProposalStructAndCastVotes(proposal, supports, signatures);
+
+        expect(await governanceAdmin.proposalVoted(proposal.chainId, proposal.nonce, trustedOrgs[0].governor.address))
+          .to.true;
+        await expect(tx).emit(governanceAdmin, 'ProposalExecuted');
+
+        await GovernanceAdminExpects.emitProposalExecutedEvent(
+          tx,
+          proposalHash,
+          [false],
+          [Encoder.encodeError('SlashDoubleSign: evidence already submitted')]
+        );
+      });
+
+      it('Should be able to slash non-validator with double signing', async () => {
+        const slasheeAddr = signers[1].address;
+        header1 = ethers.utils.toUtf8Bytes('sampleHeader3');
+        header2 = ethers.utils.toUtf8Bytes('sampleHeader4');
+
+        const latestTimestamp = await getLastBlockTimestamp();
+        let calldata = governanceAdminInterface.interface.encodeFunctionData('functionDelegateCall', [
+          slashContract.interface.encodeFunctionData('slashDoubleSign', [slasheeAddr, header1, header2]),
+        ]);
+        let proposal: ProposalDetailStruct = await governanceAdminInterface.createProposal(
+          latestTimestamp + proposalExpiryDuration,
+          slashContract.address,
+          0,
+          calldata,
+          500_000
+        );
+        let signatures = await governanceAdminInterface.generateSignatures(
+          proposal,
+          trustedOrgs.map((_) => _.governor)
+        );
+        let supports = signatures.map(() => VoteType.For);
+
+        let tx = await governanceAdmin
+          .connect(trustedOrgs[0].governor)
+          .proposeProposalStructAndCastVotes(proposal, supports, signatures);
+
+        expect(await governanceAdmin.proposalVoted(proposal.chainId, proposal.nonce, trustedOrgs[0].governor.address))
+          .to.true;
+        await expect(tx).emit(governanceAdmin, 'ProposalExecuted');
+        console.log('[test] target', slashContract.address);
+        console.log('[test] calldata', calldata);
+        console.log((await tx.wait()).events?.filter((_) => _.event === 'ProposalExecuted')[0].args);
+
+        let period = await validatorContract.currentPeriod();
+
+        await expect(tx).to.emit(slashContract, 'Slashed').withArgs(slasheeAddr, SlashType.DOUBLE_SIGNING, period);
       });
     });
   });

--- a/test/slash/SlashIndicator.test.ts
+++ b/test/slash/SlashIndicator.test.ts
@@ -26,7 +26,9 @@ import {
 } from '../helpers/address-set-types';
 import { getLastBlockTimestamp } from '../helpers/utils';
 import { ProposalDetailStruct } from '../../src/types/GovernanceAdmin';
-import { VoteType } from '../../src/script/proposal';
+import { getProposalHash, VoteType } from '../../src/script/proposal';
+import { expects as GovernanceAdminExpects } from '../helpers/governance-admin';
+import { Encoder } from '../helpers/encoder';
 
 let slashContract: MockSlashIndicatorExtended;
 let mockSlashLogic: MockSlashIndicatorExtended;
@@ -442,6 +444,49 @@ describe('Slash indicator test', () => {
         await expect(tx)
           .to.emit(slashContract, 'Slashed')
           .withArgs(validatorCandidates[slasheeIdx].consensusAddr.address, SlashType.DOUBLE_SIGNING, period);
+      });
+
+      it('Should not be able to slash validator with already submitted evidence', async () => {
+        const slasheeIdx = 1;
+        header1 = ethers.utils.toUtf8Bytes('sampleHeader1');
+        header2 = ethers.utils.toUtf8Bytes('sampleHeaderNew');
+
+        const latestTimestamp = await getLastBlockTimestamp();
+        let calldata = governanceAdminInterface.interface.encodeFunctionData('functionDelegateCall', [
+          slashContract.interface.encodeFunctionData('slashDoubleSign', [
+            validatorCandidates[slasheeIdx].consensusAddr.address,
+            header1,
+            header2,
+          ]),
+        ]);
+        let proposal: ProposalDetailStruct = await governanceAdminInterface.createProposal(
+          latestTimestamp + proposalExpiryDuration,
+          slashContract.address,
+          0,
+          calldata,
+          500_000
+        );
+        let proposalHash = getProposalHash(proposal);
+        let signatures = await governanceAdminInterface.generateSignatures(
+          proposal,
+          trustedOrgs.map((_) => _.governor)
+        );
+        let supports = signatures.map(() => VoteType.For);
+
+        let tx = await governanceAdmin
+          .connect(trustedOrgs[0].governor)
+          .proposeProposalStructAndCastVotes(proposal, supports, signatures);
+
+        expect(await governanceAdmin.proposalVoted(proposal.chainId, proposal.nonce, trustedOrgs[0].governor.address))
+          .to.true;
+        await expect(tx).emit(governanceAdmin, 'ProposalExecuted');
+
+        await GovernanceAdminExpects.emitProposalExecutedEvent(
+          tx,
+          proposalHash,
+          [false],
+          [Encoder.encodeError('SlashDoubleSign: evidence already submitted')]
+        );
       });
 
       it('Should be able to slash non-validator with double signing', async () => {

--- a/test/slash/SlashIndicator.test.ts
+++ b/test/slash/SlashIndicator.test.ts
@@ -435,9 +435,6 @@ describe('Slash indicator test', () => {
         expect(await governanceAdmin.proposalVoted(proposal.chainId, proposal.nonce, trustedOrgs[0].governor.address))
           .to.true;
         await expect(tx).emit(governanceAdmin, 'ProposalExecuted');
-        console.log('[test] target', slashContract.address);
-        console.log('[test] calldata', calldata);
-        console.log((await tx.wait()).events?.filter((_) => _.event === 'ProposalExecuted')[0].args);
 
         let period = await validatorContract.currentPeriod();
 
@@ -518,10 +515,6 @@ describe('Slash indicator test', () => {
         expect(await governanceAdmin.proposalVoted(proposal.chainId, proposal.nonce, trustedOrgs[0].governor.address))
           .to.true;
         await expect(tx).emit(governanceAdmin, 'ProposalExecuted');
-        console.log('[test] target', slashContract.address);
-        console.log('[test] calldata', calldata);
-        console.log((await tx.wait()).events?.filter((_) => _.event === 'ProposalExecuted')[0].args);
-
         let period = await validatorContract.currentPeriod();
 
         await expect(tx).to.emit(slashContract, 'Slashed').withArgs(slasheeAddr, SlashType.DOUBLE_SIGNING, period);

--- a/test/slash/SlashIndicator.test.ts
+++ b/test/slash/SlashIndicator.test.ts
@@ -394,6 +394,26 @@ describe('Slash indicator test', () => {
           .to.emit(slashContract, 'Slashed')
           .withArgs(validatorCandidates[slasheeIdx].consensusAddr.address, SlashType.DOUBLE_SIGNING, period);
       });
+
+      it('Should non-coinbase be able to slash validator with double signing', async () => {
+        const slasherIdx = 0;
+        const slasheeIdx = 1;
+        const coinbaseIdx = 2;
+        await network.provider.send('hardhat_setCoinbase', [validatorCandidates[coinbaseIdx].consensusAddr.address]);
+
+        header1 = ethers.utils.toUtf8Bytes('sampleHeader1');
+        header2 = ethers.utils.toUtf8Bytes('sampleHeader2');
+
+        let tx = await slashContract
+          .connect(validatorCandidates[slasherIdx].consensusAddr)
+          .slashDoubleSign(validatorCandidates[slasheeIdx].consensusAddr.address, header1, header2);
+
+        let period = await validatorContract.currentPeriod();
+
+        await expect(tx)
+          .to.emit(slashContract, 'Slashed')
+          .withArgs(validatorCandidates[slasheeIdx].consensusAddr.address, SlashType.DOUBLE_SIGNING, period);
+      });
     });
   });
 });


### PR DESCRIPTION
### Description

> **Warning**
> This PR may cause backward-incompatible due to change required in precompiled contract.

- Allow to double signing without coinbase check
- Mark double sign slash as cannot bailout
- Only admin can slash double sign
- Remove check of slashee must be validator
- Expose `doubleSigningOffsetLimitBlock` to indicate the at most block number can submit the evidence
- Set `doubleSigningOffsetLimitBlock` to `~14 days`
- **Add `_consensusAddr` param to precompiled call**, which may cause backward-incompatible

### Contract changes

The table below shows the following info:
- **Logic**: the logic is changed.
- **ABI**: the ABI is changed.
- **Init data**: new storage field is declared and needs initializing.
- **Dependent**: needs to be changed due to changes in other contracts.

| **Contract name** | **Logic** | **ABI** | **Init data** | **Dependent** |
|-------------------|:---------:|:-------:|:-------------:|:-------------:|
| BridgeTracking    |           |         |               |               |
| GovernanceAdmin   |           |         |               |               |
| Maintenance       |           |         |               |               |
| SlashIndicator    |     [x]      |    [x]    |       [x]        |               |
| Staking           |           |         |               |               |
| StakingVesting    |           |         |               |               |
| ValidatorSet      |           |         |               |               |

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
