### PR TITLE
Remove `@axie` package 

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -5,7 +5,7 @@ import 'hardhat-deploy';
 import 'hardhat-gas-reporter';
 import '@nomicfoundation/hardhat-chai-matchers';
 import 'hardhat-contract-sizer';
-import '@axieinfinity/hardhat-4byte-uploader';
+import '@solidstate/hardhat-4byte-uploader';
 import 'hardhat-storage-layout';
 
 import * as dotenv from 'dotenv';

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,7 +1,7 @@
 import '@typechain/hardhat';
 import '@nomiclabs/hardhat-waffle';
 import '@nomiclabs/hardhat-ethers';
-import '@axieinfinity/hardhat-deploy';
+import 'hardhat-deploy';
 import 'hardhat-gas-reporter';
 import '@nomicfoundation/hardhat-chai-matchers';
 import 'hardhat-contract-sizer';

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   },
   "devDependencies": {
     "@axieinfinity/hardhat-4byte-uploader": "^1.0.0",
-    "@axieinfinity/hardhat-deploy": "^0.11.12-trezor-alpha-4",
     "@nomicfoundation/hardhat-chai-matchers": "^1.0.3",
     "@nomiclabs/hardhat-ethers": "^2.0.3",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
@@ -40,6 +39,7 @@
     "dotenv": "^10.0.0",
     "ethers": "^5.5.2",
     "hardhat": "^2.7.1",
+    "hardhat-deploy": "0.11.29",
     "hardhat-contract-sizer": "^2.6.1",
     "hardhat-gas-reporter": "^1.0.8",
     "hardhat-storage-layout": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
     "@openzeppelin/contracts": "4.7.3"
   },
   "devDependencies": {
-    "@axieinfinity/hardhat-4byte-uploader": "^1.0.0",
     "@nomicfoundation/hardhat-chai-matchers": "^1.0.3",
     "@nomiclabs/hardhat-ethers": "^2.0.3",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
+    "@solidstate/hardhat-4byte-uploader": "^1.1.0",
     "@typechain/ethers-v5": "^8.0.5",
     "@typechain/hardhat": "^3.0.0",
     "@types/chai": "^4.3.0",

--- a/src/deploy/vault-forwarder.ts
+++ b/src/deploy/vault-forwarder.ts
@@ -1,5 +1,5 @@
 import { network } from 'hardhat';
-import { Address } from '@axieinfinity/hardhat-deploy/dist/types';
+import { Address } from 'hardhat-deploy/dist/types';
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 
 import { roninchainNetworks, vaultForwarderConf } from '../configs/config';

--- a/src/script/governance-admin-interface.ts
+++ b/src/script/governance-admin-interface.ts
@@ -1,7 +1,7 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { BigNumber, BigNumberish, BytesLike } from 'ethers';
 import { ethers, network } from 'hardhat';
-import { Address } from '@axieinfinity/hardhat-deploy/dist/types';
+import { Address } from 'hardhat-deploy/dist/types';
 import { TypedDataDomain } from '@ethersproject/abstract-signer';
 import { AbiCoder, Interface, keccak256, _TypedDataEncoder } from 'ethers/lib/utils';
 

--- a/src/script/proposal.ts
+++ b/src/script/proposal.ts
@@ -1,6 +1,6 @@
 import { BigNumberish } from 'ethers';
 import { AbiCoder, keccak256, solidityKeccak256 } from 'ethers/lib/utils';
-import { Address } from '@axieinfinity/hardhat-deploy/dist/types';
+import { Address } from 'hardhat-deploy/dist/types';
 
 import { GlobalProposalDetailStruct, ProposalDetailStruct } from '../types/GovernanceAdmin';
 

--- a/src/script/verify-address.ts
+++ b/src/script/verify-address.ts
@@ -1,4 +1,4 @@
-import { Address } from '@axieinfinity/hardhat-deploy/dist/types';
+import { Address } from 'hardhat-deploy/dist/types';
 
 export const verifyAddress = (actual: Address, expected?: Address) => {
   if (actual.toLowerCase() != (expected || '').toLowerCase()) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 import { BigNumber, BigNumberish } from 'ethers';
 import { ethers } from 'hardhat';
-import { Address } from '@axieinfinity/hardhat-deploy/dist/types';
+import { Address } from 'hardhat-deploy/dist/types';
 
 import { TrustedOrganizationStruct } from './types/IRoninTrustedOrganization';
 

--- a/test/helpers/fixture.ts
+++ b/test/helpers/fixture.ts
@@ -1,6 +1,6 @@
 import { BigNumber, BigNumberish } from 'ethers';
 import { deployments, ethers, network } from 'hardhat';
-import { Address } from '@axieinfinity/hardhat-deploy/dist/types';
+import { Address } from 'hardhat-deploy/dist/types';
 
 import { EpochController } from './ronin-validator-set';
 import {

--- a/test/helpers/staking-vesting.ts
+++ b/test/helpers/staking-vesting.ts
@@ -3,7 +3,7 @@ import { BigNumberish, ContractTransaction } from 'ethers';
 
 import { expectEvent } from './utils';
 import { StakingVesting__factory } from '../../src/types';
-import { Address } from '@axieinfinity/hardhat-deploy/dist/types';
+import { Address } from 'hardhat-deploy/dist/types';
 
 const contractInterface = StakingVesting__factory.createInterface();
 

--- a/test/helpers/utils.ts
+++ b/test/helpers/utils.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { ContractTransaction } from 'ethers';
 import { Interface, LogDescription } from 'ethers/lib/utils';
 import { ethers, network } from 'hardhat';
-import { Address } from '@axieinfinity/hardhat-deploy/dist/types';
+import { Address } from 'hardhat-deploy/dist/types';
 
 export const expectEvent = async (
   contractInterface: Interface,

--- a/test/integration/ActionSlashValidators.test.ts
+++ b/test/integration/ActionSlashValidators.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { network, ethers } from 'hardhat';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
-import { Address } from '@axieinfinity/hardhat-deploy/dist/types';
+import { Address } from 'hardhat-deploy/dist/types';
 import { BigNumber, BigNumberish, ContractTransaction } from 'ethers';
 
 import {

--- a/test/integration/ActionWrapUpEpoch.test.ts
+++ b/test/integration/ActionWrapUpEpoch.test.ts
@@ -18,7 +18,7 @@ import { EpochController, expects as ValidatorSetExpects } from '../helpers/roni
 import { mineBatchTxs } from '../helpers/utils';
 import { initTest } from '../helpers/fixture';
 import { GovernanceAdminInterface } from '../../src/script/governance-admin-interface';
-import { Address } from '@axieinfinity/hardhat-deploy/dist/types';
+import { Address } from 'hardhat-deploy/dist/types';
 import {
   createManyTrustedOrganizationAddressSets,
   createManyValidatorCandidateAddressSets,

--- a/test/precompile-usages/PrecompileUsageValidateDoubleSign.test.ts
+++ b/test/precompile-usages/PrecompileUsageValidateDoubleSign.test.ts
@@ -8,7 +8,7 @@ import {
   MockPCUValidateDoubleSign,
   MockPCUValidateDoubleSign__factory,
 } from '../../src/types';
-import { Address } from '@axieinfinity/hardhat-deploy/dist/types';
+import { Address } from 'hardhat-deploy/dist/types';
 
 let deployer: SignerWithAddress;
 let signers: SignerWithAddress[];

--- a/test/validator/ArrangeValidators.test.ts
+++ b/test/validator/ArrangeValidators.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { BigNumber, BigNumberish } from 'ethers';
 import { ethers, network } from 'hardhat';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
-import { Address } from '@axieinfinity/hardhat-deploy/dist/types';
+import { Address } from 'hardhat-deploy/dist/types';
 
 import {
   MockRoninValidatorSetExtended,

--- a/test/validator/EmergencyExit.test.ts
+++ b/test/validator/EmergencyExit.test.ts
@@ -19,7 +19,7 @@ import * as RoninValidatorSet from '../helpers/ronin-validator-set';
 import { mineBatchTxs } from '../helpers/utils';
 import { initTest } from '../helpers/fixture';
 import { GovernanceAdminInterface } from '../../src/script/governance-admin-interface';
-import { Address } from '@axieinfinity/hardhat-deploy/dist/types';
+import { Address } from 'hardhat-deploy/dist/types';
 import {
   createManyTrustedOrganizationAddressSets,
   createManyValidatorCandidateAddressSets,

--- a/test/validator/RoninValidatorSet-Candidate.test.ts
+++ b/test/validator/RoninValidatorSet-Candidate.test.ts
@@ -20,7 +20,7 @@ import * as RoninValidatorSet from '../helpers/ronin-validator-set';
 import { getLastBlockTimestamp, mineBatchTxs } from '../helpers/utils';
 import { defaultTestConfig, initTest } from '../helpers/fixture';
 import { GovernanceAdminInterface } from '../../src/script/governance-admin-interface';
-import { Address } from '@axieinfinity/hardhat-deploy/dist/types';
+import { Address } from 'hardhat-deploy/dist/types';
 import {
   createManyTrustedOrganizationAddressSets,
   createManyValidatorCandidateAddressSets,

--- a/test/validator/RoninValidatorSet-CoinbaseExecution.test.ts
+++ b/test/validator/RoninValidatorSet-CoinbaseExecution.test.ts
@@ -23,7 +23,7 @@ import { getLastBlockTimestamp, mineBatchTxs } from '../helpers/utils';
 import { initTest } from '../helpers/fixture';
 import { GovernanceAdminInterface } from '../../src/script/governance-admin-interface';
 import { BlockRewardDeprecatedType } from '../../src/script/ronin-validator-set';
-import { Address } from '@axieinfinity/hardhat-deploy/dist/types';
+import { Address } from 'hardhat-deploy/dist/types';
 import {
   createManyTrustedOrganizationAddressSets,
   createManyValidatorCandidateAddressSets,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,13 +2,6 @@
 # yarn lockfile v1
 
 
-"@axieinfinity/hardhat-4byte-uploader@^1.0.0":
-  version "1.0.0"
-  resolved "https://npm.pkg.github.com/download/@axieinfinity/hardhat-4byte-uploader/1.0.0/95fb4f6a8138a676118b7962dda18b7b337b5716#95fb4f6a8138a676118b7962dda18b7b337b5716"
-  integrity sha512-ZCZcT3uGjrVkSP8p3t4vs6CNaHoaBF/1/GsHn9GxLijKAagnmea8JzXSl6O2DU7p8loKrDn5WLEgtcU+Eoly+A==
-  dependencies:
-    axios "^0.24.0"
-
 "@babel/code-frame@^7.0.0":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.18.6.tgz#3b25d38c89600baa2dcc219edfa88a74eb2c427a"
@@ -1092,6 +1085,13 @@
   integrity sha512-29g2SZ29HtsqA58pLCtopI1P/cPy5/UAzlcAXO6T/CNJimG6yA8kx4NaseMyJULiC+TEs02Y9/yeHzClqoA0hw==
   dependencies:
     antlr4ts "^0.5.0-alpha.4"
+
+"@solidstate/hardhat-4byte-uploader@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@solidstate/hardhat-4byte-uploader/-/hardhat-4byte-uploader-1.1.0.tgz#de1b9964827c1caeb516f048855c8a4082fd98fc"
+  integrity sha512-OCyBrPqtLoC7/WPlq7c9fosEOKgAT8jqRHCy/fJ8cK1DSQgYymcgC9g619Je9XjaLKPFgamRgt/HuTpTQnAFdQ==
+  dependencies:
+    axios "^0.24.0"
 
 "@tsconfig/node10@^1.0.7":
   version "1.0.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,25 +9,6 @@
   dependencies:
     axios "^0.24.0"
 
-"@axieinfinity/hardhat-deploy@^0.11.12-trezor-alpha-4":
-  version "0.11.12-trezor-alpha-4"
-  resolved "https://npm.pkg.github.com/download/@axieinfinity/hardhat-deploy/0.11.12-trezor-alpha-4/25ebfb694a1d01a4954c4fedd525b79c1227c4d4#25ebfb694a1d01a4954c4fedd525b79c1227c4d4"
-  integrity sha512-JnvD0XTWbRdAqCeG+e1prrWG6aDtzXeI7X82nT/QNgLQkpqTi40B0xjPXXfaizJlE23ebMeqswByLDyhEsJZTw==
-  dependencies:
-    "@types/qs" "^6.9.7"
-    axios "^0.21.1"
-    chalk "^4.1.2"
-    chokidar "^3.5.2"
-    debug "^4.3.2"
-    enquirer "^2.3.6"
-    ethers "^5.5.3"
-    form-data "^4.0.0"
-    fs-extra "^10.0.0"
-    match-all "^1.2.6"
-    murmur-128 "^0.2.1"
-    qs "^6.9.4"
-    zksync-web3 "^0.7.8"
-
 "@babel/code-frame@^7.0.0":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.18.6.tgz#3b25d38c89600baa2dcc219edfa88a74eb2c427a"
@@ -322,7 +303,7 @@
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/transactions" "^5.6.2"
 
-"@ethersproject/contracts@5.7.0":
+"@ethersproject/contracts@5.7.0", "@ethersproject/contracts@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.7.0.tgz#c305e775abd07e48aa590e1a877ed5c316f8bd1e"
   integrity sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==
@@ -544,7 +525,7 @@
     bech32 "1.1.4"
     ws "7.4.6"
 
-"@ethersproject/providers@5.7.2":
+"@ethersproject/providers@5.7.2", "@ethersproject/providers@^5.7.2":
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.7.2.tgz#f8b1a4f275d7ce58cf0a2eec222269a08beb18cb"
   integrity sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==
@@ -656,7 +637,7 @@
     "@ethersproject/sha2" "^5.6.1"
     "@ethersproject/strings" "^5.6.1"
 
-"@ethersproject/solidity@5.7.0":
+"@ethersproject/solidity@5.7.0", "@ethersproject/solidity@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/solidity/-/solidity-5.7.0.tgz#5e9c911d8a2acce2a5ebb48a5e2e0af20b631cb8"
   integrity sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==
@@ -755,7 +736,7 @@
     "@ethersproject/transactions" "^5.6.2"
     "@ethersproject/wordlists" "^5.6.1"
 
-"@ethersproject/wallet@5.7.0":
+"@ethersproject/wallet@5.7.0", "@ethersproject/wallet@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/wallet/-/wallet-5.7.0.tgz#4e5d0790d96fe21d61d38fb40324e6c7ef350b2d"
   integrity sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==
@@ -3175,6 +3156,36 @@ hardhat-contract-sizer@^2.6.1:
   dependencies:
     chalk "^4.0.0"
     cli-table3 "^0.6.0"
+
+hardhat-deploy@0.11.29:
+  version "0.11.29"
+  resolved "https://registry.yarnpkg.com/hardhat-deploy/-/hardhat-deploy-0.11.29.tgz#e6d76e37fa2ed74d76d15b01f3849da3bda49a81"
+  integrity sha512-9F+MRFkEocelzB8d+SDDCcTL7edBYAj2S63ldknvfIIBSajeB6q1/jm+dlK1GjcWzAzw7EVoxtjJXzxAxZfZcg==
+  dependencies:
+    "@ethersproject/abi" "^5.7.0"
+    "@ethersproject/abstract-signer" "^5.7.0"
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/contracts" "^5.7.0"
+    "@ethersproject/providers" "^5.7.2"
+    "@ethersproject/solidity" "^5.7.0"
+    "@ethersproject/transactions" "^5.7.0"
+    "@ethersproject/wallet" "^5.7.0"
+    "@types/qs" "^6.9.7"
+    axios "^0.21.1"
+    chalk "^4.1.2"
+    chokidar "^3.5.2"
+    debug "^4.3.2"
+    enquirer "^2.3.6"
+    ethers "^5.5.3"
+    form-data "^4.0.0"
+    fs-extra "^10.0.0"
+    match-all "^1.2.6"
+    murmur-128 "^0.2.1"
+    qs "^6.9.4"
+    zksync-web3 "^0.14.3"
 
 hardhat-gas-reporter@^1.0.8:
   version "1.0.8"
@@ -5913,7 +5924,7 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zksync-web3@^0.7.8:
-  version "0.7.13"
-  resolved "https://registry.yarnpkg.com/zksync-web3/-/zksync-web3-0.7.13.tgz#9d87cfeac8a38e0c5702c2e05f80e50215d1102d"
-  integrity sha512-Zz83eOWLqPs88kgczkJLhst192oqtj7uzI3PaGyR9lkfQLL5eMEMZ+pD1eYPppTE1GohmGxhqnEf5HxG7WF0QA==
+zksync-web3@^0.14.3:
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/zksync-web3/-/zksync-web3-0.14.3.tgz#64ac2a16d597464c3fc4ae07447a8007631c57c9"
+  integrity sha512-hT72th4AnqyLW1d5Jlv8N2B/qhEnl2NePK2A3org7tAa24niem/UAaHMkEvmWI3SF9waYUPtqAtjpf+yvQ9zvQ==


### PR DESCRIPTION
### Description

The legacy packages of the following have been updated to support custom features on `@axie/*` forks. We update the package to keep up to date with the newest version, and remove the inconvenience of installing GitHub NPM-hosted packages.

- Replace `@axieinfinity/hardhat-deploy` by `hardhat-deploy@0.11.29`
- Replace `@axieinfinity/hardhat-4byte-uploader` by `solidstate/hardhat-4byte-uploader@0.1.1`
