### PR TITLE
Monitor: Add script for querying admin of all contracts

### DIFF
--- a/src/dashboard/dashboard-helper.ts
+++ b/src/dashboard/dashboard-helper.ts
@@ -1,0 +1,22 @@
+import { Address, Deployment } from 'hardhat-deploy/dist/types';
+import { DEFAULT_ADDRESS } from '../utils';
+import { ethers } from 'hardhat';
+
+export function isCorrectAdmin(admin: Address, expectedAdmin: Address): boolean {
+  if (expectedAdmin == DEFAULT_ADDRESS) return false;
+  return admin.toLocaleLowerCase() == expectedAdmin.toLocaleLowerCase();
+}
+
+export const getAdminOfProxy = async (address: Address): Promise<string> => {
+  const ADMIN_SLOT = '0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103';
+  const slotValue = await ethers.provider.getStorageAt(address, ADMIN_SLOT);
+  return ethers.utils.hexStripZeros(slotValue);
+};
+
+export interface ProxyManagementInfo {
+  deployment: Deployment | null;
+  address?: Address;
+  admin?: Address;
+  expectedAdmin?: Address;
+  isCorrect?: Boolean;
+}

--- a/src/dashboard/query-proxy-admin-mainchain.ts
+++ b/src/dashboard/query-proxy-admin-mainchain.ts
@@ -1,0 +1,63 @@
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+import { generalMainchainConf, mainchainNetworks } from '../configs/config';
+import { network } from 'hardhat';
+import { ProxyManagementInfo, getAdminOfProxy, isCorrectAdmin } from './dashboard-helper';
+
+const BridgeProxyName = {
+  BridgeContract: 'MainchainGatewayProxyV2',
+} as const;
+
+const ProxyNames = { ...BridgeProxyName } as const;
+
+type ValueOf<T> = T[keyof T];
+type ProxyNamesType = ValueOf<typeof ProxyNames>;
+
+interface ProxyManagementInfoComponents {
+  [deploymentName: ProxyNamesType | string]: ProxyManagementInfo;
+}
+
+const deploy = async ({ deployments }: HardhatRuntimeEnvironment) => {
+  if (!mainchainNetworks.includes(network.name!)) {
+    return;
+  }
+
+  const BridgeManagerDeployment = await deployments.get('MainchainBridgeManager');
+  console.log('BridgeManager', BridgeManagerDeployment.address);
+
+  const components: ProxyManagementInfoComponents = {};
+  for (const key of Object.keys(ProxyNames)) {
+    const deployment = await deployments.getOrNull(getValueByKey(key as ProxyNamesType));
+    let address = deployment?.address;
+
+    if (getValueByKey(key as ProxyNamesType) == BridgeProxyName.BridgeContract) {
+      address = address ?? generalMainchainConf[network.name].bridgeContract;
+      console.info('Loaded BridgeContract from config.');
+    }
+
+    if (!address) {
+      continue;
+    }
+
+    const admin = await getAdminOfProxy(address);
+    const expectedAdmin = BridgeManagerDeployment.address;
+    components[key] = {
+      deployment,
+      address,
+      admin,
+      expectedAdmin,
+      isCorrect: isCorrectAdmin(admin, expectedAdmin),
+    };
+  }
+
+  console.table(components, ['address', 'admin', 'expectedAdmin', 'isCorrect']);
+};
+
+function getValueByKey(key: ProxyNamesType): string {
+  const indexOfS = Object.keys(ProxyNames).indexOf(key);
+  return Object.values(ProxyNames)[indexOfS];
+}
+
+// yarn hardhat deploy --tags QueryProxyAdminMainchain --network goerli
+deploy.tags = ['QueryProxyAdminMainchain'];
+
+export default deploy;

--- a/src/dashboard/query-proxy-admin-ronin.ts
+++ b/src/dashboard/query-proxy-admin-ronin.ts
@@ -100,7 +100,7 @@ function isCorrectAdmin(admin: Address, expectedAdmin: Address): boolean {
   return admin.toLocaleLowerCase() == expectedAdmin.toLocaleLowerCase();
 }
 
-// yarn hardhat deploy --tags QueryProxyAdmin --network ronin-testnet
-deploy.tags = ['QueryProxyAdmin'];
+// yarn hardhat deploy --tags QueryProxyAdminRonin --network ronin-testnet
+deploy.tags = ['QueryProxyAdminRonin'];
 
 export default deploy;

--- a/src/dashboard/query-proxy-admin.ts
+++ b/src/dashboard/query-proxy-admin.ts
@@ -1,0 +1,91 @@
+import { EthereumProvider, HardhatRuntimeEnvironment } from 'hardhat/types';
+import { explorerUrl, proxyInterface } from '../upgrades/upgradeUtils';
+import {
+  MainchainGatewayV2__factory,
+  RoninValidatorSetTimedMigrator__factory,
+  RoninValidatorSet__factory,
+} from '../types';
+import { generalMainchainConf, generalRoninConf, roninchainNetworks } from '../configs/config';
+import { ethers, network } from 'hardhat';
+import { Address, Deployment } from 'hardhat-deploy/dist/types';
+import type * as ethersType from 'ethers';
+
+const BridgeProxyName = {
+  BridgeReward: 'BridgeRewardProxy',
+  BridgeSlash: 'BridgeSlashProxy',
+  BridgeTracking: 'BridgeTrackingProxy',
+  bridgeContract: 'RoninGatewayProxyV2',
+} as const;
+
+const DPoSProxyName = {
+  Maintenance: 'MaintenanceProxy',
+  RoninGatewayPauseEnforcer: 'RoninGatewayPauseEnforcerProxy',
+  RoninTrustedOrganization: 'RoninTrustedOrganizationProxy',
+  RoninValidatorSet: 'RoninValidatorSetProxy',
+  SlashIndicator: 'SlashIndicatorProxy',
+  Staking: 'StakingProxy',
+  StakingVesting: 'StakingVestingProxy',
+} as const;
+
+const ProxyNames = { ...BridgeProxyName, ...DPoSProxyName } as const;
+
+type ValueOf<T> = T[keyof T];
+type ProxyNamesType = ValueOf<typeof ProxyNames>;
+
+interface ProxyManagementInfo {
+  deployment: Deployment | null;
+  address?: Address;
+  admin?: Address;
+  correctAdmin?: Boolean;
+}
+
+interface ProxyManagementInfoRecords {
+  [deploymentName: ProxyNamesType | string]: ProxyManagementInfo;
+}
+
+const deploy = async ({ deployments, ethers }: HardhatRuntimeEnvironment) => {
+  if (!roninchainNetworks.includes(network.name!)) {
+    return;
+  }
+
+  const BridgeManagerDeployment = await deployments.get('RoninBridgeManager');
+  const GovernanceAdminDeployment = await deployments.get('RoninGovernanceAdmin');
+
+  console.log('BridgeManager', BridgeManagerDeployment.address);
+  console.log('GovernanceAdmin', GovernanceAdminDeployment.address);
+
+  const records: ProxyManagementInfoRecords = {};
+  for (const key of Object.keys(ProxyNames)) {
+    const deployment = await deployments.getOrNull(getValueByKey(key as ProxyNamesType));
+    const address = deployment ? deployment.address : generalRoninConf[network.name].bridgeContract; // TODO: handle load bridgeContract from config file
+
+    const admin = await getAdminOfProxy(ethers.provider, address);
+    records[key] = {
+      deployment,
+      address,
+      admin,
+      correctAdmin:
+        Object.keys(BridgeProxyName).indexOf(key) != -1
+          ? admin.toLocaleLowerCase() == BridgeManagerDeployment.address.toLocaleLowerCase()
+          : admin.toLocaleLowerCase() == GovernanceAdminDeployment.address.toLocaleLowerCase(),
+    };
+  }
+
+  console.table(records);
+};
+
+const getAdminOfProxy = async (provider: ethersType.providers.JsonRpcProvider, address: Address): Promise<string> => {
+  const ADMIN_SLOT = '0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103';
+  const slotValue = await ethers.provider.getStorageAt(address, ADMIN_SLOT);
+  return ethers.utils.hexStripZeros(slotValue);
+};
+
+function getValueByKey(key: ProxyNamesType): string {
+  const indexOfS = Object.keys(ProxyNames).indexOf(key);
+  return Object.values(ProxyNames)[indexOfS];
+}
+
+// yarn hardhat deploy --tags QueryProxyAdmin --network ronin-testnet
+deploy.tags = ['QueryProxyAdmin'];
+
+export default deploy;


### PR DESCRIPTION
## Sample

```
> yarn hardhat deploy --tags QueryProxyAdminRonin --network ronin-testnet 
```

```
BridgeManager 0xb0507f2f22697022eCb25963a00D3D076dAc5753
GovernanceAdmin 0x53Ea388CB72081A3a397114a43741e7987815896
Loaded BridgeContract from config.
┌───────────────────────────┬──────────────────────────────────────────────┬──────────────────────────────────────────────┬──────────────────────────────────────────────┬───────────┐
│          (index)          │                   address                    │                    admin                     │                expectedAdmin                 │ isCorrect │
├───────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼───────────┤
│       BridgeReward        │ '0x6E19cF519b7B83F7CE719B6d30232485d9609D95' │ '0xb0507f2f22697022ecb25963a00d3d076dac5753' │ '0xb0507f2f22697022eCb25963a00D3D076dAc5753' │   true    │
│        BridgeSlash        │ '0x7FC81d20f7D1f53D0eA094fcBdd1b531B71225EB' │ '0xb0507f2f22697022ecb25963a00d3d076dac5753' │ '0xb0507f2f22697022eCb25963a00D3D076dAc5753' │   true    │
│      BridgeTracking       │ '0x880c5da7bFF9740464287EBFE381Be1cCCCE4FEA' │ '0xb0507f2f22697022ecb25963a00d3d076dac5753' │ '0xb0507f2f22697022eCb25963a00D3D076dAc5753' │   true    │
│      BridgeContract       │ '0xCee681C9108c42C710c6A8A949307D5F13C9F3ca' │ '0x53ea388cb72081a3a397114a43741e7987815896' │ '0xb0507f2f22697022eCb25963a00D3D076dAc5753' │   false   │
│        Maintenance        │ '0x4016C80D97DDCbe4286140446759a3f0c1d20584' │ '0x53ea388cb72081a3a397114a43741e7987815896' │ '0x53Ea388CB72081A3a397114a43741e7987815896' │   true    │
│ RoninGatewayPauseEnforcer │ '0x1aD54D61F47acBcBA99fb6540A1694EB2F47AB95' │ '0x53ea388cb72081a3a397114a43741e7987815896' │ '0x53Ea388CB72081A3a397114a43741e7987815896' │   true    │
│ RoninTrustedOrganization  │ '0x7507dc433a98E1fE105d69f19f3B40E4315A4F32' │ '0x53ea388cb72081a3a397114a43741e7987815896' │ '0x53Ea388CB72081A3a397114a43741e7987815896' │   true    │
│     RoninValidatorSet     │ '0x54B3AC74a90E64E8dDE60671b6fE8F8DDf18eC9d' │ '0x53ea388cb72081a3a397114a43741e7987815896' │ '0x53Ea388CB72081A3a397114a43741e7987815896' │   true    │
│      SlashIndicator       │ '0xF7837778b6E180Df6696C8Fa986d62f8b6186752' │ '0x53ea388cb72081a3a397114a43741e7987815896' │ '0x53Ea388CB72081A3a397114a43741e7987815896' │   true    │
│          Staking          │ '0x9C245671791834daf3885533D24dce516B763B28' │ '0x53ea388cb72081a3a397114a43741e7987815896' │ '0x53Ea388CB72081A3a397114a43741e7987815896' │   true    │
│      StakingVesting       │ '0x023930A8ad88dc5AB3a3b8E8cb849BbD6a5c8441' │ '0x53ea388cb72081a3a397114a43741e7987815896' │ '0x53Ea388CB72081A3a397114a43741e7987815896' │   true    │
└───────────────────────────┴──────────────────────────────────────────────┴──────────────────────────────────────────────┴──────────────────────────────────────────────┴───────────┘
```