### PR TITLE
[ValidatorSet] Handling 0-length of memory array

### DIFF
--- a/contracts/ronin/validator/CandidateManager.sol
+++ b/contracts/ronin/validator/CandidateManager.sol
@@ -235,10 +235,11 @@ abstract contract CandidateManager is ICandidateManager, PercentageConsumer, Glo
       }
     }
 
+    assembly {
+      mstore(_unsatisfiedCandidates, _unsatisfiedCount)
+    }
+
     if (_unsatisfiedCount > 0) {
-      assembly {
-        mstore(_unsatisfiedCandidates, _unsatisfiedCount)
-      }
       emit CandidatesRevoked(_unsatisfiedCandidates);
       _staking.execDeprecatePools(_unsatisfiedCandidates, _nextPeriod);
     }


### PR DESCRIPTION
### Description

Previous code does not handle updating size of revoked candidates array, which causes false emission of event `CreditScoreUpdated(address(0))`.

### Contract changes

The table below shows the following info:
- **Logic**: the logic is changed.
- **ABI**: the ABI is changed.
- **Init data**: new storage field is declared and needs initializing.
- **Dependent**: needs to be changed due to changes in other contracts.

| **Contract name** | **Logic** | **ABI** | **Init data** | **Dependent** |
|-------------------|:---------:|:-------:|:-------------:|:-------------:|
| BridgeTracking    |           |         |               |               |
| GovernanceAdmin   |           |         |               |               |
| Maintenance       |           |         |               |               |
| SlashIndicator    |           |         |               |               |
| Staking           |           |         |               |               |
| StakingVesting    |           |         |               |               |
| ValidatorSet      |    [x]       |         |               |               |

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
