### PR TITLE
[Test]: Fix broken test case when ABI changed.

### DIFF
--- a/test/integration/Configuration.test.ts
+++ b/test/integration/Configuration.test.ts
@@ -199,7 +199,7 @@ describe('[Integration] Configuration check', () => {
     expect(await maintenanceContract.maxOffsetToStartSchedule()).eq(
       config.maintenanceArguments!.maxOffsetToStartSchedule
     );
-    expect(await maintenanceContract.maxSchedules()).eq(config.maintenanceArguments!.maxSchedules);
+    expect(await maintenanceContract.maxSchedule()).eq(config.maintenanceArguments!.maxSchedules);
   });
 
   it('Should the RoninTrustedOrganization contract set configs correctly', async () => {
@@ -318,7 +318,7 @@ describe('[Integration] Configuration check', () => {
     expect(await validatorContract.maxPrioritizedValidatorNumber()).to.eq(
       config.roninValidatorSetArguments?.maxPrioritizedValidatorNumber
     );
-    expect(await validatorContract.minEffectiveDaysOnwards()).to.eq(
+    expect(await validatorContract.minEffectiveDaysOnward()).to.eq(
       config.roninValidatorSetArguments?.minEffectiveDaysOnwards
     );
     expect(await validatorContract.numberOfBlocksInEpoch()).to.eq(

--- a/test/maintainance/Maintenance.test.ts
+++ b/test/maintainance/Maintenance.test.ts
@@ -420,7 +420,7 @@ describe('Maintenance test', () => {
     });
 
     it('Should the admin be able to cancel the schedule', async () => {
-      let _totalSchedules = await maintenanceContract.totalSchedules();
+      let _totalSchedules = await maintenanceContract.totalSchedule();
 
       let tx = await maintenanceContract
         .connect(validatorCandidates[0].candidateAdmin)
@@ -430,7 +430,7 @@ describe('Maintenance test', () => {
         .emit(maintenanceContract, 'MaintenanceScheduleCancelled')
         .withArgs(validatorCandidates[0].consensusAddr.address);
 
-      expect(_totalSchedules.sub(await maintenanceContract.totalSchedules())).eq(1);
+      expect(_totalSchedules.sub(await maintenanceContract.totalSchedule())).eq(1);
       let _cancelledSchedule = await maintenanceContract.getSchedule(validatorCandidates[0].consensusAddr.address);
       expect(_cancelledSchedule.from).eq(0);
       expect(_cancelledSchedule.to).eq(0);


### PR DESCRIPTION
### Description
This PR fix test case using old ABI that result in failing tests.
### Contract changes

The table below shows the following info:
- **Logic**: the logic is changed.
- **ABI**: the ABI is changed.
- **Init data**: new storage field is declared and needs initializing.
- **Dependent**: needs to be changed due to changes in other contracts.

| **Contract name** | **Logic** | **ABI** | **Init data** | **Dependent** |
|-------------------|:---------:|:-------:|:-------------:|:-------------:|
| BridgeTracking    |           |         |               |               |
| GovernanceAdmin   |           |         |               |               |
| Maintenance       |           |         |               |               |
| SlashIndicator    |           |         |               |               |
| Staking           |           |         |               |               |
| StakingVesting    |           |         |               |               |
| ValidatorSet      |           |         |               |               |

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
