### PR TITLE
[RoninGA] Emit event for tracking who voted

### DIFF
--- a/contracts/interfaces/IRoninGovernanceAdmin.sol
+++ b/contracts/interfaces/IRoninGovernanceAdmin.sol
@@ -18,6 +18,8 @@ interface IRoninGovernanceAdmin {
   event EmergencyExitPollApproved(bytes32 _voteHash);
   /// @dev Emitted when an emergency exit poll is expired.
   event EmergencyExitPollExpired(bytes32 _voteHash);
+  /// @dev Emitted when an emergency exit poll is voted.
+  event EmergencyExitPollVoted(bytes32 indexed _voteHash);
 
   /**
    * @dev Returns the last voted block of the bridge voter.

--- a/contracts/interfaces/IRoninGovernanceAdmin.sol
+++ b/contracts/interfaces/IRoninGovernanceAdmin.sol
@@ -19,7 +19,7 @@ interface IRoninGovernanceAdmin {
   /// @dev Emitted when an emergency exit poll is expired.
   event EmergencyExitPollExpired(bytes32 _voteHash);
   /// @dev Emitted when an emergency exit poll is voted.
-  event EmergencyExitPollVoted(bytes32 indexed _voteHash);
+  event EmergencyExitPollVoted(bytes32 indexed _voteHash, address indexed _voter);
 
   /**
    * @dev Returns the last voted block of the bridge voter.

--- a/contracts/ronin/RoninGovernanceAdmin.sol
+++ b/contracts/ronin/RoninGovernanceAdmin.sol
@@ -350,7 +350,7 @@ contract RoninGovernanceAdmin is
     require(_v.status != VoteStatus.Expired, "RoninGovernanceAdmin: query for expired vote");
 
     _v.castVote(_voter, _hash);
-    emit EmergencyExitPollVoted(_hash);
+    emit EmergencyExitPollVoted(_hash, _voter);
 
     address[] memory _voters = _v.filterByHash(_hash);
     VoteStatus _stt = _v.syncVoteStatus(_getMinimumVoteWeight(), _sumGovernorWeights(_voters), 0, 0, _hash);

--- a/contracts/ronin/RoninGovernanceAdmin.sol
+++ b/contracts/ronin/RoninGovernanceAdmin.sol
@@ -350,6 +350,8 @@ contract RoninGovernanceAdmin is
     require(_v.status != VoteStatus.Expired, "RoninGovernanceAdmin: query for expired vote");
 
     _v.castVote(_voter, _hash);
+    emit EmergencyExitPollVoted(_hash);
+
     address[] memory _voters = _v.filterByHash(_hash);
     VoteStatus _stt = _v.syncVoteStatus(_getMinimumVoteWeight(), _sumGovernorWeights(_voters), 0, 0, _hash);
     if (_stt == VoteStatus.Approved) {

--- a/test/validator/EmergencyExit.test.ts
+++ b/test/validator/EmergencyExit.test.ts
@@ -62,7 +62,7 @@ let voteHash: string;
 let snapshotId: string;
 let totalStakedAmount: BigNumber;
 
-describe('Emergency Exit test', () => {
+describe.only('Emergency Exit test', () => {
   let tx: ContractTransaction;
   let requestBlock: EthersType.providers.Block;
 
@@ -269,7 +269,9 @@ describe('Emergency Exit test', () => {
         .voteEmergencyExit(voteHash, consensusAddr, recipientAfterUnlockedFund, requestedAt, expiredAt);
     });
     it('Should the vote tx emit event EmergencyExitPollVoted', async () => {
-      await expect(tx).emit(governanceAdmin, 'EmergencyExitPollVoted').withArgs(voteHash);
+      await expect(tx)
+        .emit(governanceAdmin, 'EmergencyExitPollVoted')
+        .withArgs(voteHash, trustedOrgs[0].governor.address);
     });
 
     it('Should the vote tx emit event EmergencyExitPollApproved', async () => {

--- a/test/validator/EmergencyExit.test.ts
+++ b/test/validator/EmergencyExit.test.ts
@@ -62,7 +62,7 @@ let voteHash: string;
 let snapshotId: string;
 let totalStakedAmount: BigNumber;
 
-describe.only('Emergency Exit test', () => {
+describe('Emergency Exit test', () => {
   let tx: ContractTransaction;
   let requestBlock: EthersType.providers.Block;
 

--- a/test/validator/EmergencyExit.test.ts
+++ b/test/validator/EmergencyExit.test.ts
@@ -251,7 +251,6 @@ describe('Emergency Exit test', () => {
         .filter((v) => v != compromisedValidator.bridgeOperator.address)
     );
   });
-
   describe('Valid emergency exit', () => {
     let balance: BigNumberish;
 
@@ -268,6 +267,9 @@ describe('Emergency Exit test', () => {
       tx = await governanceAdmin
         .connect(trustedOrgs[0].governor)
         .voteEmergencyExit(voteHash, consensusAddr, recipientAfterUnlockedFund, requestedAt, expiredAt);
+    });
+    it('Should the vote tx emit event EmergencyExitPollVoted', async () => {
+      await expect(tx).emit(governanceAdmin, 'EmergencyExitPollVoted').withArgs(voteHash);
     });
 
     it('Should the vote tx emit event EmergencyExitPollApproved', async () => {


### PR DESCRIPTION
### Description
- [PSC-246](https://skymavis.atlassian.net/jira/software/projects/PSC/boards/47?selectedIssue=PSC-246) [GA][Contract] Emit event for who voted
### Contract changes

The table below shows the following info:
- **Logic**: the logic is changed.
- **ABI**: the ABI is changed.
- **Init data**: new storage field is declared and needs initializing.
- **Dependent**: needs to be changed due to changes in other contracts.

| **Contract name** | **Logic** | **ABI** | **Init data** | **Dependent** |
|-------------------|:---------:|:-------:|:-------------:|:-------------:|
| RoninGovernanceAdmin   |     x      |     x    |               |               |

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works


[PSC-246]: https://skymavis.atlassian.net/browse/PSC-246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ