### PR TITLE
[Staking] Remove cooldown when undelegate for renouncing candidate

### DIFF
--- a/contracts/ronin/staking/DelegatorStaking.sol
+++ b/contracts/ronin/staking/DelegatorStaking.sol
@@ -150,7 +150,15 @@ abstract contract DelegatorStaking is BaseStaking, IDelegatorStaking {
   ) private notPoolAdmin(_pool, _delegator) {
     if (_amount == 0) revert ErrUndelegateZeroAmount();
     if (_pool.delegatingAmount[_delegator] < _amount) revert ErrInsufficientDelegatingAmount();
-    if (_pool.lastDelegatingTimestamp[_delegator] + _cooldownSecsToUndelegate >= block.timestamp) {
+
+    bool _candidateRenounced;
+    if (_validatorContract.isValidatorCandidate(_pool.addr)) {
+      _candidateRenounced = _validatorContract.getCandidateInfo(_pool.addr).revokingTimestamp != 0;
+    }
+
+    if (
+      !_candidateRenounced && _pool.lastDelegatingTimestamp[_delegator] + _cooldownSecsToUndelegate >= block.timestamp
+    ) {
       revert ErrUndelegateTooEarly();
     }
 


### PR DESCRIPTION
### Description
Remove cooldown when undelegate for renouncing candidate

### Contract changes

The table below shows the following info:
- **Logic**: the logic is changed.
- **ABI**: the ABI is changed.
- **Init data**: new storage field is declared and needs initializing.
- **Dependent**: needs to be changed due to changes in other contracts.

| **Contract name** | **Logic** | **ABI** | **Init data** | **Dependent** |
|-------------------|:---------:|:-------:|:-------------:|:-------------:|
| BridgeTracking    |           |         |               |               |
| GovernanceAdmin   |           |         |               |               |
| Maintenance       |           |         |               |               |
| SlashIndicator    |           |         |               |               |
| Staking           |     [x]      |         |               |               |
| StakingVesting    |           |         |               |               |
| ValidatorSet      |           |         |               |               |

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
