### PR TITLE
[Maintenance] Fix assertion of maintenance elapsed

### DIFF
--- a/contracts/ronin/Maintenance.sol
+++ b/contracts/ronin/Maintenance.sol
@@ -98,9 +98,9 @@ contract Maintenance is IMaintenance, HasValidatorContract, Initializable {
       "Maintenance: start block is out of offset"
     );
     require(_startedAtBlock < _endedAtBlock, "Maintenance: start block must be less than end block");
-    uint256 _blockPeriod = _endedAtBlock - _startedAtBlock;
+    uint256 _maintenanceElapsed = _endedAtBlock - _startedAtBlock + 1;
     require(
-      _blockPeriod.inRange(minMaintenanceDurationInBlock, maxMaintenanceDurationInBlock),
+      _maintenanceElapsed.inRange(minMaintenanceDurationInBlock, maxMaintenanceDurationInBlock),
       "Maintenance: invalid maintenance duration"
     );
     require(_validator.epochEndingAt(_startedAtBlock - 1), "Maintenance: start block is not at the start of an epoch");


### PR DESCRIPTION
### Description
Wrong assertion caused validators cannot set maintenance at `minBlockDuration` but `minBlockDuration + 1 epoch`.

### Contract changes

The table below shows the following info:
- **Logic**: the logic is changed.
- **ABI**: the ABI is changed.
- **Init data**: new storage field is declared and needs initializing.
- **Dependent**: needs to be changed due to changes in other contracts.

| **Contract name** | **Logic** | **ABI** | **Init data** | **Dependent** |
|-------------------|:---------:|:-------:|:-------------:|:-------------:|
| BridgeTracking    |           |         |               |               |
| GovernanceAdmin   |           |         |               |               |
| Maintenance       |     [x]     |         |               |               |
| SlashIndicator    |           |         |               |               |
| Staking           |           |         |               |               |
| StakingVesting    |           |         |               |               |
| ValidatorSet      |           |         |               |               |

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
