### PR TITLE
[Staking] Allow validator to update consensus address

### DIFF
--- a/contracts/interfaces/staking/IBaseStaking.sol
+++ b/contracts/interfaces/staking/IBaseStaking.sol
@@ -44,9 +44,9 @@ interface IBaseStaking {
   function isAdminOfActivePool(address _poolAdminAddr) external view returns (bool);
 
   /**
-   * @dev Returns the consensus address corresponding to the pool admin.
+   * @dev Returns the pool address corresponding to the pool admin.
    */
-  function getPoolAddressOf(address _poolAdminAddr) external view returns (address);
+  function getPoolAddressOfAdmin(address _poolAdminAddr) external view returns (address);
 
   /**
    * @dev Returns the staking pool detail.

--- a/contracts/interfaces/staking/IBaseStaking.sol
+++ b/contracts/interfaces/staking/IBaseStaking.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.9;
 
 interface IBaseStaking {
   struct PoolDetail {
-    // Address of the pool i.e. consensus address of the validator
+    // Address of the pool i.e. normally is consensus address of the validator unless it is requested to be changed
     address addr;
     // Pool admin address
     address admin;

--- a/contracts/interfaces/staking/ICandidateStaking.sol
+++ b/contracts/interfaces/staking/ICandidateStaking.sol
@@ -34,6 +34,8 @@ interface ICandidateStaking is IRewardPool {
     uint256 contractBalance
   );
 
+  /// @dev Error of general invalid input.
+  error ErrInvalidInput();
   /// @dev Error of cannot transfer RON to specified target.
   error ErrCannotInitTransferRON(address addr, string extraInfo);
   /// @dev Error of three interaction addresses must be of the same in applying for validator candidate.

--- a/contracts/interfaces/staking/IStaking.sol
+++ b/contracts/interfaces/staking/IStaking.sol
@@ -7,6 +7,8 @@ import "./ICandidateStaking.sol";
 import "./IDelegatorStaking.sol";
 
 interface IStaking is IRewardPool, IBaseStaking, ICandidateStaking, IDelegatorStaking {
+  error ErrAlreadyInitialized();
+
   /**
    * @dev Records the amount of rewards `_rewards` for the pools `_consensusAddrs`.
    *

--- a/contracts/ronin/staking/BaseStaking.sol
+++ b/contracts/ronin/staking/BaseStaking.sol
@@ -16,7 +16,10 @@ abstract contract BaseStaking is
   HasValidatorContract,
   IBaseStaking
 {
-  /// @dev Mapping from pool address => staking pool detail
+  /**
+   * @dev Mapping from pool address => staking pool detail.
+   * Access to this variable must go through `_getStakingPool` function.
+   */
   mapping(address => PoolDetail) private _stakingPool;
 
   /// @dev The cooldown time in seconds to undelegate from the last timestamp (s)he delegated.
@@ -34,7 +37,7 @@ abstract contract BaseStaking is
    * @dev This empty reserved space is put in place to allow future versions to add new
    * variables without shifting down storage in the inheritance chain.
    */
-  uint256[47] private ______gap;
+  uint256[48] private ______gap;
 
   modifier noEmptyValue() {
     if (msg.value == 0) revert ErrZeroValue();

--- a/contracts/ronin/staking/CandidateStaking.sol
+++ b/contracts/ronin/staking/CandidateStaking.sol
@@ -134,8 +134,6 @@ abstract contract CandidateStaking is BaseStaking, ICandidateStaking, GlobalConf
       if (_lastRewardAmount > 0) {
         _unsafeSendRON(payable(_pool.admin), _lastRewardAmount, DEFAULT_ADDITION_GAS);
       }
-
-      delete poolOfConsensusMapping[_consensusAddrs[_i]];
     }
 
     emit PoolsDeprecated(_pools);

--- a/contracts/ronin/staking/CandidateStaking.sol
+++ b/contracts/ronin/staking/CandidateStaking.sol
@@ -80,6 +80,7 @@ abstract contract CandidateStaking is BaseStaking, ICandidateStaking, GlobalConf
     _pool.admin = _poolAdmin;
     _pool.addr = _consensusAddr;
     _adminOfActivePoolMapping[_poolAdmin] = _consensusAddr;
+    poolOfConsensusMapping[_consensusAddr] = _consensusAddr;
 
     _stake(_getStakingPool(_consensusAddr), _poolAdmin, _amount);
     emit PoolApproved(_consensusAddr, _poolAdmin);
@@ -132,6 +133,8 @@ abstract contract CandidateStaking is BaseStaking, ICandidateStaking, GlobalConf
       if (_lastRewardAmount > 0) {
         _unsafeSendRON(payable(_pool.admin), _lastRewardAmount, DEFAULT_ADDITION_GAS);
       }
+
+      delete poolOfConsensusMapping[_consensusAddrs[_i]];
     }
 
     emit PoolsDeprecated(_pools);
@@ -169,9 +172,8 @@ abstract contract CandidateStaking is BaseStaking, ICandidateStaking, GlobalConf
     onlyPoolAdmin(_getStakingPool(_oldConsensusAddr), msg.sender)
   {
     if (_oldConsensusAddr == _newConsensusAddr) revert ErrInvalidInput();
-    address _poolAddr = poolOfConsensusMapping[_oldConsensusAddr];
-    poolOfConsensusMapping[_oldConsensusAddr] = address(0);
-    poolOfConsensusMapping[_newConsensusAddr] = _poolAddr;
+    poolOfConsensusMapping[_newConsensusAddr] = poolOfConsensusMapping[_oldConsensusAddr];
+    delete poolOfConsensusMapping[_oldConsensusAddr];
   }
 
   /**

--- a/contracts/ronin/staking/CandidateStaking.sol
+++ b/contracts/ronin/staking/CandidateStaking.sol
@@ -76,13 +76,14 @@ abstract contract CandidateStaking is BaseStaking, ICandidateStaking, GlobalConf
       _amount
     );
 
+    poolOfConsensusMapping[_consensusAddr] = _consensusAddr;
+
     PoolDetail storage _pool = _getStakingPool(_consensusAddr);
     _pool.admin = _poolAdmin;
     _pool.addr = _consensusAddr;
     _adminOfActivePoolMapping[_poolAdmin] = _consensusAddr;
-    poolOfConsensusMapping[_consensusAddr] = _consensusAddr;
 
-    _stake(_getStakingPool(_consensusAddr), _poolAdmin, _amount);
+    _stake(_pool, _poolAdmin, _amount);
     emit PoolApproved(_consensusAddr, _poolAdmin);
   }
 
@@ -172,6 +173,9 @@ abstract contract CandidateStaking is BaseStaking, ICandidateStaking, GlobalConf
     onlyPoolAdmin(_getStakingPool(_oldConsensusAddr), msg.sender)
   {
     if (_oldConsensusAddr == _newConsensusAddr) revert ErrInvalidInput();
+    PoolDetail storage _pool = _getStakingPool(_oldConsensusAddr);
+
+    _adminOfActivePoolMapping[_pool.admin] = _newConsensusAddr;
     poolOfConsensusMapping[_newConsensusAddr] = poolOfConsensusMapping[_oldConsensusAddr];
     delete poolOfConsensusMapping[_oldConsensusAddr];
   }

--- a/contracts/ronin/staking/DelegatorStaking.sol
+++ b/contracts/ronin/staking/DelegatorStaking.sol
@@ -17,7 +17,7 @@ abstract contract DelegatorStaking is BaseStaking, IDelegatorStaking {
    */
   function delegate(address _consensusAddr) external payable noEmptyValue poolIsActive(_consensusAddr) {
     if (isAdminOfActivePool(msg.sender)) revert ErrAdminOfAnyActivePoolForbidden(msg.sender);
-    _delegate(_stakingPool[_consensusAddr], msg.sender, msg.value);
+    _delegate(_getStakingPool(_consensusAddr), msg.sender, msg.value);
   }
 
   /**
@@ -25,7 +25,7 @@ abstract contract DelegatorStaking is BaseStaking, IDelegatorStaking {
    */
   function undelegate(address _consensusAddr, uint256 _amount) external nonReentrant {
     address payable _delegator = payable(msg.sender);
-    _undelegate(_stakingPool[_consensusAddr], _delegator, _amount);
+    _undelegate(_getStakingPool(_consensusAddr), _delegator, _amount);
     if (!_sendRON(_delegator, _amount)) revert ErrCannotTransferRON();
   }
 
@@ -40,7 +40,7 @@ abstract contract DelegatorStaking is BaseStaking, IDelegatorStaking {
 
     for (uint _i = 0; _i < _consensusAddrs.length; _i++) {
       _total += _amounts[_i];
-      _undelegate(_stakingPool[_consensusAddrs[_i]], _delegator, _amounts[_i]);
+      _undelegate(_getStakingPool(_consensusAddrs[_i]), _delegator, _amounts[_i]);
     }
 
     if (!_sendRON(_delegator, _total)) revert ErrCannotTransferRON();
@@ -55,8 +55,8 @@ abstract contract DelegatorStaking is BaseStaking, IDelegatorStaking {
     uint256 _amount
   ) external nonReentrant poolIsActive(_consensusAddrDst) {
     address _delegator = msg.sender;
-    _undelegate(_stakingPool[_consensusAddrSrc], _delegator, _amount);
-    _delegate(_stakingPool[_consensusAddrDst], _delegator, _amount);
+    _undelegate(_getStakingPool(_consensusAddrSrc), _delegator, _amount);
+    _delegate(_getStakingPool(_consensusAddrDst), _delegator, _amount);
   }
 
   /**
@@ -186,6 +186,6 @@ abstract contract DelegatorStaking is BaseStaking, IDelegatorStaking {
     address _poolAddrDst
   ) internal returns (uint256 _amount) {
     _amount = _claimRewards(_user, _poolAddrList);
-    _delegate(_stakingPool[_poolAddrDst], _user, _amount);
+    _delegate(_getStakingPool(_poolAddrDst), _user, _amount);
   }
 }

--- a/contracts/ronin/staking/RewardCalculation.sol
+++ b/contracts/ronin/staking/RewardCalculation.sol
@@ -15,7 +15,7 @@ abstract contract RewardCalculation is IRewardPool {
   /// @dev Mapping from the pool address => user address => the reward info of the user
   mapping(address => mapping(address => UserRewardFields)) private _userReward;
   /// @dev Mapping from the pool address => reward pool fields
-  mapping(address => PoolFields) private _stakingPool;
+  mapping(address => PoolFields) private _stakingPoolField;
 
   /**
    * @dev This empty reserved space is put in place to allow future versions to add new
@@ -57,7 +57,7 @@ abstract contract RewardCalculation is IRewardPool {
 
     uint256 _aRps;
     uint256 _lastPeriodReward;
-    PoolFields storage _pool = _stakingPool[_poolAddr];
+    PoolFields storage _pool = _stakingPoolField[_poolAddr];
     PeriodWrapper storage _wrappedArps = _accumulatedRps[_poolAddr][_reward.lastPeriod];
 
     if (_wrappedArps.lastPeriod > 0) {
@@ -88,7 +88,7 @@ abstract contract RewardCalculation is IRewardPool {
     uint256 _newStakingAmount
   ) internal {
     uint256 _period = _currentPeriod();
-    PoolFields storage _pool = _stakingPool[_poolAddr];
+    PoolFields storage _pool = _stakingPoolField[_poolAddr];
     uint256 _lastShares = _pool.shares.inner;
 
     // Updates the pool shares if it is outdated
@@ -159,9 +159,15 @@ abstract contract RewardCalculation is IRewardPool {
 
     UserRewardFields storage _reward = _userReward[_poolAddr][_user];
     _reward.debited = 0;
-    _syncMinStakingAmount(_stakingPool[_poolAddr], _reward, _lastPeriod, _currentStakingAmount, _currentStakingAmount);
+    _syncMinStakingAmount(
+      _stakingPoolField[_poolAddr],
+      _reward,
+      _lastPeriod,
+      _currentStakingAmount,
+      _currentStakingAmount
+    );
     _reward.lastPeriod = _lastPeriod;
-    _reward.aRps = _stakingPool[_poolAddr].aRps;
+    _reward.aRps = _stakingPoolField[_poolAddr].aRps;
     emit UserRewardUpdated(_poolAddr, _user, 0);
   }
 
@@ -195,7 +201,7 @@ abstract contract RewardCalculation is IRewardPool {
 
     for (uint _i = 0; _i < _poolAddrs.length; _i++) {
       _poolAddr = _poolAddrs[_i];
-      PoolFields storage _pool = _stakingPool[_poolAddr];
+      PoolFields storage _pool = _stakingPoolField[_poolAddr];
       _stakingTotal = getStakingTotal(_poolAddr);
 
       if (_accumulatedRps[_poolAddr][_period].lastPeriod == _period) {

--- a/contracts/ronin/staking/Staking.sol
+++ b/contracts/ronin/staking/Staking.sol
@@ -36,6 +36,16 @@ contract Staking is IStaking, CandidateStaking, DelegatorStaking, Initializable 
   }
 
   /**
+   * @dev Initializes the mapping for consensus address => pool address.
+   * @param _consensusAddrs List of consensus addresses, including both active and unactive ones.
+   */
+  function initializeV2(address[] calldata _consensusAddrs) external reinitializer(2) {
+    for (uint _i; _i < _consensusAddrs.length; ) {
+      poolOfConsensusMapping[_consensusAddrs[_i]] = _consensusAddrs[_i];
+    }
+  }
+
+  /**
    * @inheritdoc IStaking
    */
   function execRecordRewards(
@@ -55,7 +65,7 @@ contract Staking is IStaking, CandidateStaking, DelegatorStaking, Initializable 
     onlyValidatorContract
     returns (uint256 _actualDeductingAmount)
   {
-    _actualDeductingAmount = _deductStakingAmount(_stakingPool[_consensusAddr], _amount);
+    _actualDeductingAmount = _deductStakingAmount(_getStakingPool(_consensusAddr), _amount);
     address payable _validatorContractAddr = payable(validatorContract());
     if (!_unsafeSendRON(_validatorContractAddr, _actualDeductingAmount)) {
       emit StakingAmountDeductFailed(


### PR DESCRIPTION
### Description

### Contract changes

The table below shows the following info:
- **Logic**: the logic is changed.
- **ABI**: the ABI is changed.
- **Init data**: new storage field is declared and needs initializing.
- **Dependent**: needs to be changed due to changes in other contracts.

| **Contract name** | **Logic** | **ABI** | **Init data** | **Dependent** |
|-------------------|:---------:|:-------:|:-------------:|:-------------:|
| BridgeTracking    |           |         |               |               |
| GovernanceAdmin   |           |         |               |               |
| Maintenance       |           |         |               |               |
| SlashIndicator    |           |         |               |               |
| Staking           |     x      |    x     |        x       |               |
| StakingVesting    |           |         |               |               |
| ValidatorSet      |           |         |               |               |

### Checklist
- [ ] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [ ] I tested locally to make sure this feature/fix works
