### PR TITLE
[test] Fix assertion on arrays of BigNumbers

### DIFF
--- a/test/bridge/BridgeTracking.test.ts
+++ b/test/bridge/BridgeTracking.test.ts
@@ -128,7 +128,7 @@ describe('Bridge Tracking test', () => {
       await roninValidatorSet.connect(coinbase).wrapUpEpoch();
     });
     period = await roninValidatorSet.currentPeriod();
-    expect(await roninValidatorSet.getBridgeOperators()).eql(candidates.map((v) => v.bridgeOperator.address));
+    expect(await roninValidatorSet.getBridgeOperators()).deep.equal(candidates.map((v) => v.bridgeOperator.address));
   });
 
   after(async () => {

--- a/test/bridge/GatewayPauseEnforcer.test.ts
+++ b/test/bridge/GatewayPauseEnforcer.test.ts
@@ -185,7 +185,7 @@ describe('Ronin Gateway V2 test', () => {
       await roninValidatorSet.connect(coinbase).wrapUpEpoch();
     });
     period = await roninValidatorSet.currentPeriod();
-    expect(await roninValidatorSet.getBridgeOperators()).eql(candidates.map((v) => v.bridgeOperator.address));
+    expect(await roninValidatorSet.getBridgeOperators()).deep.equal(candidates.map((v) => v.bridgeOperator.address));
   });
 
   after(async () => {

--- a/test/bridge/RoninGatewayV2.test.ts
+++ b/test/bridge/RoninGatewayV2.test.ts
@@ -174,7 +174,7 @@ describe('Ronin Gateway V2 test', () => {
       await roninValidatorSet.connect(coinbase).wrapUpEpoch();
     });
     period = await roninValidatorSet.currentPeriod();
-    expect(await roninValidatorSet.getBridgeOperators()).eql(candidates.map((v) => v.bridgeOperator.address));
+    expect(await roninValidatorSet.getBridgeOperators()).deep.equal(candidates.map((v) => v.bridgeOperator.address));
   });
 
   after(async () => {

--- a/test/governance-admin/GovernanceAdmin.test.ts
+++ b/test/governance-admin/GovernanceAdmin.test.ts
@@ -156,7 +156,7 @@ describe('Governance Admin test', () => {
         const latestBOset = await governanceAdmin.lastSyncedBridgeOperatorSetInfo();
         expect(latestBOset.period).eq(0);
         expect(latestBOset.epoch).eq(0);
-        expect(latestBOset.operators).eql([]);
+        expect(latestBOset.operators).deep.equal([]);
       });
 
       it('Should be able to vote bridge operators', async () => {
@@ -186,7 +186,7 @@ describe('Governance Admin test', () => {
         const latestBOset = await governanceAdmin.lastSyncedBridgeOperatorSetInfo();
         expect(latestBOset.period).eq(ballot.period);
         expect(latestBOset.epoch).eq(ballot.epoch);
-        expect(latestBOset.operators).eql(ballot.operators);
+        expect(latestBOset.operators).deep.equal(ballot.operators);
       });
 
       it('Should be able relay vote bridge operators', async () => {
@@ -195,11 +195,11 @@ describe('Governance Admin test', () => {
         await mainchainGovernanceAdmin.connect(relayer).relayBridgeOperators(ballot, signatures);
         expect(await mainchainGovernanceAdmin.bridgeOperatorsRelayed(ballot.period, ballot.epoch)).to.true;
         const bridgeOperators = await bridgeContract.getBridgeOperators();
-        expect([...bridgeOperators].sort(compareAddrs)).eql(ballot.operators);
+        expect([...bridgeOperators].sort(compareAddrs)).deep.equal(ballot.operators);
         const latestBOset = await mainchainGovernanceAdmin.lastSyncedBridgeOperatorSetInfo();
         expect(latestBOset.period).eq(ballot.period);
         expect(latestBOset.epoch).eq(ballot.epoch);
-        expect(latestBOset.operators).eql(ballot.operators);
+        expect(latestBOset.operators).deep.equal(ballot.operators);
       });
 
       it('Should not able to relay again', async () => {
@@ -307,18 +307,18 @@ describe('Governance Admin test', () => {
         expect(lastLength).not.eq(ballot.operators.length);
         expect(latestBOset.period).eq(ballot.period);
         expect(latestBOset.epoch).eq(ballot.epoch);
-        expect(latestBOset.operators).eql(ballot.operators);
+        expect(latestBOset.operators).deep.equal(ballot.operators);
       });
 
       it('Should be able relay vote bridge operators', async () => {
         const [, signatures] = await governanceAdmin.getBridgeOperatorVotingSignatures(ballot.period, ballot.epoch);
         await mainchainGovernanceAdmin.connect(relayer).relayBridgeOperators(ballot, signatures);
         const bridgeOperators = await bridgeContract.getBridgeOperators();
-        expect([...bridgeOperators].sort(compareAddrs)).eql(ballot.operators);
+        expect([...bridgeOperators].sort(compareAddrs)).deep.equal(ballot.operators);
         const latestBOset = await mainchainGovernanceAdmin.lastSyncedBridgeOperatorSetInfo();
         expect(latestBOset.period).eq(ballot.period);
         expect(latestBOset.epoch).eq(ballot.epoch);
-        expect(latestBOset.operators).eql(ballot.operators);
+        expect(latestBOset.operators).deep.equal(ballot.operators);
       });
 
       it('Should be able to vote for a same number of bridge operators', async () => {
@@ -341,7 +341,7 @@ describe('Governance Admin test', () => {
         expect(lastLength).eq(ballot.operators.length);
         expect(latestBOset.period).eq(ballot.period);
         expect(latestBOset.epoch).eq(ballot.epoch);
-        expect(latestBOset.operators).eql(ballot.operators);
+        expect(latestBOset.operators).deep.equal(ballot.operators);
       });
     });
   });
@@ -766,14 +766,14 @@ describe('Governance Admin test', () => {
         proposal.chainId,
         proposal.nonce
       );
-      expect(voters).eql([
+      expect(voters).deep.equal([
         trustedOrgs[1].governor.address,
         trustedOrgs[0].governor.address,
         trustedOrgs[2].governor.address,
       ]);
-      expect(supports).eql([VoteType.For, VoteType.Against, VoteType.Against]);
+      expect(supports).deep.equal([VoteType.For, VoteType.Against, VoteType.Against]);
       const emptySignatures = [0, ethers.constants.HashZero, ethers.constants.HashZero];
-      expect(signatures).eql([
+      expect(signatures).deep.equal([
         emptySignatures,
         emptySignatures,
         ...votedSignatures.map((sig) => [sig.v, sig.r, sig.s]),

--- a/test/helpers/candidate-manager.ts
+++ b/test/helpers/candidate-manager.ts
@@ -15,7 +15,7 @@ export const expects = {
       'CandidatesRevoked',
       tx,
       (event) => {
-        expect(event.args[0], 'invalid revoked candidates').eql(expectingRevokedCandidates);
+        expect(event.args[0], 'invalid revoked candidates').deep.equal(expectingRevokedCandidates);
       },
       1
     );
@@ -33,10 +33,10 @@ export const expects = {
       'CandidateGranted',
       tx,
       (event) => {
-        expect(event.args[0], 'invalid consensus address').eql(expectingConsensusAddr);
-        expect(event.args[1], 'invalid treasury address').eql(expectingTreasuryAddr);
-        expect(event.args[2], 'invalid admin address').eql(expectingAdmin);
-        expect(event.args[3], 'invalid bridge operator address').eql(expectingBridgeOperatorAddr);
+        expect(event.args[0], 'invalid consensus address').deep.equal(expectingConsensusAddr);
+        expect(event.args[1], 'invalid treasury address').deep.equal(expectingTreasuryAddr);
+        expect(event.args[2], 'invalid admin address').deep.equal(expectingAdmin);
+        expect(event.args[3], 'invalid bridge operator address').deep.equal(expectingBridgeOperatorAddr);
       },
       1
     );

--- a/test/helpers/governance-admin.ts
+++ b/test/helpers/governance-admin.ts
@@ -19,8 +19,8 @@ export const expects = {
       tx,
       (event) => {
         expect(event.args[0], 'invalid proposal hash').eq(expectingProposalHash);
-        expect(event.args[1], 'invalid success calls').eql(expectingSuccessCalls);
-        expect(event.args[2], 'invalid returned datas').eql(expectingReturnedDatas);
+        expect(event.args[1], 'invalid success calls').deep.equal(expectingSuccessCalls);
+        expect(event.args[2], 'invalid returned datas').deep.equal(expectingReturnedDatas);
       },
       1
     );

--- a/test/helpers/ronin-validator-set.ts
+++ b/test/helpers/ronin-validator-set.ts
@@ -136,10 +136,10 @@ export const expects = {
       (event) => {
         expect(event.args[0], 'invalid total distributing reward').eq(expectingTotalAmount);
         if (expectingValidators) {
-          expect(event.args[1], 'invalid validator list').eql(expectingValidators);
+          expect(event.args[1], 'invalid validator list').deep.equal(expectingValidators);
         }
         if (expectingAmounts) {
-          expect(event.args[2], 'invalid amount list').eql(expectingAmounts);
+          expect(event.args[2], 'invalid amount list').deep.equal(expectingAmounts);
         }
       },
       1
@@ -157,7 +157,7 @@ export const expects = {
       tx,
       (event) => {
         expect(event.args[0], 'invalid period').eq(expectingPeriod);
-        expect(event.args[1], 'invalid validator set').eql(expectingValidators);
+        expect(event.args[1], 'invalid validator set').deep.equal(expectingValidators);
       },
       1
     );
@@ -176,7 +176,8 @@ export const expects = {
       (event) => {
         !!expectingPeriod && expect(event.args[0], 'invalid period').eq(expectingPeriod);
         !!expectingEpoch && expect(event.args[1], 'invalid epoch').eq(expectingEpoch);
-        !!expectingBlockProducers && expect(event.args[2], 'invalid block producers').eql(expectingBlockProducers);
+        !!expectingBlockProducers &&
+          expect(event.args[2], 'invalid block producers').deep.equal(expectingBlockProducers);
       },
       1
     );
@@ -195,7 +196,8 @@ export const expects = {
       (event) => {
         !!expectingPeriod && expect(event.args[0], 'invalid period').eq(expectingPeriod);
         !!expectingEpoch && expect(event.args[1], 'invalid epoch').eq(expectingEpoch);
-        !!expectingBridgeOperators && expect(event.args[2], 'invalid bridge operators').eql(expectingBridgeOperators);
+        !!expectingBridgeOperators &&
+          expect(event.args[2], 'invalid bridge operators').deep.equal(expectingBridgeOperators);
       },
       1
     );
@@ -213,8 +215,8 @@ export const expects = {
       tx,
       (event) => {
         expect(event.args[0], 'invalid validator').eq(expectingValidator);
-        expect(event.args[1], 'invalid removed reward').eql(expectingRemovedReward);
-        expect(event.args[2], 'invalid deprecated type').eql(expectingDeprecatedType);
+        expect(event.args[1], 'invalid removed reward').deep.equal(expectingRemovedReward);
+        expect(event.args[2], 'invalid deprecated type').deep.equal(expectingDeprecatedType);
       },
       1
     );
@@ -231,7 +233,7 @@ export const expects = {
       tx,
       (event) => {
         expect(event.args[0], 'invalid withdraw target').eq(expectingWithdrawnTarget);
-        expect(event.args[1], 'invalid withdraw amount').eql(expectingWithdrawnAmount);
+        expect(event.args[1], 'invalid withdraw amount').deep.equal(expectingWithdrawnAmount);
       },
       1
     );

--- a/test/helpers/staking-vesting.ts
+++ b/test/helpers/staking-vesting.ts
@@ -22,16 +22,16 @@ export const expects = {
       tx,
       (event) => {
         if (blockNumber) {
-          expect(event.args[0], eventName + ': invalid block number').eql(blockNumber);
+          expect(event.args[0], eventName + ': invalid block number').deep.equal(blockNumber);
         }
         if (recipient) {
-          expect(event.args[1], eventName + ': invalid recipient').eql(recipient);
+          expect(event.args[1], eventName + ': invalid recipient').deep.equal(recipient);
         }
         if (blockProducerBonus) {
-          expect(event.args[2], eventName + ': invalid block producer bonus').eql(blockProducerBonus);
+          expect(event.args[2], eventName + ': invalid block producer bonus').deep.equal(blockProducerBonus);
         }
         if (bridgeOperatorBonus) {
-          expect(event.args[3], eventName + ': invalid bridge operator bonus').eql(bridgeOperatorBonus);
+          expect(event.args[3], eventName + ': invalid bridge operator bonus').deep.equal(bridgeOperatorBonus);
         }
       },
       1
@@ -53,19 +53,19 @@ export const expects = {
       tx,
       (event) => {
         if (blockNumber) {
-          expect(event.args[0], eventName + ': invalid block number').eql(blockNumber);
+          expect(event.args[0], eventName + ': invalid block number').deep.equal(blockNumber);
         }
         if (recipient) {
-          expect(event.args[1], eventName + ': invalid recipient').eql(recipient);
+          expect(event.args[1], eventName + ': invalid recipient').deep.equal(recipient);
         }
         if (blockProducerBonus) {
-          expect(event.args[2], eventName + ': invalid block producer bonus').eql(blockProducerBonus);
+          expect(event.args[2], eventName + ': invalid block producer bonus').deep.equal(blockProducerBonus);
         }
         if (bridgeOperatorBonus) {
-          expect(event.args[3], eventName + ': invalid bridge operator bonus').eql(bridgeOperatorBonus);
+          expect(event.args[3], eventName + ': invalid bridge operator bonus').deep.equal(bridgeOperatorBonus);
         }
         if (bridgeOperatorBonus) {
-          expect(event.args[4], eventName + ': invalid contract balance').eql(contractBalance);
+          expect(event.args[4], eventName + ': invalid contract balance').deep.equal(contractBalance);
         }
       },
       1

--- a/test/helpers/staking.ts
+++ b/test/helpers/staking.ts
@@ -19,13 +19,13 @@ export const expects = {
       tx,
       (event) => {
         if (!!expectingPeriod) {
-          expect(event.args[0], 'invalid period').eql(expectingPeriod);
+          expect(event.args[0], 'invalid period').deep.equal(expectingPeriod);
         }
         if (!!expectingPoolAddressList) {
-          expect(event.args[1], 'invalid pool address list').eql(expectingPoolAddressList);
+          expect(event.args[1], 'invalid pool address list').deep.equal(expectingPoolAddressList);
         }
         if (!!expectingAccumulatedRpsList) {
-          expect(event.args[2], 'invalid accumulated rps list').eql(expectingAccumulatedRpsList);
+          expect(event.args[2], 'invalid accumulated rps list').deep.equal(expectingAccumulatedRpsList);
         }
       },
       1

--- a/test/helpers/utils.ts
+++ b/test/helpers/utils.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { ContractTransaction } from 'ethers';
+import { BigNumber, ContractTransaction } from 'ethers';
 import { Interface, LogDescription } from 'ethers/lib/utils';
 import { ethers, network } from 'hardhat';
 import { Address } from 'hardhat-deploy/dist/types';
@@ -53,3 +53,6 @@ export const compareAddrs = (firstStr: string, secondStr: string) =>
 
 export const accessControlRevertStr = (addr: Address, role: string): string =>
   `AccessControl: account ${addr.toLocaleLowerCase()} is missing role ${role}`;
+
+export const compareBigNumbers = (firstBigNumbers: BigNumber[], secondBigNumbers: BigNumber[]) =>
+  expect(firstBigNumbers.map((_) => _.toHexString())).deep.equal(secondBigNumbers.map((_) => _.toHexString()));

--- a/test/integration/ActionBridgeTracking.test.ts
+++ b/test/integration/ActionBridgeTracking.test.ts
@@ -170,7 +170,7 @@ describe('[Integration] Bridge Tracking test', () => {
       await roninValidatorSet.connect(coinbase).wrapUpEpoch();
     });
     period = await roninValidatorSet.currentPeriod();
-    expect(await roninValidatorSet.getBridgeOperators()).eql(candidates.map((v) => v.bridgeOperator.address));
+    expect(await roninValidatorSet.getBridgeOperators()).deep.equal(candidates.map((v) => v.bridgeOperator.address));
   });
 
   after(async () => {
@@ -181,7 +181,7 @@ describe('[Integration] Bridge Tracking test', () => {
     expect(await bridgeTracking.bridgeContract()).eq(bridgeContract.address);
     expect(await bridgeContract.bridgeTrackingContract()).eq(bridgeTracking.address);
     expect(await bridgeContract.validatorContract()).eq(roninValidatorSet.address);
-    expect(await bridgeContract.getMainchainToken(token.address, mainchainId)).eql([0, token.address]);
+    expect(await bridgeContract.getMainchainToken(token.address, mainchainId)).deep.equal([0, token.address]);
     expect(await roninValidatorSet.currentPeriod()).eq(period);
   });
 

--- a/test/integration/ActionSlashValidators.test.ts
+++ b/test/integration/ActionSlashValidators.test.ts
@@ -183,8 +183,8 @@ describe('[Integration] Slash validators', () => {
         expectingBlockProducerSet.push(slashee.consensusAddr.address);
         await RoninValidatorSetExpects.emitValidatorSetUpdatedEvent(wrapUpEpochTx!, period, expectingValidatorSet);
 
-        expect((await validatorContract.getValidators())[0]).eql(expectingValidatorSet);
-        expect(await validatorContract.getBlockProducers()).eql(expectingBlockProducerSet);
+        expect((await validatorContract.getValidators())[0]).deep.equal(expectingValidatorSet);
+        expect(await validatorContract.getBlockProducers()).deep.equal(expectingBlockProducerSet);
       });
 
       it('Should the ValidatorSet contract emit event', async () => {
@@ -213,7 +213,11 @@ describe('[Integration] Slash validators', () => {
 
       it('Should the validator is put in jail', async () => {
         let blockNumber = await network.provider.send('eth_blockNumber');
-        expect(await validatorContract.getJailUntils(expectingValidatorSet)).eql([
+        // await compareBigNumbers(await validatorContract.getJailUntils(expectingValidatorSet), [
+        //   BigNumber.from(blockNumber).add(jailDurationForUnavailabilityTier2Threshold),
+        // ]);
+
+        expect(await validatorContract.getJailUntils(expectingValidatorSet)).deep.equal([
           BigNumber.from(blockNumber).add(jailDurationForUnavailabilityTier2Threshold),
         ]);
       });
@@ -237,7 +241,7 @@ describe('[Integration] Slash validators', () => {
           wrapUpEpochTx = await validatorContract.connect(coinbase).wrapUpEpoch();
         });
         expectingBlockProducerSet.pop();
-        expect(await validatorContract.getBlockProducers()).eql(expectingBlockProducerSet);
+        expect(await validatorContract.getBlockProducers()).deep.equal(expectingBlockProducerSet);
         await RoninValidatorSetExpects.emitBlockProducerSetUpdatedEvent(
           wrapUpEpochTx!,
           period,
@@ -273,7 +277,7 @@ describe('[Integration] Slash validators', () => {
         });
         expectingBlockProducerSet.push(slashee.consensusAddr.address);
 
-        expect(await validatorContract.getBlockProducers()).eql(expectingBlockProducerSet);
+        expect(await validatorContract.getBlockProducers()).deep.equal(expectingBlockProducerSet);
         await RoninValidatorSetExpects.emitBlockProducerSetUpdatedEvent(
           wrapUpEpochTx!,
           period,
@@ -328,7 +332,7 @@ describe('[Integration] Slash validators', () => {
 
         period = await validatorContract.currentPeriod();
         await RoninValidatorSetExpects.emitValidatorSetUpdatedEvent(wrapUpEpochTx!, period, expectingValidatorSet);
-        expect((await validatorContract.getValidators())[0]).eql(expectingValidatorSet);
+        expect((await validatorContract.getValidators())[0]).deep.equal(expectingValidatorSet);
       });
 
       describe('Check effects on indicator and staking amount', async () => {
@@ -362,7 +366,7 @@ describe('[Integration] Slash validators', () => {
 
         it('Should the validators are put in jail', async () => {
           const blockNumber = await network.provider.send('eth_blockNumber');
-          expect(await validatorContract.getJailUntils(slashees.map((v) => v.consensusAddr.address))).eql([
+          expect(await validatorContract.getJailUntils(slashees.map((v) => v.consensusAddr.address))).deep.equal([
             BigNumber.from(blockNumber).add(jailDurationForUnavailabilityTier2Threshold).sub(1),
             BigNumber.from(blockNumber).add(jailDurationForUnavailabilityTier2Threshold).sub(0),
           ]);
@@ -394,7 +398,7 @@ describe('[Integration] Slash validators', () => {
             await validatorContract.connect(coinbase).endEpoch();
             wrapUpEpochTx = await validatorContract.connect(coinbase).wrapUpEpoch();
           });
-          expect(await validatorContract.getBlockProducers()).eql(expectingBlockProducerSet);
+          expect(await validatorContract.getBlockProducers()).deep.equal(expectingBlockProducerSet);
           await RoninValidatorSetExpects.emitBlockProducerSetUpdatedEvent(
             wrapUpEpochTx!,
             period,
@@ -429,8 +433,8 @@ describe('[Integration] Slash validators', () => {
           });
 
           slashees.forEach((slashee) => expectingBlockProducerSet.push(slashee.consensusAddr.address));
-          expect(await validatorContract.getBlockProducers()).eql(expectingBlockProducerSet);
-          expect((await validatorContract.getValidators())[0]).eql(expectingBlockProducerSet);
+          expect(await validatorContract.getBlockProducers()).deep.equal(expectingBlockProducerSet);
+          expect((await validatorContract.getValidators())[0]).deep.equal(expectingBlockProducerSet);
           await RoninValidatorSetExpects.emitBlockProducerSetUpdatedEvent(
             wrapUpEpochTx!,
             period,
@@ -460,8 +464,8 @@ describe('[Integration] Slash validators', () => {
 
           period = await validatorContract.currentPeriod();
           await RoninValidatorSetExpects.emitValidatorSetUpdatedEvent(wrapUpEpochTx!, period, expectingValidatorSet);
-          expect(await validatorContract.getBlockProducers()).eql(expectingBlockProducerSet);
-          expect((await validatorContract.getValidators())[0]).eql(expectingValidatorSet);
+          expect(await validatorContract.getBlockProducers()).deep.equal(expectingBlockProducerSet);
+          expect((await validatorContract.getValidators())[0]).deep.equal(expectingValidatorSet);
         });
 
         it('The validator should be able to top up before deadline', async () => {
@@ -495,8 +499,8 @@ describe('[Integration] Slash validators', () => {
           period = await validatorContract.currentPeriod();
 
           await RoninValidatorSetExpects.emitValidatorSetUpdatedEvent(wrapUpEpochTx!, period, expectingValidatorSet);
-          expect(await validatorContract.getBlockProducers()).eql(expectingBlockProducerSet);
-          expect((await validatorContract.getValidators())[0]).eql(expectingValidatorSet);
+          expect(await validatorContract.getBlockProducers()).deep.equal(expectingBlockProducerSet);
+          expect((await validatorContract.getValidators())[0]).deep.equal(expectingValidatorSet);
         });
 
         it('Should the event of revoking under balance candidates emitted', async () => {

--- a/test/integration/ActionWrapUpEpoch.test.ts
+++ b/test/integration/ActionWrapUpEpoch.test.ts
@@ -219,7 +219,7 @@ describe('[Integration] Wrap up epoch', () => {
           await Promise.all(
             validators.map(async (v) => slashContract.currentUnavailabilityIndicator(v.consensusAddr.address))
           )
-        ).eql(
+        ).deep.equal(
           validators.map((v) => (v.consensusAddr.address == coinbase.address ? BigNumber.from(0) : BigNumber.from(1)))
         );
       });
@@ -234,7 +234,7 @@ describe('[Integration] Wrap up epoch', () => {
           await Promise.all(
             validators.map(async (v) => slashContract.currentUnavailabilityIndicator(v.consensusAddr.address))
           )
-        ).eql(validators.map(() => BigNumber.from(0)));
+        ).deep.equal(validators.map(() => BigNumber.from(0)));
       });
     });
   });
@@ -308,10 +308,10 @@ describe('[Integration] Wrap up epoch', () => {
           expectingBlockProducerSet
         );
 
-        expect((await validatorContract.getValidators())[0]).eql(
+        expect((await validatorContract.getValidators())[0]).deep.equal(
           [validators[1], validators[2], validators[3]].map((_) => _.consensusAddr.address).reverse()
         );
-        expect(await validatorContract.getBlockProducers()).eql(expectingBlockProducerSet);
+        expect(await validatorContract.getBlockProducers()).deep.equal(expectingBlockProducerSet);
       });
 
       it('Should the validators in the previous epoch (including slashed one) got slashing counter reset, when the epoch ends', async () => {
@@ -324,7 +324,7 @@ describe('[Integration] Wrap up epoch', () => {
           await Promise.all(
             validators.map(async (v) => slashContract.currentUnavailabilityIndicator(v.consensusAddr.address))
           )
-        ).eql(validators.map(() => BigNumber.from(0)));
+        ).deep.equal(validators.map(() => BigNumber.from(0)));
       });
     });
   });

--- a/test/integration/Configuration.test.ts
+++ b/test/integration/Configuration.test.ts
@@ -26,6 +26,7 @@ import {
 import { initTest, InitTestInput } from '../helpers/fixture';
 import { MAX_UINT255, randomAddress } from '../../src/utils';
 import { createManyTrustedOrganizationAddressSets, TrustedOrganizationAddressSet } from '../helpers/address-set-types';
+import { compareBigNumbers } from '../helpers/utils';
 
 let stakingVestingContract: StakingVesting;
 let maintenanceContract: Maintenance;
@@ -198,7 +199,7 @@ describe('[Integration] Configuration check', () => {
           addedBlock: undefined,
         })
       )
-    ).eql(
+    ).deep.equal(
       trustedOrgs.map((v) => ({
         consensusAddr: v.consensusAddr.address,
         governor: v.governor.address,
@@ -207,7 +208,7 @@ describe('[Integration] Configuration check', () => {
         addedBlock: undefined,
       }))
     );
-    expect(await roninTrustedOrganizationContract.getThreshold()).eql(
+    expect(await roninTrustedOrganizationContract.getThreshold()).deep.equal(
       [config.roninTrustedOrganizationArguments?.numerator, config.roninTrustedOrganizationArguments?.denominator].map(
         BigNumber.from
       )
@@ -219,7 +220,8 @@ describe('[Integration] Configuration check', () => {
     expect(await slashContract.maintenanceContract()).to.eq(maintenanceContract.address);
     expect(await slashContract.roninTrustedOrganizationContract()).to.eq(roninTrustedOrganizationContract.address);
     expect(await slashContract.roninGovernanceAdminContract()).to.eq(roninGovernanceAdminContract.address);
-    expect(await slashContract.getBridgeOperatorSlashingConfigs()).to.eql(
+    await compareBigNumbers(
+      await slashContract.getBridgeOperatorSlashingConfigs(),
       [
         config.slashIndicatorArguments?.bridgeOperatorSlashing?.missingVotesRatioTier1,
         config.slashIndicatorArguments?.bridgeOperatorSlashing?.missingVotesRatioTier2,
@@ -227,20 +229,23 @@ describe('[Integration] Configuration check', () => {
         config.slashIndicatorArguments?.bridgeOperatorSlashing?.skipBridgeOperatorSlashingThreshold,
       ].map(BigNumber.from)
     );
-    expect(await slashContract.getBridgeVotingSlashingConfigs()).to.eql(
+    await compareBigNumbers(
+      await slashContract.getBridgeVotingSlashingConfigs(),
       [
         config.slashIndicatorArguments?.bridgeVotingSlashing?.bridgeVotingThreshold,
         config.slashIndicatorArguments?.bridgeVotingSlashing?.bridgeVotingSlashAmount,
       ].map(BigNumber.from)
     );
-    expect(await slashContract.getDoubleSignSlashingConfigs()).to.eql(
+    await compareBigNumbers(
+      await slashContract.getDoubleSignSlashingConfigs(),
       [
         config.slashIndicatorArguments?.doubleSignSlashing?.slashDoubleSignAmount,
         config.slashIndicatorArguments?.doubleSignSlashing?.doubleSigningJailUntilBlock,
         config.slashIndicatorArguments?.doubleSignSlashing?.doubleSigningOffsetLimitBlock,
       ].map(BigNumber.from)
     );
-    expect(await slashContract.getUnavailabilitySlashingConfigs()).to.eql(
+    await compareBigNumbers(
+      await slashContract.getUnavailabilitySlashingConfigs(),
       [
         config.slashIndicatorArguments?.unavailabilitySlashing?.unavailabilityTier1Threshold,
         config.slashIndicatorArguments?.unavailabilitySlashing?.unavailabilityTier2Threshold,
@@ -248,7 +253,8 @@ describe('[Integration] Configuration check', () => {
         config.slashIndicatorArguments?.unavailabilitySlashing?.jailDurationForUnavailabilityTier2Threshold,
       ].map(BigNumber.from)
     );
-    expect(await slashContract.getCreditScoreConfigs()).to.eql(
+    await compareBigNumbers(
+      await slashContract.getCreditScoreConfigs(),
       [
         config.slashIndicatorArguments?.creditScore?.gainCreditScore,
         config.slashIndicatorArguments?.creditScore?.maxCreditScore,

--- a/test/maintainance/Maintenance.test.ts
+++ b/test/maintainance/Maintenance.test.ts
@@ -141,8 +141,12 @@ describe('Maintenance test', () => {
       validatorCandidates.map((_) => _.consensusAddr.address)
     );
 
-    expect((await validatorContract.getValidators())[0]).eql(validatorCandidates.map((_) => _.consensusAddr.address));
-    expect(await validatorContract.getBlockProducers()).eql(validatorCandidates.map((_) => _.consensusAddr.address));
+    expect((await validatorContract.getValidators())[0]).deep.equal(
+      validatorCandidates.map((_) => _.consensusAddr.address)
+    );
+    expect(await validatorContract.getBlockProducers()).deep.equal(
+      validatorCandidates.map((_) => _.consensusAddr.address)
+    );
   });
 
   after(async () => {
@@ -310,7 +314,9 @@ describe('Maintenance test', () => {
       let tx = await validatorContract.connect(coinbase).wrapUpEpoch();
 
       currentBlock = (await ethers.provider.getBlockNumber()) + 1;
-      expect(await validatorContract.getBlockProducers()).eql(validatorCandidates.map((_) => _.consensusAddr.address));
+      expect(await validatorContract.getBlockProducers()).deep.equal(
+        validatorCandidates.map((_) => _.consensusAddr.address)
+      );
     });
 
     it('Should the validator not appear in the block producer list since the maintenance is started', async () => {
@@ -327,7 +333,7 @@ describe('Maintenance test', () => {
         await validatorContract.epochOf((await ethers.provider.getBlockNumber()) + 1),
         expectingBlockProducerSet
       );
-      expect(await validatorContract.getBlockProducers()).eql(
+      expect(await validatorContract.getBlockProducers()).deep.equal(
         validatorCandidates.slice(2).map((_) => _.consensusAddr.address)
       );
     });
@@ -351,7 +357,7 @@ describe('Maintenance test', () => {
         await validatorContract.epochOf((await ethers.provider.getBlockNumber()) + 1),
         expectingBlockProducerSet
       );
-      expect(await validatorContract.getBlockProducers()).eql(expectingBlockProducerSet);
+      expect(await validatorContract.getBlockProducers()).deep.equal(expectingBlockProducerSet);
     });
 
     it('Should not be able to schedule again when cooldown time is not over', async () => {
@@ -450,7 +456,9 @@ describe('Maintenance test', () => {
         await validatorContract.epochOf((await ethers.provider.getBlockNumber()) + 1),
         expectingBlockProducerSet
       );
-      expect(await validatorContract.getBlockProducers()).eql(validatorCandidates.map((_) => _.consensusAddr.address));
+      expect(await validatorContract.getBlockProducers()).deep.equal(
+        validatorCandidates.map((_) => _.consensusAddr.address)
+      );
     });
   });
 });

--- a/test/precompile-usages/PrecompileUsageSortValidators.test.ts
+++ b/test/precompile-usages/PrecompileUsageSortValidators.test.ts
@@ -45,7 +45,7 @@ describe('[Precompile] Sorting validators test', () => {
       .sort((a, b) => (a.balance > b.balance ? -1 : 1))
       .map((_) => _.address);
 
-    expect(sortedValidators).eql(expectingValidators);
+    expect(sortedValidators).deep.equal(expectingValidators);
   });
 
   it('Should the usage contract revert with proper message on calling the precompile contract fails', async () => {

--- a/test/precompile-usages/PrecompileUsageValidateDoubleSign.test.ts
+++ b/test/precompile-usages/PrecompileUsageValidateDoubleSign.test.ts
@@ -35,7 +35,7 @@ describe('[Precompile] Validate double sign test', () => {
 
   it('Should the usage contract can call the precompile address', async () => {
     let sortedValidators = await usageValidating.callPrecompile(slasheeAddr, header1, header2);
-    expect(sortedValidators).eql(true);
+    expect(sortedValidators).deep.equal(true);
   });
 
   it('Should the usage contract revert with proper message on calling the precompile contract fails', async () => {

--- a/test/slash/CreditScore.test.ts
+++ b/test/slash/CreditScore.test.ts
@@ -233,10 +233,10 @@ describe('Credit score and bail out test', () => {
     localEpochController = new EpochController(minOffsetToStartSchedule, numberOfBlocksInEpoch);
     await localEpochController.mineToBeforeEndOfEpoch(2);
     await validatorContract.connect(coinbase).wrapUpEpoch();
-    expect((await validatorContract.getValidators())[0]).eql(
+    expect((await validatorContract.getValidators())[0]).deep.equal(
       validatorCandidates.slice(0, maxValidatorNumber).map((_) => _.consensusAddr.address)
     );
-    expect(await validatorContract.getBlockProducers()).eql(
+    expect(await validatorContract.getBlockProducers()).deep.equal(
       validatorCandidates.slice(0, maxValidatorNumber).map((_) => _.consensusAddr.address)
     );
 

--- a/test/slash/SlashIndicator.test.ts
+++ b/test/slash/SlashIndicator.test.ts
@@ -166,7 +166,9 @@ describe('Slash indicator test', () => {
     localEpochController = new EpochController(minOffsetToStartSchedule, numberOfBlocksInEpoch);
     await localEpochController.mineToBeforeEndOfEpoch(2);
     await validatorContract.connect(coinbase).wrapUpEpoch();
-    expect((await validatorContract.getValidators())[0]).eql(validatorCandidates.map((_) => _.consensusAddr.address));
+    expect((await validatorContract.getValidators())[0]).deep.equal(
+      validatorCandidates.map((_) => _.consensusAddr.address)
+    );
 
     localIndicators = new IndicatorController(validatorCandidates.length);
   });

--- a/test/sorting/QuickSort.test.ts
+++ b/test/sorting/QuickSort.test.ts
@@ -38,7 +38,7 @@ const runSortWithNRecords = async (numOfRecords: number) => {
     balances.map((_) => _.value)
   );
 
-  expect(sorted).eql(balances.map((_) => _.address));
+  expect(sorted).deep.equal(balances.map((_) => _.address));
   return gasUsed.toString();
 };
 

--- a/test/staking/Staking.test.ts
+++ b/test/staking/Staking.test.ts
@@ -325,7 +325,7 @@ describe('Staking test', () => {
     it('Should the consensus account is no longer be a candidate, and the staked amount is transferred back to the pool admin', async () => {
       await network.provider.send('evm_increaseTime', [waitingSecsToRevoke]);
       const stakingAmount = minValidatorStakingAmount.mul(2);
-      expect(await stakingContract.getPoolDetail(poolAddrSet.consensusAddr.address)).eql([
+      expect(await stakingContract.getPoolDetail(poolAddrSet.consensusAddr.address)).deep.equal([
         poolAddrSet.poolAdmin.address,
         stakingAmount,
         stakingAmount.add(9),
@@ -497,7 +497,7 @@ describe('Staking test', () => {
           2,
           /* 0.02% */ { value: minValidatorStakingAmount }
         );
-      expect(await stakingContract.getPoolDetail(poolAddrSet.consensusAddr.address)).eql([
+      expect(await stakingContract.getPoolDetail(poolAddrSet.consensusAddr.address)).deep.equal([
         poolAddrSet.poolAdmin.address,
         minValidatorStakingAmount,
         minValidatorStakingAmount.add(8),
@@ -516,7 +516,7 @@ describe('Staking test', () => {
           [poolAddrSet.consensusAddr.address, poolAddrSet.consensusAddr.address],
           [userA.address, userB.address]
         )
-      ).eql([2, 2].map(BigNumber.from));
+      ).deep.equal([2, 2].map(BigNumber.from));
 
       await network.provider.send('evm_increaseTime', [cooldownSecsToUndelegate + 1]);
       await stakingContract.connect(userA).undelegate(poolAddrSet.consensusAddr.address, 2);
@@ -526,7 +526,7 @@ describe('Staking test', () => {
           [poolAddrSet.consensusAddr.address, poolAddrSet.consensusAddr.address],
           [userA.address, userB.address]
         )
-      ).eql([0, 1].map(BigNumber.from));
+      ).deep.equal([0, 1].map(BigNumber.from));
     });
 
     it('Should be able to delegate for a renouncing candidate', async () => {

--- a/test/validator/ArrangeValidators.test.ts
+++ b/test/validator/ArrangeValidators.test.ts
@@ -218,7 +218,7 @@ describe('Arrange validators', () => {
         maxPrioritizedValidatorNumber
       );
 
-      expect(outputValidators).eql(expectingValidatorAddrs);
+      expect(outputValidators).deep.equal(expectingValidatorAddrs);
     });
 
     it('Actual(prioritized) == MaxNum(prioritized); Actual(regular) >  MaxNum(regular)', async () => {
@@ -244,7 +244,7 @@ describe('Arrange validators', () => {
         maxValidatorNumber,
         maxPrioritizedValidatorNumber
       );
-      expect(outputValidators).eql(expectingValidatorAddrs);
+      expect(outputValidators).deep.equal(expectingValidatorAddrs);
     });
 
     it('Actual(prioritized) == MaxNum(prioritized); Actual(regular) <  MaxNum(regular)', async () => {
@@ -270,7 +270,7 @@ describe('Arrange validators', () => {
         actualPrioritizedNumber + actualRegularNumber,
         maxPrioritizedValidatorNumber
       );
-      expect(outputValidators).eql(expectingValidatorAddrs);
+      expect(outputValidators).deep.equal(expectingValidatorAddrs);
     });
 
     it('Actual(prioritized) >  MaxNum(prioritized); Actual(regular) == MaxNum(regular)', async () => {
@@ -296,7 +296,7 @@ describe('Arrange validators', () => {
         maxValidatorNumber,
         maxPrioritizedValidatorNumber
       );
-      expect(outputValidators).eql(expectingValidatorAddrs);
+      expect(outputValidators).deep.equal(expectingValidatorAddrs);
     });
 
     it('Actual(prioritized) >  MaxNum(prioritized); Actual(regular) >  MaxNum(regular)', async () => {
@@ -322,7 +322,7 @@ describe('Arrange validators', () => {
         maxValidatorNumber,
         maxPrioritizedValidatorNumber
       );
-      expect(outputValidators).eql(expectingValidatorAddrs);
+      expect(outputValidators).deep.equal(expectingValidatorAddrs);
     });
 
     it('Actual(prioritized) >  MaxNum(prioritized); Actual(regular) <  MaxNum(regular)', async () => {
@@ -350,7 +350,7 @@ describe('Arrange validators', () => {
         maxValidatorNumber,
         maxPrioritizedValidatorNumber
       );
-      expect(outputValidators).eql(expectingValidatorAddrs);
+      expect(outputValidators).deep.equal(expectingValidatorAddrs);
     });
 
     it('Actual(prioritized) <  MaxNum(prioritized); Actual(regular) == MaxNum(regular)', async () => {
@@ -376,7 +376,7 @@ describe('Arrange validators', () => {
         actualPrioritizedNumber + actualRegularNumber,
         maxPrioritizedValidatorNumber
       );
-      expect(outputValidators).eql(expectingValidatorAddrs);
+      expect(outputValidators).deep.equal(expectingValidatorAddrs);
     });
 
     it('Actual(prioritized) <  MaxNum(prioritized); Actual(regular) >  MaxNum(regular)', async () => {
@@ -404,7 +404,7 @@ describe('Arrange validators', () => {
         maxValidatorNumber,
         maxPrioritizedValidatorNumber
       );
-      expect(outputValidators).eql(expectingValidatorAddrs);
+      expect(outputValidators).deep.equal(expectingValidatorAddrs);
     });
 
     it('Actual(prioritized) <  MaxNum(prioritized); Actual(regular) <  MaxNum(regular)', async () => {
@@ -430,7 +430,7 @@ describe('Arrange validators', () => {
         actualPrioritizedNumber + actualRegularNumber,
         maxPrioritizedValidatorNumber
       );
-      expect(outputValidators).eql(expectingValidatorAddrs);
+      expect(outputValidators).deep.equal(expectingValidatorAddrs);
     });
   });
 
@@ -457,7 +457,7 @@ describe('Arrange validators', () => {
         maxValidatorNumber,
         maxPrioritizedValidatorNumber
       );
-      expect(outputValidators).eql(expectingValidatorAddrs);
+      expect(outputValidators).deep.equal(expectingValidatorAddrs);
     });
 
     it('Shuffled: Actual(prioritized) >  MaxNum(prioritized); Actual(regular) <  MaxNum(regular)', async () => {
@@ -476,7 +476,7 @@ describe('Arrange validators', () => {
         maxValidatorNumber,
         maxPrioritizedValidatorNumber
       );
-      expect(outputValidators).eql(expectingValidatorAddrs);
+      expect(outputValidators).deep.equal(expectingValidatorAddrs);
     });
 
     it('Shuffled: Actual(prioritized) <  MaxNum(prioritized); Actual(regular) >  MaxNum(regular)', async () => {
@@ -495,7 +495,7 @@ describe('Arrange validators', () => {
         maxValidatorNumber,
         maxPrioritizedValidatorNumber
       );
-      expect(outputValidators).eql(expectingValidatorAddrs);
+      expect(outputValidators).deep.equal(expectingValidatorAddrs);
     });
   });
 });

--- a/test/validator/EmergencyExit.test.ts
+++ b/test/validator/EmergencyExit.test.ts
@@ -163,7 +163,9 @@ describe('Emergency Exit test', () => {
   });
 
   it('Should be able to get list of the validator candidates', async () => {
-    expect(validatorCandidates.map((v) => v.consensusAddr.address)).eql(await roninValidatorSet.getBlockProducers());
+    expect(validatorCandidates.map((v) => v.consensusAddr.address)).deep.equal(
+      await roninValidatorSet.getBlockProducers()
+    );
   });
 
   it('Should not be able to request emergency exit using unauthorized accounts', async () => {
@@ -212,7 +214,9 @@ describe('Emergency Exit test', () => {
   });
 
   it("Should the emergency exit's requester be still in the validator list", async () => {
-    expect(validatorCandidates.map((v) => v.consensusAddr.address)).eql(await roninValidatorSet.getBlockProducers());
+    expect(validatorCandidates.map((v) => v.consensusAddr.address)).deep.equal(
+      await roninValidatorSet.getBlockProducers()
+    );
     expect(await roninValidatorSet.isValidator(compromisedValidator.consensusAddr.address)).to.true;
     expect(await roninValidatorSet.isBlockProducer(compromisedValidator.consensusAddr.address)).to.true;
     expect(await roninValidatorSet.isOperatingBridge(compromisedValidator.consensusAddr.address)).to.true;

--- a/test/validator/RoninValidatorSet-Candidate.test.ts
+++ b/test/validator/RoninValidatorSet-Candidate.test.ts
@@ -185,8 +185,8 @@ describe('Ronin Validator Set: candidate test', () => {
       await expect(tx!).emit(roninValidatorSet, 'WrappedUpEpoch').withArgs(lastPeriod, epoch, true);
       lastPeriod = await roninValidatorSet.currentPeriod();
       await RoninValidatorSet.expects.emitValidatorSetUpdatedEvent(tx!, lastPeriod, expectingValidatorsAddr);
-      expect((await roninValidatorSet.getValidators())[0]).eql(expectingValidatorsAddr);
-      expect(await roninValidatorSet.getBlockProducers()).eql(expectingValidatorsAddr);
+      expect((await roninValidatorSet.getValidators())[0]).deep.equal(expectingValidatorsAddr);
+      expect(await roninValidatorSet.getBlockProducers()).deep.equal(expectingValidatorsAddr);
     });
 
     it('Should trusted org can apply for candidate and the set get synced', async () => {
@@ -223,8 +223,8 @@ describe('Ronin Validator Set: candidate test', () => {
       await expect(tx!).emit(roninValidatorSet, 'WrappedUpEpoch').withArgs(lastPeriod, epoch, true);
       lastPeriod = await roninValidatorSet.currentPeriod();
       await RoninValidatorSet.expects.emitValidatorSetUpdatedEvent(tx!, lastPeriod, expectingValidatorsAddr);
-      expect((await roninValidatorSet.getValidators())[0]).eql(expectingValidatorsAddr);
-      expect(await roninValidatorSet.getBlockProducers()).eql(expectingValidatorsAddr);
+      expect((await roninValidatorSet.getValidators())[0]).deep.equal(expectingValidatorsAddr);
+      expect(await roninValidatorSet.getBlockProducers()).deep.equal(expectingValidatorsAddr);
     });
   });
 

--- a/test/validator/RoninValidatorSet-CoinbaseExecution.test.ts
+++ b/test/validator/RoninValidatorSet-CoinbaseExecution.test.ts
@@ -180,7 +180,7 @@ describe('Ronin Validator Set: Coinbase execution test', () => {
       await expect(tx!).emit(roninValidatorSet, 'WrappedUpEpoch').withArgs(lastPeriod, epoch, true);
       lastPeriod = await roninValidatorSet.currentPeriod();
       await RoninValidatorSetExpects.emitBlockProducerSetUpdatedEvent(tx!, lastPeriod, nextEpoch, []);
-      expect((await roninValidatorSet.getValidators())[0]).eql([]);
+      expect((await roninValidatorSet.getValidators())[0]).deep.equal([]);
     });
   });
 
@@ -208,8 +208,8 @@ describe('Ronin Validator Set: Coinbase execution test', () => {
         tx = await roninValidatorSet.connect(consensusAddr).wrapUpEpoch();
       });
       await expect(tx!).emit(roninValidatorSet, 'WrappedUpEpoch').withArgs(lastPeriod, epoch, false);
-      expect((await roninValidatorSet.getValidators())[0]).eql([]);
-      expect(await roninValidatorSet.getBlockProducers()).eql([]);
+      expect((await roninValidatorSet.getValidators())[0]).deep.equal([]);
+      expect(await roninValidatorSet.getBlockProducers()).deep.equal([]);
       await expect(tx!).not.emit(roninValidatorSet, 'ValidatorSetUpdated');
     });
   });
@@ -234,8 +234,8 @@ describe('Ronin Validator Set: Coinbase execution test', () => {
       await expect(tx!).emit(roninValidatorSet, 'WrappedUpEpoch').withArgs(lastPeriod, epoch, true);
       lastPeriod = await roninValidatorSet.currentPeriod();
       await RoninValidatorSetExpects.emitValidatorSetUpdatedEvent(tx!, lastPeriod, expectingValidatorsAddr);
-      expect((await roninValidatorSet.getValidators())[0]).eql(expectingValidatorsAddr);
-      expect(await roninValidatorSet.getBlockProducers()).eql(expectingValidatorsAddr);
+      expect((await roninValidatorSet.getValidators())[0]).deep.equal(expectingValidatorsAddr);
+      expect(await roninValidatorSet.getBlockProducers()).deep.equal(expectingValidatorsAddr);
     });
 
     it('Should validator is set with correct flags', async () => {
@@ -309,8 +309,8 @@ describe('Ronin Validator Set: Coinbase execution test', () => {
       await expect(tx!).emit(roninValidatorSet, 'WrappedUpEpoch').withArgs(lastPeriod, epoch, true);
       lastPeriod = await roninValidatorSet.currentPeriod();
       await RoninValidatorSetExpects.emitValidatorSetUpdatedEvent(tx!, lastPeriod, currentValidatorSet);
-      expect((await roninValidatorSet.getValidators())[0]).eql(currentValidatorSet);
-      expect(await roninValidatorSet.getBlockProducers()).eql(currentValidatorSet);
+      expect((await roninValidatorSet.getValidators())[0]).deep.equal(currentValidatorSet);
+      expect(await roninValidatorSet.getBlockProducers()).deep.equal(currentValidatorSet);
     });
   });
 
@@ -351,8 +351,8 @@ describe('Ronin Validator Set: Coinbase execution test', () => {
       });
 
       it('Should validator is set with correct flags', async () => {
-        expect((await roninValidatorSet.getValidators())[0]).eql(expectingValidatorsAddr);
-        expect(await roninValidatorSet.getBlockProducers()).eql(expectingValidatorsAddr);
+        expect((await roninValidatorSet.getValidators())[0]).deep.equal(expectingValidatorsAddr);
+        expect(await roninValidatorSet.getBlockProducers()).deep.equal(expectingValidatorsAddr);
         for (let validatorAddr of expectingValidatorsAddr) {
           expect(await roninValidatorSet.isValidator(validatorAddr)).eq(
             true,


### PR DESCRIPTION
The `hardhat-deploy` package uses higher version of `ethers` which causes the following test case failed.

```
console.log(await validatorContract.getJailUntils(expectingValidatorSet));
console.log(BigNumber.from(blockNumber).add(jailDurationForUnavailabilityTier2Threshold));
```

Before upgrade
```
[ BigNumber { value: "57658" } ]
BigNumber { value: "57658" }
```

After upgrade
```
[ BigNumber { _hex: '0xe13a', _isBigNumber: true } ]
BigNumber { value: "57658" }
```