### PR TITLE
Fix/missing-event-for-bailout

### DIFF
--- a/contracts/interfaces/slash-indicator/ICreditScore.sol
+++ b/contracts/interfaces/slash-indicator/ICreditScore.sol
@@ -10,10 +10,10 @@ interface ICreditScore {
     uint256 bailOutCostMultiplier,
     uint256 cutOffPercentageAfterBailout
   );
-  /// @dev Emitted the credit score of validators is updated
+  /// @dev Emitted the credit score of validators is updated.
   event CreditScoresUpdated(address[] validators, uint256[] creditScores);
-  /// @dev Emitted when a validator bailed out of jail
-  event BailedOut(address indexed validator, uint256 period);
+  /// @dev Emitted when a validator bailed out of jail, with info of `creditScore` left.
+  event BailedOut(address indexed validator, uint256 period, uint256 creditScore);
 
   /**
    * @dev Updates the credit score for the validators.

--- a/contracts/ronin/slash-indicator/CreditScore.sol
+++ b/contracts/ronin/slash-indicator/CreditScore.sol
@@ -99,6 +99,7 @@ abstract contract CreditScore is ICreditScore, HasValidatorContract, HasMaintena
     _creditScore[_consensusAddr] -= _cost;
     _setUnavailabilityIndicator(_consensusAddr, _period, 0);
     _checkBailedOutAtPeriod[_consensusAddr][_period] = true;
+    emit BailedOut(_consensusAddr, _period, _creditScore[_consensusAddr]);
   }
 
   /**

--- a/test/slash/CreditScore.test.ts
+++ b/test/slash/CreditScore.test.ts
@@ -345,15 +345,17 @@ describe('Credit score and bail out test', () => {
         tx = await slashContract
           .connect(validatorCandidates[0].candidateAdmin)
           .bailOut(validatorCandidates[0].consensusAddr.address);
-        let _period = validatorContract.currentPeriod();
-
-        expect(tx).emit(slashContract, 'BailedOut').withArgs([validatorCandidates[0].consensusAddr.address, _period]);
-        expect(tx)
-          .emit(validatorContract, 'ValidatorUnjailed')
-          .withArgs([validatorCandidates[0].consensusAddr.address]);
+        let _period = await validatorContract.currentPeriod();
 
         localScoreController.subAtNonNegative(0, bailOutCostMultiplier * _jailLeft.epochLeft_.toNumber());
         await validateScoreAt(0);
+
+        await expect(tx)
+          .emit(slashContract, 'BailedOut')
+          .withArgs(validatorCandidates[0].consensusAddr.address, _period, localScoreController.getAt(0));
+        await expect(tx)
+          .emit(validatorContract, 'ValidatorUnjailed')
+          .withArgs(validatorCandidates[0].consensusAddr.address, _period);
       });
 
       it('Should the indicator get reset', async () => {
@@ -398,11 +400,11 @@ describe('Credit score and bail out test', () => {
         let tx = await endPeriodAndWrapUpAndResetIndicators();
         await localScoreController.increaseAtWithUpperbound(0, maxCreditScore, gainCreditScore);
 
-        expect(tx)
+        await expect(tx)
           .emit(validatorContract, 'MiningRewardDistributed')
           .withArgs(
             validatorCandidates[0].consensusAddr.address,
-            validatorCandidates[0].consensusAddr.address,
+            validatorCandidates[0].poolAdmin.address,
             submittedRewardEachBlock.add(blockProducerBonusPerBlock).div(2)
           );
       });
@@ -453,15 +455,17 @@ describe('Credit score and bail out test', () => {
         let tx = await slashContract
           .connect(validatorCandidates[0].candidateAdmin)
           .bailOut(validatorCandidates[0].consensusAddr.address);
-        let _period = validatorContract.currentPeriod();
-
-        expect(tx).emit(slashContract, 'BailedOut').withArgs([validatorCandidates[0].consensusAddr.address, _period]);
-        expect(tx)
-          .emit(validatorContract, 'ValidatorUnjailed')
-          .withArgs([validatorCandidates[0].consensusAddr.address]);
+        let _period = await validatorContract.currentPeriod();
 
         localScoreController.subAtNonNegative(0, bailOutCostMultiplier * _jailLeft.epochLeft_.toNumber());
         await validateScoreAt(0);
+
+        await expect(tx)
+          .emit(slashContract, 'BailedOut')
+          .withArgs(validatorCandidates[0].consensusAddr.address, _period, localScoreController.getAt(0));
+        await expect(tx)
+          .emit(validatorContract, 'ValidatorUnjailed')
+          .withArgs(validatorCandidates[0].consensusAddr.address, _period);
       });
 
       it('Should the indicator get reset', async () => {
@@ -506,11 +510,11 @@ describe('Credit score and bail out test', () => {
         let tx = await endPeriodAndWrapUpAndResetIndicators();
         await localScoreController.increaseAtWithUpperbound(0, maxCreditScore, gainCreditScore);
 
-        expect(tx)
+        await expect(tx)
           .emit(validatorContract, 'MiningRewardDistributed')
           .withArgs(
             validatorCandidates[0].consensusAddr.address,
-            validatorCandidates[0].consensusAddr.address,
+            validatorCandidates[0].poolAdmin.address,
             submittedRewardEachBlock.add(blockProducerBonusPerBlock).div(2)
           );
       });
@@ -542,12 +546,7 @@ describe('Credit score and bail out test', () => {
         let tx = await slashContract
           .connect(validatorCandidates[0].candidateAdmin)
           .bailOut(validatorCandidates[0].consensusAddr.address);
-        let _period = validatorContract.currentPeriod();
-
-        expect(tx).emit(slashContract, 'BailedOut').withArgs([validatorCandidates[0].consensusAddr.address, _period]);
-        expect(tx)
-          .emit(validatorContract, 'ValidatorUnjailed')
-          .withArgs([validatorCandidates[0].consensusAddr.address]);
+        let _period = await validatorContract.currentPeriod();
 
         localIndicatorController.resetAt(0);
         await validateIndicatorAt(0);
@@ -557,6 +556,13 @@ describe('Credit score and bail out test', () => {
 
         await localEpochController.mineToBeforeEndOfEpoch();
         await wrapUpEpoch();
+
+        await expect(tx)
+          .emit(slashContract, 'BailedOut')
+          .withArgs(validatorCandidates[0].consensusAddr.address, _period, localScoreController.getAt(0));
+        await expect(tx)
+          .emit(validatorContract, 'ValidatorUnjailed')
+          .withArgs(validatorCandidates[0].consensusAddr.address, _period);
 
         expect(await validatorContract.isBlockProducer(validatorCandidates[0].consensusAddr.address)).eq(true);
       });


### PR DESCRIPTION
### Description
- Add missing emitted event.
- Add `creditScore` for `BailedOut` event.
- Fix test. Add `await` before test.

### Contract changes

The table below shows the following info:
- **Logic**: the logic is changed.
- **ABI**: the ABI is changed.
- **Init data**: new storage field is declared and needs initializing.
- **Dependent**: needs to be changed due to changes in other contracts.

| **Contract name** | **Logic** | **ABI** | **Init data** | **Dependent** |
|-------------------|:---------:|:-------:|:-------------:|:-------------:|
| BridgeTracking    |           |         |               |               |
| GovernanceAdmin   |           |         |               |               |
| Maintenance       |           |         |               |               |
| SlashIndicator    |      [x]     |         |               |               |
| Staking           |           |         |               |               |
| StakingVesting    |           |         |               |               |
| ValidatorSet      |           |         |               |               |

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
