### PR TITLE
[ValidatorSet] Add method check bridge slashing tier-1

### DIFF
--- a/contracts/interfaces/validator/info-fragments/IJailingInfo.sol
+++ b/contracts/interfaces/validator/info-fragments/IJailingInfo.sol
@@ -54,4 +54,10 @@ interface IJailingInfo {
     external
     view
     returns (bool[] memory);
+
+  /**
+   * @dev Returns whether the incoming reward of the validator with `_consensusAddr` is deprecated in the current period.
+   */
+
+  function checkBridgeRewardDeprecated(address _consensusAddr) external view returns (bool _result);
 }

--- a/contracts/mocks/validator/MockValidatorSet.sol
+++ b/contracts/mocks/validator/MockValidatorSet.sol
@@ -50,6 +50,8 @@ contract MockValidatorSet is IRoninValidatorSet, CandidateManager {
 
   function checkMiningRewardDeprecated(address[] calldata) external view override returns (bool[] memory) {}
 
+  function checkBridgeRewardDeprecated(address _consensusAddr) external view returns (bool _result) {}
+
   function epochOf(uint256 _block) external view override returns (uint256) {}
 
   function getValidators() external view override returns (address[] memory) {}

--- a/contracts/ronin/validator/storage-fragments/JailingStorage.sol
+++ b/contracts/ronin/validator/storage-fragments/JailingStorage.sol
@@ -121,6 +121,14 @@ abstract contract JailingStorage is IJailingInfo {
   }
 
   /**
+   * @inheritdoc IJailingInfo
+   */
+  function checkBridgeRewardDeprecated(address _consensusAddr) external view override returns (bool _result) {
+    uint256 _period = currentPeriod();
+    return _bridgeRewardDeprecated(_consensusAddr, _period);
+  }
+
+  /**
    * @dev See `ITimingInfo-epochOf`
    */
   function epochOf(uint256 _block) public view virtual returns (uint256);


### PR DESCRIPTION
### Description

Add method check bridge slashing tier-1: `checkBridgeRewardDeprecated`

### Contract changes

The table below shows the following info:
- **Logic**: the logic is changed.
- **ABI**: the ABI is changed.
- **Init data**: new storage field is declared and needs initializing.
- **Dependent**: needs to be changed due to changes in other contracts.

| **Contract name** | **Logic** | **ABI** | **Init data** | **Dependent** |
|-------------------|:---------:|:-------:|:-------------:|:-------------:|
| BridgeTracking    |           |         |               |               |
| GovernanceAdmin   |           |         |               |               |
| Maintenance       |           |         |               |               |
| SlashIndicator    |           |         |               |               |
| Staking           |           |         |               |               |
| StakingVesting    |           |         |               |               |
| ValidatorSet      |    [x]       |    [x]     |               |               |

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
