### PR TITLE
[ValidatorSet] Fix bridge reward calculation for validator exited by emergency

### DIFF
--- a/contracts/interfaces/validator/info-fragments/IValidatorInfo.sol
+++ b/contracts/interfaces/validator/info-fragments/IValidatorInfo.sol
@@ -56,14 +56,22 @@ interface IValidatorInfo {
   function totalBlockProducers() external view returns (uint256);
 
   /**
-   * @dev Returns the current bridge operator list.
+   * @dev Returns the current on-working bridge operator list.
+   * @param bridgeOperatorList The list of working bridge operators.
+   * @param validatorList The list of corresponding validators.
    */
-  function getBridgeOperators() external view returns (address[] memory);
+  function getBridgeOperators()
+    external
+    view
+    returns (address[] memory bridgeOperatorList, address[] memory validatorList);
 
   /**
    * @dev Returns the bridge operator list corresponding to validator address list.
    */
-  function getBridgeOperatorsOf(address[] memory _validatorAddrs) external view returns (address[] memory);
+  function getBridgeOperatorsOf(address[] memory _validatorAddrs)
+    external
+    view
+    returns (address[] memory bridgeOperatorList);
 
   /**
    * @dev Returns whether the address is bridge operator.

--- a/contracts/mocks/validator/MockValidatorSet.sol
+++ b/contracts/mocks/validator/MockValidatorSet.sol
@@ -103,7 +103,12 @@ contract MockValidatorSet is IRoninValidatorSet, CandidateManager {
     return _numberOfBlocksInEpoch;
   }
 
-  function getBridgeOperators() external view override returns (address[] memory) {}
+  function getBridgeOperators()
+    external
+    view
+    override
+    returns (address[] memory _bridges, address[] memory _validators)
+  {}
 
   function getBridgeOperatorsOf(address[] memory _validatorAddrs) external view override returns (address[] memory) {}
 

--- a/contracts/ronin/validator/storage-fragments/ValidatorInfoStorage.sol
+++ b/contracts/ronin/validator/storage-fragments/ValidatorInfoStorage.sol
@@ -96,17 +96,26 @@ abstract contract ValidatorInfoStorage is IValidatorInfo, HasRoninTrustedOrganiz
   /**
    * @inheritdoc IValidatorInfo
    */
-  function getBridgeOperators() public view override returns (address[] memory _result) {
-    _result = new address[](validatorCount);
+  function getBridgeOperators()
+    public
+    view
+    override
+    returns (address[] memory _bridgeOperatorList, address[] memory _validatorList)
+  {
+    _bridgeOperatorList = new address[](validatorCount);
+    _validatorList = new address[](validatorCount);
     uint256 _count = 0;
-    for (uint _i; _i < _result.length; _i++) {
+    for (uint _i; _i < _bridgeOperatorList.length; _i++) {
       if (isOperatingBridge(_validators[_i])) {
-        _result[_count++] = _bridgeOperatorOf(_validators[_i]);
+        address __validator = _validators[_i];
+        _bridgeOperatorList[_count++] = _bridgeOperatorOf(__validator);
+        _validatorList[_count] = __validator;
       }
     }
 
     assembly {
-      mstore(_result, _count)
+      mstore(_bridgeOperatorList, _count)
+      mstore(_validatorList, _count)
     }
   }
 
@@ -117,11 +126,11 @@ abstract contract ValidatorInfoStorage is IValidatorInfo, HasRoninTrustedOrganiz
     public
     view
     override
-    returns (address[] memory _result)
+    returns (address[] memory _bridgeOperatorList)
   {
-    _result = new address[](_validatorAddrs.length);
-    for (uint _i; _i < _result.length; _i++) {
-      _result[_i] = _bridgeOperatorOf(_validatorAddrs[_i]);
+    _bridgeOperatorList = new address[](_validatorAddrs.length);
+    for (uint _i; _i < _bridgeOperatorList.length; _i++) {
+      _bridgeOperatorList[_i] = _bridgeOperatorOf(_validatorAddrs[_i]);
     }
   }
 

--- a/contracts/ronin/validator/storage-fragments/ValidatorInfoStorage.sol
+++ b/contracts/ronin/validator/storage-fragments/ValidatorInfoStorage.sol
@@ -102,14 +102,15 @@ abstract contract ValidatorInfoStorage is IValidatorInfo, HasRoninTrustedOrganiz
     override
     returns (address[] memory _bridgeOperatorList, address[] memory _validatorList)
   {
-    _bridgeOperatorList = new address[](validatorCount);
-    _validatorList = new address[](validatorCount);
+    uint256 _length = validatorCount;
+    _bridgeOperatorList = new address[](_length);
+    _validatorList = new address[](_length);
     uint256 _count = 0;
-    for (uint _i; _i < _bridgeOperatorList.length; _i++) {
+    for (uint _i; _i < _length; _i++) {
       if (isOperatingBridge(_validators[_i])) {
         address __validator = _validators[_i];
-        _bridgeOperatorList[_count++] = _bridgeOperatorOf(__validator);
-        _validatorList[_count] = __validator;
+        _bridgeOperatorList[_count] = _bridgeOperatorOf(__validator);
+        _validatorList[_count++] = __validator;
       }
     }
 

--- a/test/bridge/BridgeTracking.test.ts
+++ b/test/bridge/BridgeTracking.test.ts
@@ -128,7 +128,9 @@ describe('Bridge Tracking test', () => {
       await roninValidatorSet.connect(coinbase).wrapUpEpoch();
     });
     period = await roninValidatorSet.currentPeriod();
-    expect(await roninValidatorSet.getBridgeOperators()).deep.equal(candidates.map((v) => v.bridgeOperator.address));
+    expect((await roninValidatorSet.getBridgeOperators())._bridgeOperatorList).deep.equal(
+      candidates.map((v) => v.bridgeOperator.address)
+    );
   });
 
   after(async () => {

--- a/test/bridge/GatewayPauseEnforcer.test.ts
+++ b/test/bridge/GatewayPauseEnforcer.test.ts
@@ -185,7 +185,9 @@ describe('Ronin Gateway V2 test', () => {
       await roninValidatorSet.connect(coinbase).wrapUpEpoch();
     });
     period = await roninValidatorSet.currentPeriod();
-    expect(await roninValidatorSet.getBridgeOperators()).deep.equal(candidates.map((v) => v.bridgeOperator.address));
+    expect((await roninValidatorSet.getBridgeOperators())._bridgeOperatorList).deep.equal(
+      candidates.map((v) => v.bridgeOperator.address)
+    );
   });
 
   after(async () => {

--- a/test/bridge/RoninGatewayV2.test.ts
+++ b/test/bridge/RoninGatewayV2.test.ts
@@ -174,7 +174,9 @@ describe('Ronin Gateway V2 test', () => {
       await roninValidatorSet.connect(coinbase).wrapUpEpoch();
     });
     period = await roninValidatorSet.currentPeriod();
-    expect(await roninValidatorSet.getBridgeOperators()).deep.equal(candidates.map((v) => v.bridgeOperator.address));
+    expect((await roninValidatorSet.getBridgeOperators())._bridgeOperatorList).deep.equal(
+      candidates.map((v) => v.bridgeOperator.address)
+    );
   });
 
   after(async () => {

--- a/test/integration/ActionBridgeTracking.test.ts
+++ b/test/integration/ActionBridgeTracking.test.ts
@@ -170,7 +170,9 @@ describe('[Integration] Bridge Tracking test', () => {
       await roninValidatorSet.connect(coinbase).wrapUpEpoch();
     });
     period = await roninValidatorSet.currentPeriod();
-    expect(await roninValidatorSet.getBridgeOperators()).deep.equal(candidates.map((v) => v.bridgeOperator.address));
+    expect((await roninValidatorSet.getBridgeOperators())._bridgeOperatorList).deep.equal(
+      candidates.map((v) => v.bridgeOperator.address)
+    );
   });
 
   after(async () => {


### PR DESCRIPTION
### Description

### Contract changes

The table below shows the following info:
- **Logic**: the logic is changed.
- **ABI**: the ABI is changed.
- **Init data**: new storage field is declared and needs initializing.
- **Dependent**: needs to be changed due to changes in other contracts.

| **Contract name** | **Logic** | **ABI** | **Init data** | **Dependent** |
|-------------------|:---------:|:-------:|:-------------:|:-------------:|
| ValidatorSet      |     x      |     x    |               |               |

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
