### PR TITLE
Fix addition gas in external calls

### DIFF
--- a/contracts/extensions/consumers/GlobalConfigConsumer.sol
+++ b/contracts/extensions/consumers/GlobalConfigConsumer.sol
@@ -3,8 +3,8 @@
 pragma solidity ^0.8.9;
 
 abstract contract GlobalConfigConsumer {
-  /// The addition amount of gas stipend send along in external calls.
-  uint256 public constant DEFAULT_ADDITION_GAS = 3500;
+  /// @dev The addition amount of gas sending along in external calls. Total gas stipend is added with default 2300 gas.
+  uint256 public constant DEFAULT_ADDITION_GAS = 1200;
   /// @dev The length of a period in second.
   uint256 public constant PERIOD_DURATION = 1 days;
 }

--- a/contracts/extensions/consumers/GlobalConfigConsumer.sol
+++ b/contracts/extensions/consumers/GlobalConfigConsumer.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.9;
+
+abstract contract GlobalConfigConsumer {
+  /// The addition amount of gas stipend send along in external calls.
+  uint256 public constant DEFAULT_ADDITION_GAS = 3500;
+  /// @dev The length of a period in second.
+  uint256 public constant PERIOD_DURATION = 1 days;
+}

--- a/contracts/mocks/MockStaking.sol
+++ b/contracts/mocks/MockStaking.sol
@@ -2,9 +2,10 @@
 
 pragma solidity ^0.8.9;
 
+import "../extensions/consumers/GlobalConfigConsumer.sol";
 import "../ronin/staking/RewardCalculation.sol";
 
-contract MockStaking is RewardCalculation {
+contract MockStaking is RewardCalculation, GlobalConfigConsumer {
   /// @dev Mapping from user => staking balance
   mapping(address => uint256) internal _stakingAmount;
   /// @dev Mapping from period number => slashed
@@ -22,7 +23,7 @@ contract MockStaking is RewardCalculation {
 
   function firstEverWrapup() external {
     delete pendingReward;
-    lastUpdatedPeriod = block.timestamp / 1 days + 1;
+    lastUpdatedPeriod = block.timestamp / PERIOD_DURATION + 1;
   }
 
   function endPeriod() external {

--- a/contracts/mocks/MockTransferFallback.sol
+++ b/contracts/mocks/MockTransferFallback.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
+
+import "../extensions/RONTransferHelper.sol";
+import "hardhat/console.sol";
+
+contract MockPaymentFallback {
+  event SafeReceived(address indexed sender, uint256 value);
+
+  /// @dev Fallback function accepts Ether transactions.
+  receive() external payable {
+    emit SafeReceived(msg.sender, msg.value);
+  }
+}
+
+contract MockPaymentFallbackExpensive {
+  uint[] public array;
+  event SafeReceived(address indexed sender, uint256 value);
+
+  constructor() {
+    array.push(0);
+  }
+
+  /// @dev Fallback function accepts Ether transactions.
+  receive() external payable {
+    // console.log(gasleft());
+    array.push(block.number);
+    // console.log(gasleft());
+    emit SafeReceived(msg.sender, msg.value);
+  }
+}
+
+contract MockTransfer is RONTransferHelper {
+  uint256 public track;
+
+  constructor() payable {}
+
+  function fooTransfer(
+    address payable _recipient,
+    uint256 _amount,
+    uint256 _gas
+  ) external {
+    if (_unsafeSendRON(_recipient, _amount, _gas)) {
+      track++;
+    }
+  }
+}

--- a/contracts/mocks/MockTransferFallback.sol
+++ b/contracts/mocks/MockTransferFallback.sol
@@ -2,12 +2,11 @@
 pragma solidity ^0.8.9;
 
 import "../extensions/RONTransferHelper.sol";
-import "hardhat/console.sol";
 
 contract MockPaymentFallback {
   event SafeReceived(address indexed sender, uint256 value);
 
-  /// @dev Fallback function accepts Ether transactions.
+  /// @dev Fallback function accepts ether transactions.
   receive() external payable {
     emit SafeReceived(msg.sender, msg.value);
   }
@@ -21,11 +20,9 @@ contract MockPaymentFallbackExpensive {
     array.push(0);
   }
 
-  /// @dev Fallback function accepts Ether transactions.
+  /// @dev Fallback function accepts ether transactions and set non-zero value to a zero value slot.
   receive() external payable {
-    // console.log(gasleft());
     array.push(block.number);
-    // console.log(gasleft());
     emit SafeReceived(msg.sender, msg.value);
   }
 }

--- a/contracts/ronin/staking/CandidateStaking.sol
+++ b/contracts/ronin/staking/CandidateStaking.sol
@@ -2,12 +2,13 @@
 
 pragma solidity ^0.8.9;
 
+import "../../extensions/consumers/GlobalConfigConsumer.sol";
 import "../../extensions/consumers/PercentageConsumer.sol";
 import "../../libraries/AddressArrayUtils.sol";
 import "../../interfaces/staking/ICandidateStaking.sol";
 import "./BaseStaking.sol";
 
-abstract contract CandidateStaking is BaseStaking, ICandidateStaking, PercentageConsumer {
+abstract contract CandidateStaking is BaseStaking, ICandidateStaking, GlobalConfigConsumer, PercentageConsumer {
   /// @dev The minimum threshold for being a validator candidate.
   uint256 internal _minValidatorStakingAmount;
 
@@ -111,7 +112,7 @@ abstract contract CandidateStaking is BaseStaking, ICandidateStaking, Percentage
       uint256 _deductingAmount = _pool.stakingAmount;
       if (_deductingAmount > 0) {
         _deductStakingAmount(_pool, _deductingAmount);
-        if (!_unsafeSendRON(payable(_pool.admin), _deductingAmount, 3500)) {
+        if (!_unsafeSendRON(payable(_pool.admin), _deductingAmount, DEFAULT_ADDITION_GAS)) {
           emit StakingAmountTransferFailed(_pool.addr, _pool.admin, _deductingAmount, address(this).balance);
         }
       }
@@ -119,7 +120,7 @@ abstract contract CandidateStaking is BaseStaking, ICandidateStaking, Percentage
       // Settle the unclaimed reward and transfer to the pool admin.
       uint256 _lastRewardAmount = _claimReward(_pools[_i], _pool.admin, _newPeriod);
       if (_lastRewardAmount > 0) {
-        _unsafeSendRON(payable(_pool.admin), _lastRewardAmount, 3500);
+        _unsafeSendRON(payable(_pool.admin), _lastRewardAmount, DEFAULT_ADDITION_GAS);
       }
     }
 
@@ -149,7 +150,7 @@ abstract contract CandidateStaking is BaseStaking, ICandidateStaking, Percentage
     if (_remainAmount < _minValidatorStakingAmount) revert ErrStakingAmountLeft();
 
     _unstake(_pool, _requester, _amount);
-    if (!_unsafeSendRON(payable(_requester), _amount, 3500)) revert ErrCannotTransferRON();
+    if (!_unsafeSendRON(payable(_requester), _amount, DEFAULT_ADDITION_GAS)) revert ErrCannotTransferRON();
   }
 
   /**

--- a/contracts/ronin/staking/Staking.sol
+++ b/contracts/ronin/staking/Staking.sol
@@ -56,7 +56,7 @@ contract Staking is IStaking, CandidateStaking, DelegatorStaking, Initializable 
   {
     _actualDeductingAmount = _deductStakingAmount(_stakingPool[_consensusAddr], _amount);
     address payable _recipientAddr = payable(validatorContract());
-    if (!_unsafeSendRON(_recipientAddr, _actualDeductingAmount, 3500)) {
+    if (!_unsafeSendRON(_recipientAddr, _actualDeductingAmount, DEFAULT_ADDITION_GAS)) {
       emit StakingAmountDeductFailed(_consensusAddr, _recipientAddr, _actualDeductingAmount, address(this).balance);
     }
   }

--- a/contracts/ronin/staking/Staking.sol
+++ b/contracts/ronin/staking/Staking.sol
@@ -55,9 +55,14 @@ contract Staking is IStaking, CandidateStaking, DelegatorStaking, Initializable 
     returns (uint256 _actualDeductingAmount)
   {
     _actualDeductingAmount = _deductStakingAmount(_stakingPool[_consensusAddr], _amount);
-    address payable _recipientAddr = payable(validatorContract());
-    if (!_unsafeSendRON(_recipientAddr, _actualDeductingAmount, DEFAULT_ADDITION_GAS)) {
-      emit StakingAmountDeductFailed(_consensusAddr, _recipientAddr, _actualDeductingAmount, address(this).balance);
+    address payable _validatorContractAddr = payable(validatorContract());
+    if (!_unsafeSendRON(_validatorContractAddr, _actualDeductingAmount)) {
+      emit StakingAmountDeductFailed(
+        _consensusAddr,
+        _validatorContractAddr,
+        _actualDeductingAmount,
+        address(this).balance
+      );
     }
   }
 

--- a/contracts/ronin/validator/CandidateManager.sol
+++ b/contracts/ronin/validator/CandidateManager.sol
@@ -3,11 +3,12 @@
 pragma solidity ^0.8.9;
 
 import "../../extensions/collections/HasStakingContract.sol";
+import "../../extensions/consumers/GlobalConfigConsumer.sol";
 import "../../extensions/consumers/PercentageConsumer.sol";
 import "../../interfaces/validator/ICandidateManager.sol";
 import "../../interfaces/staking/IStaking.sol";
 
-abstract contract CandidateManager is ICandidateManager, PercentageConsumer, HasStakingContract {
+abstract contract CandidateManager is ICandidateManager, PercentageConsumer, GlobalConfigConsumer, HasStakingContract {
   /// @dev Maximum number of validator candidate
   uint256 private _maxValidatorCandidate;
 
@@ -124,7 +125,7 @@ abstract contract CandidateManager is ICandidateManager, PercentageConsumer, Has
     if (_effectiveDaysOnwards < _minEffectiveDaysOnwards) revert ErrInvalidEffectiveDaysOnwards();
 
     CommissionSchedule storage _schedule = _candidateCommissionChangeSchedule[_consensusAddr];
-    uint256 _effectiveTimestamp = ((block.timestamp / 1 days) + _effectiveDaysOnwards) * 1 days;
+    uint256 _effectiveTimestamp = ((block.timestamp / PERIOD_DURATION) + _effectiveDaysOnwards) * PERIOD_DURATION;
     _schedule.effectiveTimestamp = _effectiveTimestamp;
     _schedule.commissionRate = _commissionRate;
 

--- a/contracts/ronin/validator/CoinbaseExecution.sol
+++ b/contracts/ronin/validator/CoinbaseExecution.sol
@@ -189,14 +189,8 @@ abstract contract CoinbaseExecution is
       return;
     }
 
-    // unchecked {
     uint256 _votedRatio = (_validatorBallots * _MAX_PERCENTAGE) / _totalVotes;
     uint256 _missedRatio = _MAX_PERCENTAGE - _votedRatio;
-    //   if () {
-    //     emit Error();
-    //   }
-    // }
-
     if (_missedRatio >= _ratioTier2) {
       _bridgeRewardDeprecatedAtPeriod[_validator][_period] = true;
       _miningRewardDeprecatedAtPeriod[_validator][_period] = true;

--- a/contracts/ronin/validator/CoinbaseExecution.sol
+++ b/contracts/ronin/validator/CoinbaseExecution.sol
@@ -189,8 +189,14 @@ abstract contract CoinbaseExecution is
       return;
     }
 
+    // unchecked {
     uint256 _votedRatio = (_validatorBallots * _MAX_PERCENTAGE) / _totalVotes;
     uint256 _missedRatio = _MAX_PERCENTAGE - _votedRatio;
+    //   if () {
+    //     emit Error();
+    //   }
+    // }
+
     if (_missedRatio >= _ratioTier2) {
       _bridgeRewardDeprecatedAtPeriod[_validator][_period] = true;
       _miningRewardDeprecatedAtPeriod[_validator][_period] = true;
@@ -269,7 +275,7 @@ abstract contract CoinbaseExecution is
   function _distributeMiningReward(address _consensusAddr, address payable _treasury) private {
     uint256 _amount = _miningReward[_consensusAddr];
     if (_amount > 0) {
-      if (_unsafeSendRON(_treasury, _amount, 3500)) {
+      if (_unsafeSendRON(_treasury, _amount, DEFAULT_ADDITION_GAS)) {
         emit MiningRewardDistributed(_consensusAddr, _treasury, _amount);
         return;
       }
@@ -294,7 +300,7 @@ abstract contract CoinbaseExecution is
   ) private {
     uint256 _amount = _bridgeOperatingReward[_consensusAddr];
     if (_amount > 0) {
-      if (_unsafeSendRON(_treasury, _amount, 3500)) {
+      if (_unsafeSendRON(_treasury, _amount, DEFAULT_ADDITION_GAS)) {
         emit BridgeOperatorRewardDistributed(_consensusAddr, _bridgeOperator, _treasury, _amount);
         return;
       }

--- a/contracts/ronin/validator/EmergencyExit.sol
+++ b/contracts/ronin/validator/EmergencyExit.sol
@@ -99,7 +99,7 @@ abstract contract EmergencyExit is IEmergencyExit, RONTransferHelper, CandidateM
       _lockedConsensusList.pop();
 
       _lockedFundReleased[_consensusAddr] = true;
-      if (_unsafeSendRON(_recipient, _amount, 3500)) {
+      if (_unsafeSendRON(_recipient, _amount, DEFAULT_ADDITION_GAS)) {
         emit EmergencyExitLockedFundReleased(_consensusAddr, _recipient, _amount);
         return;
       }

--- a/contracts/ronin/validator/storage-fragments/TimingStorage.sol
+++ b/contracts/ronin/validator/storage-fragments/TimingStorage.sol
@@ -2,12 +2,10 @@
 
 pragma solidity ^0.8.9;
 
+import "../../../extensions/consumers/GlobalConfigConsumer.sol";
 import "../../../interfaces/validator/info-fragments/ITimingInfo.sol";
 
-abstract contract TimingStorage is ITimingInfo {
-  /// @dev Length of period in seconds
-  uint256 internal constant _periodLength = 1 days;
-
+abstract contract TimingStorage is ITimingInfo, GlobalConfigConsumer {
   /// @dev The number of blocks in a epoch
   uint256 internal _numberOfBlocksInEpoch;
   /// @dev The last updated block
@@ -93,6 +91,6 @@ abstract contract TimingStorage is ITimingInfo {
    * @dev Returns the calculated period.
    */
   function _computePeriod(uint256 _timestamp) internal pure returns (uint256) {
-    return _timestamp / _periodLength;
+    return _timestamp / PERIOD_DURATION;
   }
 }

--- a/test/transfer/PaymentFallback.test.ts
+++ b/test/transfer/PaymentFallback.test.ts
@@ -1,0 +1,99 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+
+import {
+  MockPaymentFallback,
+  MockPaymentFallbackExpensive,
+  MockPaymentFallbackExpensive__factory,
+  MockPaymentFallback__factory,
+  MockTransfer,
+  MockTransfer__factory,
+} from '../../src/types';
+import { BigNumber } from 'ethers';
+
+let senderContract: MockTransfer;
+let receiverContract: MockPaymentFallback;
+let receiverExpensiveContract: MockPaymentFallbackExpensive;
+
+let deployer: SignerWithAddress;
+let signers: SignerWithAddress[];
+
+describe('Payment fallback test', () => {
+  before(async () => {
+    [deployer, ...signers] = await ethers.getSigners();
+    senderContract = await new MockTransfer__factory(deployer).deploy({ value: 1000 });
+    receiverContract = await new MockPaymentFallback__factory(deployer).deploy();
+    receiverExpensiveContract = await new MockPaymentFallbackExpensive__factory(deployer).deploy();
+  });
+  describe('Receiver contract only emit one event in fallback', async () => {
+    it('Should transfer successfully with 0 gas in addition', async () => {
+      let value = 1;
+      let gas = 0;
+      await expect(senderContract.fooTransfer(receiverContract.address, value, gas))
+        .emit(receiverContract, 'SafeReceived')
+        .withArgs(senderContract.address, value);
+    });
+    it('Should transfer successfully with 2300 gas in addition', async () => {
+      let value = 1;
+      let gas = 2300;
+      await expect(senderContract.fooTransfer(receiverContract.address, value, gas))
+        .emit(receiverContract, 'SafeReceived')
+        .withArgs(senderContract.address, value);
+    });
+    it('Should transfer successfully with 3500 gas in addition', async () => {
+      let value = 1;
+      let gas = 3500;
+      await expect(senderContract.fooTransfer(receiverContract.address, value, gas))
+        .emit(receiverContract, 'SafeReceived')
+        .withArgs(senderContract.address, value);
+    });
+  });
+  describe('Receiver contract only emit one event in fallback and set one storage in contract', async () => {
+    it('Should transfer failed with 0 gas in addition', async () => {
+      let value = 1;
+      let gas = 0;
+      let tx;
+      await expect(
+        async () => (tx = await senderContract.fooTransfer(receiverExpensiveContract.address, value, gas))
+      ).changeEtherBalances([receiverExpensiveContract.address], [BigNumber.from(0)]);
+      await expect(tx).not.emit(receiverExpensiveContract, 'SafeReceived');
+    });
+    it('Should transfer failed with 1000 gas in addition', async () => {
+      let value = 1;
+      let gas = 1000;
+      let tx;
+      await expect(
+        async () => (tx = await senderContract.fooTransfer(receiverExpensiveContract.address, value, gas))
+      ).changeEtherBalances([receiverExpensiveContract.address], [BigNumber.from(0)]);
+      await expect(tx).not.emit(receiverExpensiveContract, 'SafeReceived');
+    });
+    it('Should transfer failed with 2300 gas in addition', async () => {
+      let value = 1;
+      let gas = 2300;
+      let tx;
+      await expect(
+        async () => (tx = await senderContract.fooTransfer(receiverExpensiveContract.address, value, gas))
+      ).changeEtherBalances([receiverExpensiveContract.address], [BigNumber.from(0)]);
+      await expect(tx).not.emit(receiverExpensiveContract, 'SafeReceived');
+    });
+    it('Should transfer failed with 20000 gas in addition', async () => {
+      let value = 1;
+      let gas = 20000;
+      let tx;
+      await expect(
+        async () => (tx = await senderContract.fooTransfer(receiverExpensiveContract.address, value, gas))
+      ).changeEtherBalances([receiverExpensiveContract.address], [BigNumber.from(0)]);
+      await expect(tx).not.emit(receiverExpensiveContract, 'SafeReceived');
+    });
+    it('Should transfer successfully with 26000 gas in addition', async () => {
+      let value = 1;
+      let gas = 26000;
+      let tx;
+      await expect(
+        async () => (tx = await senderContract.fooTransfer(receiverExpensiveContract.address, value, gas))
+      ).changeEtherBalances([receiverExpensiveContract.address], [BigNumber.from(1)]);
+      await expect(tx).emit(receiverExpensiveContract, 'SafeReceived');
+    });
+  });
+});


### PR DESCRIPTION
### Description

In low-level call `<contract>.call{ value: _amount, gas: _gas }()`, the actual amount of gas stipend forwarding to the external is `2300 + _gas`. The compiler determines this, regardless of hardfork of the chain.

Since we design that the recipient will receive 3500 gas (as in #127), this PR reduces the number of 3500 in the parameter of `.call` to 1200.

### Contract storage
No slot of storage is shuffled after this PR.

### Contract changes

The table below shows the following info:
- **Logic**: the logic is changed.
- **ABI**: the ABI is changed.
- **Init data**: new storage field is declared and needs initializing.
- **Dependent**: needs to be changed due to changes in other contracts.

| **Contract name** | **Logic** | **ABI** | **Init data** | **Dependent** |
|-------------------|:---------:|:-------:|:-------------:|:-------------:|
| BridgeTracking    |           |         |               |               |
| GovernanceAdmin   |           |         |               |               |
| Maintenance       |           |         |               |               |
| SlashIndicator    |           |         |               |               |
| Staking           |     [x]      |         |               |               |
| StakingVesting    |           |         |               |               |
| ValidatorSet      |     [x]     |         |               |               |

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
