### PR TITLE
[ValidatorSet] Add getter for bridge slash at period. Remove batch getters.

### DIFF
--- a/contracts/interfaces/validator/info-fragments/IJailingInfo.sol
+++ b/contracts/interfaces/validator/info-fragments/IJailingInfo.sol
@@ -58,6 +58,13 @@ interface IJailingInfo {
   /**
    * @dev Returns whether the incoming reward of the validator with `_consensusAddr` is deprecated in the current period.
    */
-
   function checkBridgeRewardDeprecated(address _consensusAddr) external view returns (bool _result);
+
+  /**
+   * @dev Returns whether the incoming reward of the validator with `_consensusAddr` is deprecated in the  `_period`.
+   */
+  function checkBridgeRewardDeprecatedAtPeriod(address _consensusAddr, uint256 _period)
+    external
+    view
+    returns (bool _result);
 }

--- a/contracts/interfaces/validator/info-fragments/IJailingInfo.sol
+++ b/contracts/interfaces/validator/info-fragments/IJailingInfo.sol
@@ -43,17 +43,14 @@ interface IJailingInfo {
   function checkManyJailed(address[] calldata) external view returns (bool[] memory);
 
   /**
-   * @dev Returns whether the incoming reward of the block producers are deprecated during the current period.
+   * @dev Returns whether the incoming reward of the block producer is deprecated during the current period.
    */
-  function checkMiningRewardDeprecated(address[] calldata _blockProducers) external view returns (bool[] memory);
+  function checkMiningRewardDeprecated(address _blockProducer) external view returns (bool);
 
   /**
-   * @dev Returns whether the incoming reward of the block producers are deprecated during a specific period.
+   * @dev Returns whether the incoming reward of the block producer is deprecated during a specific period.
    */
-  function checkMiningRewardDeprecatedAtPeriod(address[] calldata _blockProducers, uint256 _period)
-    external
-    view
-    returns (bool[] memory);
+  function checkMiningRewardDeprecatedAtPeriod(address _blockProducer, uint256 _period) external view returns (bool);
 
   /**
    * @dev Returns whether the incoming reward of the validator with `_consensusAddr` is deprecated in the current period.

--- a/contracts/interfaces/validator/info-fragments/IJailingInfo.sol
+++ b/contracts/interfaces/validator/info-fragments/IJailingInfo.sol
@@ -53,9 +53,9 @@ interface IJailingInfo {
   function checkMiningRewardDeprecatedAtPeriod(address _blockProducer, uint256 _period) external view returns (bool);
 
   /**
-   * @dev Returns whether the incoming reward of the validator with `_consensusAddr` is deprecated in the current period.
+   * @dev Returns whether the incoming reward of the validator with `_consensusAddr` is deprecated in the latest wrapped up period.
    */
-  function checkBridgeRewardDeprecated(address _consensusAddr) external view returns (bool _result);
+  function checkBridgeRewardDeprecatedAtLatestPeriod(address _consensusAddr) external view returns (bool _result);
 
   /**
    * @dev Returns whether the incoming reward of the validator with `_consensusAddr` is deprecated in the  `_period`.

--- a/contracts/mocks/validator/MockValidatorSet.sol
+++ b/contracts/mocks/validator/MockValidatorSet.sol
@@ -41,14 +41,9 @@ contract MockValidatorSet is IRoninValidatorSet, CandidateManager {
 
   function checkManyJailed(address[] calldata) external view override returns (bool[] memory) {}
 
-  function checkMiningRewardDeprecatedAtPeriod(address[] calldata, uint256 _period)
-    external
-    view
-    override
-    returns (bool[] memory)
-  {}
+  function checkMiningRewardDeprecatedAtPeriod(address, uint256 _period) external view override returns (bool) {}
 
-  function checkMiningRewardDeprecated(address[] calldata) external view override returns (bool[] memory) {}
+  function checkMiningRewardDeprecated(address) external view override returns (bool) {}
 
   function checkBridgeRewardDeprecated(address _consensusAddr) external view returns (bool _result) {}
 

--- a/contracts/mocks/validator/MockValidatorSet.sol
+++ b/contracts/mocks/validator/MockValidatorSet.sol
@@ -45,7 +45,12 @@ contract MockValidatorSet is IRoninValidatorSet, CandidateManager {
 
   function checkMiningRewardDeprecated(address) external view override returns (bool) {}
 
-  function checkBridgeRewardDeprecated(address _consensusAddr) external view returns (bool _result) {}
+  function checkBridgeRewardDeprecatedAtLatestPeriod(address _consensusAddr)
+    external
+    view
+    override
+    returns (bool _result)
+  {}
 
   function checkBridgeRewardDeprecatedAtPeriod(address _consensusAddr, uint256 _period)
     external

--- a/contracts/mocks/validator/MockValidatorSet.sol
+++ b/contracts/mocks/validator/MockValidatorSet.sol
@@ -52,6 +52,12 @@ contract MockValidatorSet is IRoninValidatorSet, CandidateManager {
 
   function checkBridgeRewardDeprecated(address _consensusAddr) external view returns (bool _result) {}
 
+  function checkBridgeRewardDeprecatedAtPeriod(address _consensusAddr, uint256 _period)
+    external
+    view
+    returns (bool _result)
+  {}
+
   function epochOf(uint256 _block) external view override returns (uint256) {}
 
   function getValidators() external view override returns (address[] memory) {}

--- a/contracts/ronin/validator/storage-fragments/JailingStorage.sol
+++ b/contracts/ronin/validator/storage-fragments/JailingStorage.sol
@@ -111,9 +111,17 @@ abstract contract JailingStorage is IJailingInfo {
 
   /**
    * @inheritdoc IJailingInfo
+   *
+   * @dev Because the information of deprecating bridge reward of a period is only determined at the end of that period, this
+   * method will return the deprecating info of the latest period. A method for querying that info of current period is no need.
    */
-  function checkBridgeRewardDeprecated(address _consensusAddr) external view override returns (bool _result) {
-    uint256 _period = currentPeriod();
+  function checkBridgeRewardDeprecatedAtLatestPeriod(address _consensusAddr)
+    external
+    view
+    override
+    returns (bool _result)
+  {
+    uint256 _period = currentPeriod() - 1;
     return _bridgeRewardDeprecated(_consensusAddr, _period);
   }
 

--- a/contracts/ronin/validator/storage-fragments/JailingStorage.sol
+++ b/contracts/ronin/validator/storage-fragments/JailingStorage.sol
@@ -129,6 +129,18 @@ abstract contract JailingStorage is IJailingInfo {
   }
 
   /**
+   * @inheritdoc IJailingInfo
+   */
+  function checkBridgeRewardDeprecatedAtPeriod(address _consensusAddr, uint256 _period)
+    external
+    view
+    override
+    returns (bool _result)
+  {
+    return _bridgeRewardDeprecated(_consensusAddr, _period);
+  }
+
+  /**
    * @dev See `ITimingInfo-epochOf`
    */
   function epochOf(uint256 _block) public view virtual returns (uint256);

--- a/contracts/ronin/validator/storage-fragments/JailingStorage.sol
+++ b/contracts/ronin/validator/storage-fragments/JailingStorage.sol
@@ -92,32 +92,21 @@ abstract contract JailingStorage is IJailingInfo {
   /**
    * @inheritdoc IJailingInfo
    */
-  function checkMiningRewardDeprecated(address[] calldata _blockProducers)
-    external
-    view
-    override
-    returns (bool[] memory _result)
-  {
-    _result = new bool[](_blockProducers.length);
+  function checkMiningRewardDeprecated(address _blockProducer) external view override returns (bool _result) {
     uint256 _period = currentPeriod();
-    for (uint256 _i; _i < _blockProducers.length; _i++) {
-      _result[_i] = _miningRewardDeprecated(_blockProducers[_i], _period);
-    }
+    return _miningRewardDeprecated(_blockProducer, _period);
   }
 
   /**
    * @inheritdoc IJailingInfo
    */
-  function checkMiningRewardDeprecatedAtPeriod(address[] calldata _blockProducers, uint256 _period)
+  function checkMiningRewardDeprecatedAtPeriod(address _blockProducer, uint256 _period)
     external
     view
     override
-    returns (bool[] memory _result)
+    returns (bool _result)
   {
-    _result = new bool[](_blockProducers.length);
-    for (uint256 _i; _i < _blockProducers.length; _i++) {
-      _result[_i] = _miningRewardDeprecated(_blockProducers[_i], _period);
-    }
+    return _miningRewardDeprecated(_blockProducer, _period);
   }
 
   /**


### PR DESCRIPTION
### Description
Remove methods to reduce contract size. DApp must migrate to these new methods.

- Add methods for checking deprecated reward of:
    - `mining()`
    - `miningAtPeriod(uint256)`
    - `bridgeAtLatestPeriod()`
    - `bridgeAtPeriod(uint256)`
   
- Remove methods:
    - `function checkBridgeRewardDeprecated(address _consensusAddr) external view returns (bool _result)`
    - `function checkMiningRewardDeprecated(address[] calldata _blockProducers) external view returns (bool[] memory);` 
    - `function checkMiningRewardDeprecatedAtPeriod(address[] calldata _blockProducers, uint256 _period) external view returns (bool[] memory);`
### Contract changes

The table below shows the following info:
- **Logic**: the logic is changed.
- **ABI**: the ABI is changed.
- **Init data**: new storage field is declared and needs initializing.
- **Dependent**: needs to be changed due to changes in other contracts.

| **Contract name** | **Logic** | **ABI** | **Init data** | **Dependent** |
|-------------------|:---------:|:-------:|:-------------:|:-------------:|
| BridgeTracking    |           |         |               |               |
| GovernanceAdmin   |           |         |               |               |
| Maintenance       |           |         |               |               |
| SlashIndicator    |           |         |               |               |
| Staking           |           |         |               |               |
| StakingVesting    |           |         |               |               |
| ValidatorSet      |    [x]      |    [x]     |               |               |

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
