### PR TITLE
[ValidatorSet] Fix private method of setting new validator set

### DIFF
--- a/contracts/ronin/validator/CoinbaseExecution.sol
+++ b/contracts/ronin/validator/CoinbaseExecution.sol
@@ -15,7 +15,6 @@ import "../../precompile-usages/PCUPickValidatorSet.sol";
 import "./storage-fragments/CommonStorage.sol";
 import "./CandidateManager.sol";
 import "./EmergencyExit.sol";
-import "hardhat/console.sol";
 
 abstract contract CoinbaseExecution is
   ICoinbaseExecution,
@@ -405,42 +404,26 @@ abstract contract CoinbaseExecution is
     uint256 _newValidatorCount,
     uint256 _newPeriod
   ) private {
-    for (uint256 _i = _newValidatorCount; _i < validatorCount; _i++) {
+    // Remove exceeding validators in the current set
+    for (uint256 _i = 0; _i < validatorCount; _i++) {
       delete _validatorMap[_validators[_i]];
       delete _validators[_i];
     }
 
-    uint256 _count;
+    // Remove flag for all validator in the current set
+    for (uint _i = 0; _i < _newValidatorCount; _i++) {
+      delete _validatorMap[_validators[_i]];
+    }
+
+    // Update new validator set and set flag correspondingly.
     for (uint256 _i = 0; _i < _newValidatorCount; _i++) {
       address _newValidator = _newValidators[_i];
-      // console.log("i", _i);
-      // console.log("count", _count);
-      if (_newValidator == _validators[_count]) {
-        _count++;
-        continue;
-      }
-
-      delete _validatorMap[_validators[_count]];
-      // console.log(
-      //   "_validatorMap[_validators[_count]]",
-      //   _validators[_count],
-      //   uint256(_validatorMap[_validators[_count]])
-      // );
       _validatorMap[_newValidator] = EnumFlags.ValidatorFlag.Both;
-
-      // console.log("_validatorMap[_newValidator]", _newValidator, uint256(_validatorMap[_newValidator]));
-      _validators[_count] = _newValidator;
-      _count++;
+      _validators[_i] = _newValidator;
     }
 
-    validatorCount = _count;
+    validatorCount = _newValidatorCount;
     emit ValidatorSetUpdated(_newPeriod, _newValidators);
-
-    console.log("--- post");
-    for (uint256 _i = 0; _i < validatorCount; _i++) {
-      console.log(_validators[_i], uint8(_validatorMap[_validators[_i]]));
-    }
-    console.log("---");
   }
 
   /**

--- a/contracts/ronin/validator/CoinbaseExecution.sol
+++ b/contracts/ronin/validator/CoinbaseExecution.sol
@@ -15,6 +15,7 @@ import "../../precompile-usages/PCUPickValidatorSet.sol";
 import "./storage-fragments/CommonStorage.sol";
 import "./CandidateManager.sol";
 import "./EmergencyExit.sol";
+import "hardhat/console.sol";
 
 abstract contract CoinbaseExecution is
   ICoinbaseExecution,
@@ -404,25 +405,35 @@ abstract contract CoinbaseExecution is
     uint256 _newValidatorCount,
     uint256 _newPeriod
   ) private {
-    // Remove exceeding validators in the current set
-    for (uint256 _i = 0; _i < validatorCount; _i++) {
+    for (uint256 _i = _newValidatorCount; _i < validatorCount; _i++) {
       delete _validatorMap[_validators[_i]];
       delete _validators[_i];
     }
 
-    // Remove flag for all validator in the current set
-    for (uint _i = 0; _i < _newValidatorCount; _i++) {
-      delete _validatorMap[_validators[_i]];
-    }
-
-    // Update new validator set and set flag correspondingly.
+    uint256 _count;
     for (uint256 _i = 0; _i < _newValidatorCount; _i++) {
       address _newValidator = _newValidators[_i];
+      console.log("i", _i);
+      console.log("count", _count);
+      if (_newValidator == _validators[_count]) {
+        _count++;
+        continue;
+      }
+
+      delete _validatorMap[_validators[_count]];
+      console.log(
+        "_validatorMap[_validators[_count]]",
+        _validators[_count],
+        uint256(_validatorMap[_validators[_count]])
+      );
       _validatorMap[_newValidator] = EnumFlags.ValidatorFlag.Both;
-      _validators[_i] = _newValidator;
+
+      console.log("_validatorMap[_newValidator]", _newValidator, uint256(_validatorMap[_newValidator]));
+      _validators[_count] = _newValidator;
+      _count++;
     }
 
-    validatorCount = _newValidatorCount;
+    validatorCount = _count;
     emit ValidatorSetUpdated(_newPeriod, _newValidators);
   }
 

--- a/contracts/ronin/validator/CoinbaseExecution.sol
+++ b/contracts/ronin/validator/CoinbaseExecution.sol
@@ -413,28 +413,34 @@ abstract contract CoinbaseExecution is
     uint256 _count;
     for (uint256 _i = 0; _i < _newValidatorCount; _i++) {
       address _newValidator = _newValidators[_i];
-      console.log("i", _i);
-      console.log("count", _count);
+      // console.log("i", _i);
+      // console.log("count", _count);
       if (_newValidator == _validators[_count]) {
         _count++;
         continue;
       }
 
       delete _validatorMap[_validators[_count]];
-      console.log(
-        "_validatorMap[_validators[_count]]",
-        _validators[_count],
-        uint256(_validatorMap[_validators[_count]])
-      );
+      // console.log(
+      //   "_validatorMap[_validators[_count]]",
+      //   _validators[_count],
+      //   uint256(_validatorMap[_validators[_count]])
+      // );
       _validatorMap[_newValidator] = EnumFlags.ValidatorFlag.Both;
 
-      console.log("_validatorMap[_newValidator]", _newValidator, uint256(_validatorMap[_newValidator]));
+      // console.log("_validatorMap[_newValidator]", _newValidator, uint256(_validatorMap[_newValidator]));
       _validators[_count] = _newValidator;
       _count++;
     }
 
     validatorCount = _count;
     emit ValidatorSetUpdated(_newPeriod, _newValidators);
+
+    console.log("--- post");
+    for (uint256 _i = 0; _i < validatorCount; _i++) {
+      console.log(_validators[_i], uint8(_validatorMap[_validators[_i]]));
+    }
+    console.log("---");
   }
 
   /**

--- a/contracts/ronin/validator/CoinbaseExecution.sol
+++ b/contracts/ronin/validator/CoinbaseExecution.sol
@@ -404,26 +404,25 @@ abstract contract CoinbaseExecution is
     uint256 _newValidatorCount,
     uint256 _newPeriod
   ) private {
-    for (uint256 _i = _newValidatorCount; _i < validatorCount; _i++) {
+    // Remove exceeding validators in the current set
+    for (uint256 _i = 0; _i < validatorCount; _i++) {
       delete _validatorMap[_validators[_i]];
       delete _validators[_i];
     }
 
-    uint256 _count;
-    for (uint256 _i = 0; _i < _newValidatorCount; _i++) {
-      address _newValidator = _newValidators[_i];
-      if (_newValidator == _validators[_count]) {
-        _count++;
-        continue;
-      }
-
-      delete _validatorMap[_validators[_count]];
-      _validatorMap[_newValidator] = EnumFlags.ValidatorFlag.Both;
-      _validators[_count] = _newValidator;
-      _count++;
+    // Remove flag for all validator in the current set
+    for (uint _i = 0; _i < _newValidatorCount; _i++) {
+      delete _validatorMap[_validators[_i]];
     }
 
-    validatorCount = _count;
+    // Update new validator set and set flag correspondingly.
+    for (uint256 _i = 0; _i < _newValidatorCount; _i++) {
+      address _newValidator = _newValidators[_i];
+      _validatorMap[_newValidator] = EnumFlags.ValidatorFlag.Both;
+      _validators[_i] = _newValidator;
+    }
+
+    validatorCount = _newValidatorCount;
     emit ValidatorSetUpdated(_newPeriod, _newValidators);
   }
 

--- a/contracts/ronin/validator/CoinbaseExecution.sol
+++ b/contracts/ronin/validator/CoinbaseExecution.sol
@@ -405,7 +405,7 @@ abstract contract CoinbaseExecution is
     uint256 _newPeriod
   ) private {
     // Remove exceeding validators in the current set
-    for (uint256 _i = 0; _i < validatorCount; _i++) {
+    for (uint256 _i = _newValidatorCount; _i < validatorCount; _i++) {
       delete _validatorMap[_validators[_i]];
       delete _validators[_i];
     }

--- a/contracts/ronin/validator/storage-fragments/ValidatorInfoStorage.sol
+++ b/contracts/ronin/validator/storage-fragments/ValidatorInfoStorage.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.9;
 import "../../../libraries/EnumFlags.sol";
 import "../../../extensions/collections/HasRoninTrustedOrganizationContract.sol";
 import "../../../interfaces/validator/info-fragments/IValidatorInfo.sol";
+import "hardhat/console.sol";
 
 abstract contract ValidatorInfoStorage is IValidatorInfo, HasRoninTrustedOrganizationContract {
   using EnumFlags for EnumFlags.ValidatorFlag;
@@ -65,6 +66,7 @@ abstract contract ValidatorInfoStorage is IValidatorInfo, HasRoninTrustedOrganiz
    * @inheritdoc IValidatorInfo
    */
   function isBlockProducer(address _addr) public view override returns (bool) {
+    console.log("---isBlockProducer", _addr, uint8(_validatorMap[_addr]));
     return _validatorMap[_addr].hasFlag(EnumFlags.ValidatorFlag.BlockProducer);
   }
 

--- a/contracts/ronin/validator/storage-fragments/ValidatorInfoStorage.sol
+++ b/contracts/ronin/validator/storage-fragments/ValidatorInfoStorage.sol
@@ -5,7 +5,6 @@ pragma solidity ^0.8.9;
 import "../../../libraries/EnumFlags.sol";
 import "../../../extensions/collections/HasRoninTrustedOrganizationContract.sol";
 import "../../../interfaces/validator/info-fragments/IValidatorInfo.sol";
-import "hardhat/console.sol";
 
 abstract contract ValidatorInfoStorage is IValidatorInfo, HasRoninTrustedOrganizationContract {
   using EnumFlags for EnumFlags.ValidatorFlag;
@@ -66,7 +65,6 @@ abstract contract ValidatorInfoStorage is IValidatorInfo, HasRoninTrustedOrganiz
    * @inheritdoc IValidatorInfo
    */
   function isBlockProducer(address _addr) public view override returns (bool) {
-    console.log("---isBlockProducer", _addr, uint8(_validatorMap[_addr]));
     return _validatorMap[_addr].hasFlag(EnumFlags.ValidatorFlag.BlockProducer);
   }
 

--- a/test/validator/RoninValidatorSet-CoinbaseExecution.test.ts
+++ b/test/validator/RoninValidatorSet-CoinbaseExecution.test.ts
@@ -75,7 +75,9 @@ describe('Ronin Validator Set: Coinbase execution test', () => {
     treasury = poolAdmin;
 
     trustedOrgs = createManyTrustedOrganizationAddressSets(signers.splice(0, 3));
-    validatorCandidates = createManyValidatorCandidateAddressSets(signers.slice(0, localValidatorCandidatesLength * 3));
+    validatorCandidates = createManyValidatorCandidateAddressSets(
+      signers.splice(0, localValidatorCandidatesLength * 3)
+    );
 
     await network.provider.send('hardhat_setCoinbase', [consensusAddr.address]);
 
@@ -186,7 +188,7 @@ describe('Ronin Validator Set: Coinbase execution test', () => {
             validatorCandidates[i].bridgeOperator.address,
             2_00,
             {
-              value: minValidatorStakingAmount.add(i),
+              value: minValidatorStakingAmount.add(i * 5),
             }
           );
       }
@@ -216,10 +218,13 @@ describe('Ronin Validator Set: Coinbase execution test', () => {
         tx = await roninValidatorSet.connect(consensusAddr).wrapUpEpoch();
       });
 
-      expectingValidatorsAddr = validatorCandidates
+      expectingValidatorsAddr = validatorCandidates // [candidates[4..1]]
         .slice(0, 4)
         .reverse()
         .map((_) => _.consensusAddr.address);
+
+      console.log(validatorCandidates.map((_) => _.consensusAddr.address));
+      console.log(expectingValidatorsAddr);
 
       await expect(tx!).emit(roninValidatorSet, 'WrappedUpEpoch').withArgs(lastPeriod, epoch, true);
       lastPeriod = await roninValidatorSet.currentPeriod();
@@ -228,14 +233,27 @@ describe('Ronin Validator Set: Coinbase execution test', () => {
       expect(await roninValidatorSet.getBlockProducers()).eql(expectingValidatorsAddr);
     });
 
-    it('Should isValidator method returns `true` for validator', async () => {
+    it('Should validator is set with correct flags', async () => {
       for (let validatorAddr of expectingValidatorsAddr) {
-        expect(await roninValidatorSet.isValidator(validatorAddr)).eq(true);
+        expect(await roninValidatorSet.isValidator(validatorAddr)).eq(
+          true,
+          `Wrong validator flag for ${validatorAddr}`
+        );
+        expect(await roninValidatorSet.isBlockProducer(validatorAddr)).eq(
+          true,
+          `Wrong block producer flag for ${validatorAddr}`
+        );
+        expect(await roninValidatorSet.isOperatingBridge(validatorAddr)).eq(
+          true,
+          `Wrong operating bridge flag for ${validatorAddr}`
+        );
       }
     });
 
-    it('Should isValidator method returns `false` for non-validator', async () => {
+    it('Should non-validator is set with correct flags', async () => {
       expect(await roninValidatorSet.isValidator(deployer.address)).eq(false);
+      expect(await roninValidatorSet.isBlockProducer(deployer.address)).eq(false);
+      expect(await roninValidatorSet.isBridgeOperator(deployer.address)).eq(false);
     });
 
     it(`Should be able to wrap up epoch at the end of period and pick top ${maxValidatorNumber} to be validators`, async () => {
@@ -261,7 +279,7 @@ describe('Ronin Validator Set: Coinbase execution test', () => {
             validatorCandidates[i].bridgeOperator.address,
             2_00,
             {
-              value: minValidatorStakingAmount.add(i),
+              value: minValidatorStakingAmount.add(i * 5),
             }
           );
       }
@@ -275,18 +293,82 @@ describe('Ronin Validator Set: Coinbase execution test', () => {
         await roninValidatorSet.endEpoch();
         tx = await roninValidatorSet.connect(consensusAddr).wrapUpEpoch();
         currentValidatorSet = [
+          // [coinbase, candidates[4..2]]
           consensusAddr.address,
-          ...validatorCandidates
-            .slice(2)
-            .reverse()
-            .map((_) => _.consensusAddr.address),
+          ...[validatorCandidates[4], validatorCandidates[3], validatorCandidates[2]].map(
+            (_) => _.consensusAddr.address
+          ),
         ];
       });
+
+      console.log(validatorCandidates.map((_) => _.consensusAddr.address));
+      console.log(currentValidatorSet);
+
       await expect(tx!).emit(roninValidatorSet, 'WrappedUpEpoch').withArgs(lastPeriod, epoch, true);
       lastPeriod = await roninValidatorSet.currentPeriod();
       await RoninValidatorSetExpects.emitValidatorSetUpdatedEvent(tx!, lastPeriod, currentValidatorSet);
       expect(await roninValidatorSet.getValidators()).eql(currentValidatorSet);
       expect(await roninValidatorSet.getBlockProducers()).eql(currentValidatorSet);
+    });
+  });
+
+  describe('Setting new validator set', async () => {
+    before(async () => {
+      snapshotId = await network.provider.send('evm_snapshot');
+    });
+
+    after(async () => {
+      await network.provider.send('evm_revert', [snapshotId]);
+    });
+
+    describe('Case updating from [V100,V4,V3,V2] --> [V100,V3,V4,V2]', async () => {
+      let expectingValidatorsAddr: Address[];
+      it('Should the validator set is updated correctly', async () => {
+        // [(V4: 20), (V3: 15), (V2: 10)] ---> [(V3: 21), (V4: 20), (V2: 10)]
+        await stakingContract.connect(signers[0]).delegate(validatorCandidates[3].consensusAddr.address, { value: 6 });
+
+        let tx: ContractTransaction;
+        await EpochController.setTimestampToPeriodEnding();
+        epoch = await roninValidatorSet.epochOf(await ethers.provider.getBlockNumber());
+        lastPeriod = await roninValidatorSet.currentPeriod();
+        await mineBatchTxs(async () => {
+          await roninValidatorSet.endEpoch();
+          tx = await roninValidatorSet.connect(consensusAddr).wrapUpEpoch();
+          expectingValidatorsAddr = [
+            // [coinbase, candidates[3], candidates[4], candidates[2]]
+            consensusAddr.address,
+            ...[validatorCandidates[3], validatorCandidates[4], validatorCandidates[2]].map(
+              (_) => _.consensusAddr.address
+            ),
+          ];
+        });
+
+        console.log(validatorCandidates.map((_) => _.consensusAddr.address));
+        console.log(expectingValidatorsAddr);
+
+        await expect(tx!).emit(roninValidatorSet, 'WrappedUpEpoch').withArgs(lastPeriod, epoch, true);
+        lastPeriod = await roninValidatorSet.currentPeriod();
+        await RoninValidatorSetExpects.emitValidatorSetUpdatedEvent(tx!, lastPeriod, expectingValidatorsAddr);
+      });
+
+      it('Should validator is set with correct flags', async () => {
+        expect(await roninValidatorSet.getValidators()).eql(expectingValidatorsAddr);
+        expect(await roninValidatorSet.getBlockProducers()).eql(expectingValidatorsAddr);
+        for (let validatorAddr of expectingValidatorsAddr) {
+          expect(await roninValidatorSet.isValidator(validatorAddr)).eq(
+            true,
+            `Wrong validator flag for ${validatorAddr}`
+          );
+          expect(await roninValidatorSet.isBlockProducer(validatorAddr)).eq(
+            true,
+            `Wrong block producer flag for ${validatorAddr}`
+          );
+          expect(await roninValidatorSet.isOperatingBridge(validatorAddr)).eq(
+            true,
+            `Wrong operating bridge flag for ${validatorAddr}`
+          );
+        }
+      });
     });
   });
 

--- a/test/validator/RoninValidatorSet-CoinbaseExecution.test.ts
+++ b/test/validator/RoninValidatorSet-CoinbaseExecution.test.ts
@@ -55,6 +55,7 @@ let epoch: BigNumber;
 
 let snapshotId: string;
 
+const dummyStakingMultiplier = 5;
 const localValidatorCandidatesLength = 5;
 
 const waitingSecsToRevoke = 3 * 86400;
@@ -188,7 +189,7 @@ describe('Ronin Validator Set: Coinbase execution test', () => {
             validatorCandidates[i].bridgeOperator.address,
             2_00,
             {
-              value: minValidatorStakingAmount.add(i * 5),
+              value: minValidatorStakingAmount.add(i * dummyStakingMultiplier),
             }
           );
       }
@@ -222,9 +223,6 @@ describe('Ronin Validator Set: Coinbase execution test', () => {
         .slice(0, 4)
         .reverse()
         .map((_) => _.consensusAddr.address);
-
-      console.log(validatorCandidates.map((_) => _.consensusAddr.address));
-      console.log(expectingValidatorsAddr);
 
       await expect(tx!).emit(roninValidatorSet, 'WrappedUpEpoch').withArgs(lastPeriod, epoch, true);
       lastPeriod = await roninValidatorSet.currentPeriod();
@@ -279,7 +277,7 @@ describe('Ronin Validator Set: Coinbase execution test', () => {
             validatorCandidates[i].bridgeOperator.address,
             2_00,
             {
-              value: minValidatorStakingAmount.add(i * 5),
+              value: minValidatorStakingAmount.add(i * dummyStakingMultiplier),
             }
           );
       }
@@ -300,9 +298,6 @@ describe('Ronin Validator Set: Coinbase execution test', () => {
           ),
         ];
       });
-
-      console.log(validatorCandidates.map((_) => _.consensusAddr.address));
-      console.log(currentValidatorSet);
 
       await expect(tx!).emit(roninValidatorSet, 'WrappedUpEpoch').withArgs(lastPeriod, epoch, true);
       lastPeriod = await roninValidatorSet.currentPeriod();
@@ -342,9 +337,6 @@ describe('Ronin Validator Set: Coinbase execution test', () => {
             ),
           ];
         });
-
-        console.log(validatorCandidates.map((_) => _.consensusAddr.address));
-        console.log(expectingValidatorsAddr);
 
         await expect(tx!).emit(roninValidatorSet, 'WrappedUpEpoch').withArgs(lastPeriod, epoch, true);
         lastPeriod = await roninValidatorSet.currentPeriod();
@@ -444,13 +436,15 @@ describe('Ronin Validator Set: Coinbase execution test', () => {
       lastPeriod = await roninValidatorSet.currentPeriod();
 
       let balanceAfter = await currValidator.poolAdmin.getBalance();
-      expect(balanceAfter.sub(balanceBefore)).eq(minValidatorStakingAmount.add(4).add(unclaimedReward));
+      expect(balanceAfter.sub(balanceBefore)).eq(
+        minValidatorStakingAmount.add(4 * dummyStakingMultiplier).add(unclaimedReward)
+      );
     });
 
     it('Should the self-staking amount get refunded', async () => {
       await expect(wrapupEpochTx!)
         .emit(stakingContract, 'Unstaked')
-        .withArgs(currValidator.consensusAddr.address, minValidatorStakingAmount.add(4));
+        .withArgs(currValidator.consensusAddr.address, minValidatorStakingAmount.add(4 * dummyStakingMultiplier));
     });
 
     it('Should the unclaimed reward amount get transferred on revoke, and the claimable reward get reset', async () => {

--- a/test/validator/RoninValidatorSet-CoinbaseExecution.test.ts
+++ b/test/validator/RoninValidatorSet-CoinbaseExecution.test.ts
@@ -75,9 +75,7 @@ describe('Ronin Validator Set: Coinbase execution test', () => {
     treasury = poolAdmin;
 
     trustedOrgs = createManyTrustedOrganizationAddressSets(signers.splice(0, 3));
-    validatorCandidates = createManyValidatorCandidateAddressSets(
-      signers.splice(0, localValidatorCandidatesLength * 3)
-    );
+    validatorCandidates = createManyValidatorCandidateAddressSets(signers.slice(0, localValidatorCandidatesLength * 3));
 
     await network.provider.send('hardhat_setCoinbase', [consensusAddr.address]);
 
@@ -188,7 +186,7 @@ describe('Ronin Validator Set: Coinbase execution test', () => {
             validatorCandidates[i].bridgeOperator.address,
             2_00,
             {
-              value: minValidatorStakingAmount.add(i * 5),
+              value: minValidatorStakingAmount.add(i),
             }
           );
       }
@@ -218,13 +216,10 @@ describe('Ronin Validator Set: Coinbase execution test', () => {
         tx = await roninValidatorSet.connect(consensusAddr).wrapUpEpoch();
       });
 
-      expectingValidatorsAddr = validatorCandidates // [candidates[4..1]]
+      expectingValidatorsAddr = validatorCandidates
         .slice(0, 4)
         .reverse()
         .map((_) => _.consensusAddr.address);
-
-      console.log(validatorCandidates.map((_) => _.consensusAddr.address));
-      console.log(expectingValidatorsAddr);
 
       await expect(tx!).emit(roninValidatorSet, 'WrappedUpEpoch').withArgs(lastPeriod, epoch, true);
       lastPeriod = await roninValidatorSet.currentPeriod();
@@ -233,27 +228,14 @@ describe('Ronin Validator Set: Coinbase execution test', () => {
       expect(await roninValidatorSet.getBlockProducers()).eql(expectingValidatorsAddr);
     });
 
-    it('Should validator is set with correct flags', async () => {
+    it('Should isValidator method returns `true` for validator', async () => {
       for (let validatorAddr of expectingValidatorsAddr) {
-        expect(await roninValidatorSet.isValidator(validatorAddr)).eq(
-          true,
-          `Wrong validator flag for ${validatorAddr}`
-        );
-        expect(await roninValidatorSet.isBlockProducer(validatorAddr)).eq(
-          true,
-          `Wrong block producer flag for ${validatorAddr}`
-        );
-        expect(await roninValidatorSet.isOperatingBridge(validatorAddr)).eq(
-          true,
-          `Wrong operating bridge flag for ${validatorAddr}`
-        );
+        expect(await roninValidatorSet.isValidator(validatorAddr)).eq(true);
       }
     });
 
-    it('Should non-validator is set with correct flags', async () => {
+    it('Should isValidator method returns `false` for non-validator', async () => {
       expect(await roninValidatorSet.isValidator(deployer.address)).eq(false);
-      expect(await roninValidatorSet.isBlockProducer(deployer.address)).eq(false);
-      expect(await roninValidatorSet.isBridgeOperator(deployer.address)).eq(false);
     });
 
     it(`Should be able to wrap up epoch at the end of period and pick top ${maxValidatorNumber} to be validators`, async () => {
@@ -279,7 +261,7 @@ describe('Ronin Validator Set: Coinbase execution test', () => {
             validatorCandidates[i].bridgeOperator.address,
             2_00,
             {
-              value: minValidatorStakingAmount.add(i * 5),
+              value: minValidatorStakingAmount.add(i),
             }
           );
       }
@@ -293,82 +275,18 @@ describe('Ronin Validator Set: Coinbase execution test', () => {
         await roninValidatorSet.endEpoch();
         tx = await roninValidatorSet.connect(consensusAddr).wrapUpEpoch();
         currentValidatorSet = [
-          // [coinbase, candidates[4..2]]
           consensusAddr.address,
-          ...[validatorCandidates[4], validatorCandidates[3], validatorCandidates[2]].map(
-            (_) => _.consensusAddr.address
-          ),
+          ...validatorCandidates
+            .slice(2)
+            .reverse()
+            .map((_) => _.consensusAddr.address),
         ];
       });
-
-      console.log(validatorCandidates.map((_) => _.consensusAddr.address));
-      console.log(currentValidatorSet);
-
       await expect(tx!).emit(roninValidatorSet, 'WrappedUpEpoch').withArgs(lastPeriod, epoch, true);
       lastPeriod = await roninValidatorSet.currentPeriod();
       await RoninValidatorSetExpects.emitValidatorSetUpdatedEvent(tx!, lastPeriod, currentValidatorSet);
       expect(await roninValidatorSet.getValidators()).eql(currentValidatorSet);
       expect(await roninValidatorSet.getBlockProducers()).eql(currentValidatorSet);
-    });
-  });
-
-  describe('Setting new validator set', async () => {
-    before(async () => {
-      snapshotId = await network.provider.send('evm_snapshot');
-    });
-
-    after(async () => {
-      await network.provider.send('evm_revert', [snapshotId]);
-    });
-
-    describe('Case updating from [V100,V4,V3,V2] --> [V100,V3,V4,V2]', async () => {
-      let expectingValidatorsAddr: Address[];
-      it('Should the validator set is updated correctly', async () => {
-        // [(V4: 20), (V3: 15), (V2: 10)] ---> [(V3: 21), (V4: 20), (V2: 10)]
-        await stakingContract.connect(signers[0]).delegate(validatorCandidates[3].consensusAddr.address, { value: 6 });
-
-        let tx: ContractTransaction;
-        await EpochController.setTimestampToPeriodEnding();
-        epoch = await roninValidatorSet.epochOf(await ethers.provider.getBlockNumber());
-        lastPeriod = await roninValidatorSet.currentPeriod();
-        await mineBatchTxs(async () => {
-          await roninValidatorSet.endEpoch();
-          tx = await roninValidatorSet.connect(consensusAddr).wrapUpEpoch();
-          expectingValidatorsAddr = [
-            // [coinbase, candidates[3], candidates[4], candidates[2]]
-            consensusAddr.address,
-            ...[validatorCandidates[3], validatorCandidates[4], validatorCandidates[2]].map(
-              (_) => _.consensusAddr.address
-            ),
-          ];
-        });
-
-        console.log(validatorCandidates.map((_) => _.consensusAddr.address));
-        console.log(expectingValidatorsAddr);
-
-        await expect(tx!).emit(roninValidatorSet, 'WrappedUpEpoch').withArgs(lastPeriod, epoch, true);
-        lastPeriod = await roninValidatorSet.currentPeriod();
-        await RoninValidatorSetExpects.emitValidatorSetUpdatedEvent(tx!, lastPeriod, expectingValidatorsAddr);
-      });
-
-      it('Should validator is set with correct flags', async () => {
-        expect(await roninValidatorSet.getValidators()).eql(expectingValidatorsAddr);
-        expect(await roninValidatorSet.getBlockProducers()).eql(expectingValidatorsAddr);
-        for (let validatorAddr of expectingValidatorsAddr) {
-          expect(await roninValidatorSet.isValidator(validatorAddr)).eq(
-            true,
-            `Wrong validator flag for ${validatorAddr}`
-          );
-          expect(await roninValidatorSet.isBlockProducer(validatorAddr)).eq(
-            true,
-            `Wrong block producer flag for ${validatorAddr}`
-          );
-          expect(await roninValidatorSet.isOperatingBridge(validatorAddr)).eq(
-            true,
-            `Wrong operating bridge flag for ${validatorAddr}`
-          );
-        }
-      });
     });
   });
 


### PR DESCRIPTION
### Description
https://skymavis.atlassian.net/browse/PSC-198?atlOrigin=eyJpIjoiNWIzZTc4MzBjOWQ0NDQ0ZGI5YWJjOTlmM2E0YzIxYTIiLCJwIjoiaiJ9

When updating the validator set from `[A, B, C]` to `[A, C, B]`, the flag mapping of `C` is incorrectly updated in `_setNewValidatorSet`. This flag mapping is later updated correctly in `_revampRoles` method. However, this is still a potential issue and needs to be mitigated.

### Contract changes

The table below shows the following info:
- **Logic**: the logic is changed.
- **ABI**: the ABI is changed.
- **Init data**: new storage field is declared and needs initializing.
- **Dependent**: needs to be changed due to changes in other contracts.

| **Contract name** | **Logic** | **ABI** | **Init data** | **Dependent** |
|-------------------|:---------:|:-------:|:-------------:|:-------------:|
| BridgeTracking    |           |         |               |               |
| GovernanceAdmin   |           |         |               |               |
| Maintenance       |           |         |               |               |
| SlashIndicator    |        |         |               |               |
| Staking           |           |         |               |               |
| StakingVesting    |           |         |               |               |
| ValidatorSet      |     [x]      |         |               |               |

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
