### PR TITLE
[Slash|ValidatorSet] Fix calculation of jail until block

### DIFF
--- a/contracts/libraries/Math.sol
+++ b/contracts/libraries/Math.sol
@@ -55,6 +55,13 @@ library Math {
    * @dev Returns value of a - b; in case of negative result, 0 is returned.
    */
   function subNonNegative(uint256 a, uint256 b) internal pure returns (uint256) {
-    return a - min(a, b);
+    return a > b ? a - b : 0;
+  }
+
+  /**
+   * @dev Returns value of `a + zeroable` if zerobale is not 0; otherwise, return 0.
+   */
+  function addIfNonZero(uint256 a, uint256 zeroable) internal pure returns (uint256) {
+    return zeroable != 0 ? a + zeroable : 0;
   }
 }

--- a/contracts/ronin/slash-indicator/SlashUnavailability.sol
+++ b/contracts/ronin/slash-indicator/SlashUnavailability.sol
@@ -57,12 +57,13 @@ abstract contract SlashUnavailability is ISlashUnavailability, HasValidatorContr
 
     uint256 _period = _validatorContract.currentPeriod();
     uint256 _count = ++_unavailabilityIndicator[_validatorAddr][_period];
+    uint256 _newJailedUntilBlock = Math.addIfNonZero(block.number, _jailDurationForUnavailabilityTier2Threshold);
 
     if (_count == _unavailabilityTier2Threshold) {
       emit Slashed(_validatorAddr, SlashType.UNAVAILABILITY_TIER_2, _period);
       _validatorContract.execSlash(
         _validatorAddr,
-        block.number + _jailDurationForUnavailabilityTier2Threshold,
+        _newJailedUntilBlock,
         _slashAmountForUnavailabilityTier2Threshold,
         false
       );
@@ -74,10 +75,9 @@ abstract contract SlashUnavailability is ISlashUnavailability, HasValidatorContr
       } else {
         /// Handles tier-3
         emit Slashed(_validatorAddr, SlashType.UNAVAILABILITY_TIER_3, _period);
-        uint256 _jailedUntilBlock = block.number + _jailDurationForUnavailabilityTier2Threshold;
         _validatorContract.execSlash(
           _validatorAddr,
-          _jailedUntilBlock,
+          _newJailedUntilBlock,
           _slashAmountForUnavailabilityTier2Threshold,
           true
         );


### PR DESCRIPTION
### Description
- Assert the block number that validator is put in jail are updated correctly:
    - No update if the jail duration is 0.
    - The `current block` is excluded when calculating with jail duration.
- Check the jail status of validators at the `current block + 1`

### Contract changes

The table below shows the following info:
- **Logic**: the logic is changed.
- **ABI**: the ABI is changed.
- **Init data**: new storage field is declared and needs initializing.
- **Dependent**: needs to be changed due to changes in other contracts.

| **Contract name** | **Logic** | **ABI** | **Init data** | **Dependent** |
|-------------------|:---------:|:-------:|:-------------:|:-------------:|
| BridgeTracking    |           |         |               |               |
| GovernanceAdmin   |           |         |               |               |
| Maintenance       |           |         |               |               |
| SlashIndicator    |      x     |         |               |               |
| Staking           |           |         |               |               |
| StakingVesting    |           |         |               |               |
| ValidatorSet      |     x      |         |               |               |

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
